### PR TITLE
Remove namespace when not passed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -46,7 +46,7 @@ class Keyv extends EventEmitter {
 	}
 
 	_getKeyPrefix(key) {
-		return `${this.opts.namespace}:${key}`;
+		return this.opts.namespace ? `${this.opts.namespace}:${key}` : key;
 	}
 
 	get(key) {

--- a/test/keyv.js
+++ b/test/keyv.js
@@ -91,5 +91,12 @@ test.serial('Keyv uses custom serializer when provided instead of json-buffer', 
 	t.is(await keyv.get('foo'), 'bar');
 });
 
+test.serial('An empty namespace stores the key as-is', async t => {
+	const store = new Map();
+	const keyv = new Keyv({ store, namespace: '' });
+	await keyv.set(42, 'foo');
+	t.is(Array.from(store.keys())[0], 42);
+});
+
 const store = () => new Map();
 keyvTestSuite(test, Keyv, store);


### PR DESCRIPTION
Hi! I'd like to propose a small change related to how cache key computation works: if the namespace is overridden with an empty string, remove it. The goal for that is to allow numerical keys to be used in conjunction with a SQL backed interface, which can significantly speed up things.