### PR TITLE
fix: typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,8 @@ The following are third-party storage adapters compatible with Keyv:
 - [quick-lru](https://github.com/sindresorhus/quick-lru) - Simple "Least Recently Used" (LRU) cache
 - [keyv-file](https://github.com/zaaack/keyv-file) - File system storage adapter for Keyv
 - [keyv-dynamodb](https://www.npmjs.com/package/keyv-dynamodb) - DynamoDB storage adapter for Keyv
-- [keyv-lru] (https://www.npmjs.com/package/keyv-lru) - LRU storage adapter for Keyv
-- [keyv-null] (https://www.npmjs.com/package/keyv-null) - Null storage adapter for Keyv
+- [keyv-lru](https://www.npmjs.com/package/keyv-lru) - LRU storage adapter for Keyv
+- [keyv-null](https://www.npmjs.com/package/keyv-null) - Null storage adapter for Keyv
 - [keyv-firestore ](https://github.com/goto-bus-stop/keyv-firestore) – Firebase Cloud Firestore adapter for Keyv
 - [keyv-mssql](https://github.com/pmorgan3/keyv-mssql) - Microsoft Sql Server adapter for Keyv
 - [keyv-memcache](https://github.com/jaredwray/keyv-memcache) - Memcache storage adapter for Keyv


### PR DESCRIPTION
There was an additional space in constructing a link.