### PR TITLE
Convert sqlite3 to better-sqlite3

### DIFF
--- a/packages/keyv/test/test.js
+++ b/packages/keyv/test/test.js
@@ -1,11 +1,12 @@
-const EventEmitter = require('events');
 const test = require('ava');
-const keyvTestSuite = require('@keyv/test-suite').default;
-const { keyvOfficialTests } = require('@keyv/test-suite');
+const { keyvOfficialTests, default: keyvTestSuite } = require('@keyv/test-suite');
 const Keyv = require('this');
 const tk = require('timekeeper');
-const sqlite3 = require('sqlite3');
-const pify = require('pify');
+const KeyvSqlite = require('@keyv/sqlite');
+
+keyvOfficialTests(test, Keyv, 'sqlite://test/testdb.sqlite', 'sqlite://non/existent/database.sqlite');
+const store = () => new KeyvSqlite({ uri: 'sqlite://test/testdb.sqlite', busyTimeout: 3000 });
+keyvTestSuite(test, Keyv, store);
 
 test.serial('Keyv is a class', t => {
 	t.is(typeof Keyv, 'function');
@@ -127,91 +128,3 @@ test.serial('Keyv supports async serializer/deserializer', async t => {
 	await keyv.set('foo', 'bar');
 	t.is(await keyv.get('foo'), 'bar');
 });
-
-class TestAdapter extends EventEmitter {
-	constructor(options) {
-		super();
-		this.ttlSupport = false;
-		options = Object.assign({
-			dialect: 'sqlite',
-			uri: 'sqlite://:memory:',
-		}, options);
-		options.db = options.uri.replace(/^sqlite:\/\//, '');
-
-		options.connect = () => new Promise((resolve, reject) => {
-			const db = new sqlite3.Database(options.db, error => {
-				if (error) {
-					reject(error);
-				} else {
-					if (options.busyTimeout) {
-						db.configure('busyTimeout', options.busyTimeout);
-					}
-
-					resolve(db);
-				}
-			});
-		})
-			.then(db => pify(db.all).bind(db));
-
-		this.opts = Object.assign({
-			table: 'keyv',
-			keySize: 255,
-		}, options);
-
-		const createTable = `CREATE TABLE IF NOT EXISTS ${this.opts.table}(key VARCHAR(${Number(this.opts.keySize)}) PRIMARY KEY, value TEXT )`;
-
-		const connected = this.opts.connect()
-			.then(query => query(createTable).then(() => query))
-			.catch(error => this.emit('error', error));
-
-		this.query = sqlString => connected
-			.then(query => query(sqlString));
-	}
-
-	get(key) {
-		const select = `SELECT * FROM ${this.opts.table} WHERE key = '${key}'`;
-		return this.query(select)
-			.then(rows => {
-				const row = rows[0];
-				if (row === undefined) {
-					return undefined;
-				}
-
-				return row.value;
-			});
-	}
-
-	set(key, value) {
-		const upsert = `INSERT INTO ${this.opts.table} (key, value)
-			VALUES('${key}', '${value}') 
-			ON CONFLICT(key) 
-			DO UPDATE SET value=excluded.value;`;
-		return this.query(upsert);
-	}
-
-	delete(key) {
-		const select = `SELECT * FROM ${this.opts.table} WHERE key = '${key}'`;
-		const del = `DELETE FROM ${this.opts.table} WHERE key = '${key}'`;
-		return this.query(select)
-			.then(rows => {
-				const row = rows[0];
-				if (row === undefined) {
-					return false;
-				}
-
-				return this.query(del)
-					.then(() => true);
-			});
-	}
-
-	clear() {
-		const del = `DELETE FROM ${this.opts.table} WHERE key LIKE '${this.namespace}:%'`;
-		return this.query(del)
-			.then(() => undefined);
-	}
-}
-
-keyvOfficialTests(test, Keyv, 'sqlite://test/testdb.sqlite', 'sqlite://non/existent/database.sqlite');
-
-const store = () => new TestAdapter({ uri: 'sqlite://test/testdb.sqlite', busyTimeout: 3000 });
-keyvTestSuite(test, Keyv, store);

--- a/packages/sqlite/package.json
+++ b/packages/sqlite/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keyv/sqlite",
-	"version": "2.1.0",
+	"version": "3.0.0",
 	"description": "SQLite storage adapter for Keyv",
 	"main": "src/index.js",
 	"scripts": {
@@ -42,8 +42,7 @@
 	},
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
-		"pify": "5.0.0",
-		"sqlite3": "^5.0.2"
+		"better-sqlite3": "^7.5.0"
 	},
 	"devDependencies": {
 		"@keyv/test-suite": "*",

--- a/packages/sqlite/src/index.js
+++ b/packages/sqlite/src/index.js
@@ -1,8 +1,7 @@
 'use strict';
 
 const EventEmitter = require('events');
-const sqlite3 = require('sqlite3');
-const pify = require('pify');
+const Database = require('better-sqlite3');
 
 class KeyvSqlite extends EventEmitter {
 	constructor(options) {
@@ -14,21 +13,6 @@ class KeyvSqlite extends EventEmitter {
 		}, options);
 		options.db = options.uri.replace(/^sqlite:\/\//, '');
 
-		options.connect = () => new Promise((resolve, reject) => {
-			const db = new sqlite3.Database(options.db, error => {
-				if (error) {
-					reject(error);
-				} else {
-					if (options.busyTimeout) {
-						db.configure('busyTimeout', options.busyTimeout);
-					}
-
-					resolve(db);
-				}
-			});
-		})
-			.then(db => pify(db.all).bind(db));
-
 		this.opts = Object.assign({
 			table: 'keyv',
 			keySize: 255,
@@ -36,54 +20,54 @@ class KeyvSqlite extends EventEmitter {
 
 		const createTable = `CREATE TABLE IF NOT EXISTS ${this.opts.table}(key VARCHAR(${Number(this.opts.keySize)}) PRIMARY KEY, value TEXT )`;
 
-		const connected = this.opts.connect()
-			.then(query => query(createTable).then(() => query))
-			.catch(error => this.emit('error', error));
+		const dbOptions = {};
+		if (options.busyTimeout) {
+			dbOptions.timeout = options.busyTimeout;
+		}
 
-		this.query = sqlString => connected
-			.then(query => query(sqlString));
+		try {
+			this.db = new Database(options.db, dbOptions);
+			this.db.prepare(createTable).run();
+		} catch (error) {
+			setImmediate(() => this.emit('error', error));
+		}
 	}
 
 	get(key) {
-		const select = `SELECT * FROM ${this.opts.table} WHERE key = '${key}'`;
-		return this.query(select)
-			.then(rows => {
-				const row = rows[0];
-				if (row === undefined) {
-					return undefined;
-				}
+		const select = `SELECT * FROM ${this.opts.table} WHERE key = ?`;
+		const row = this.db.prepare(select).get(key);
+		if (row === undefined) {
+			return undefined;
+		}
 
-				return row.value;
-			});
+		return row.value;
 	}
 
 	set(key, value) {
 		const upsert = `INSERT INTO ${this.opts.table} (key, value)
-			VALUES('${key}', '${value}') 
+			VALUES(?, ?) 
 			ON CONFLICT(key) 
 			DO UPDATE SET value=excluded.value;`;
-		return this.query(upsert);
+		return this.db.prepare(upsert).run(key, value);
 	}
 
 	delete(key) {
-		const select = `SELECT * FROM ${this.opts.table} WHERE key = '${key}'`;
-		const del = `DELETE FROM ${this.opts.table} WHERE key = '${key}'`;
-		return this.query(select)
-			.then(rows => {
-				const row = rows[0];
-				if (row === undefined) {
-					return false;
-				}
+		const select = `SELECT * FROM ${this.opts.table} WHERE key = ?`;
+		const del = `DELETE FROM ${this.opts.table} WHERE key = ?`;
 
-				return this.query(del)
-					.then(() => true);
-			});
+		const row = this.db.prepare(select).get(key);
+		if (row === undefined) {
+			return false;
+		}
+
+		this.db.prepare(del).run(key);
+		return true;
 	}
 
 	clear() {
-		const del = `DELETE FROM ${this.opts.table} WHERE key LIKE '${this.namespace}:%'`;
-		return this.query(del)
-			.then(() => undefined);
+		const del = `DELETE FROM ${this.opts.table} WHERE key LIKE ?`;
+		this.db.prepare(del).run(`${this.namespace}:%`);
+		return undefined;
 	}
 }
 


### PR DESCRIPTION
[node-sqlite3](https://github.com/mapbox/node-sqlite3) appears to be somewhat abandoned and has been racking up security vulnerabilities in its dependencies. This PR switches it to [better-sqlite3](https://github.com/JoshuaWise/better-sqlite3) which is more performant, supports more architectures, and is actively maintained.

This PR also switches to using [Bind Parameters](https://github.com/JoshuaWise/better-sqlite3/blob/master/docs/api.md#binding-parameters) which resolves an issue I was experiencing when storing values that contain a single quote (`'`).

Note: I didn't really understand what was going on with the `TestAdapter`, so I just reverted [these changes](https://github.com/jaredwray/keyv/commit/ed094d0a0f7d492c5d0546dd5cd6cfe40f15708f#diff-a640cdc5ceede57b891b18b7ad8e7e093898041443596dde09b0b542fa9d9b87). The tests seem to still pass from what I see, although you may want to re-run manually to double check.

I understand this is a big change, so if you feel you want to stick with node-sqlite3 and just resolve its security vulnerabilities (like [this solution](https://github.com/mapbox/node-sqlite3/issues/1493#issuecomment-980521241)), I can just port this module into a standalone package. However, you still may want to consider switching to bind parameters, which node-sqlite3 also offers.