### PR TITLE
fix typescript issues (old node + previous @types/keyv compat issues)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,5 +19,8 @@
   },
   "dependencies": {
     "@types/node": "^17.0.21"
+  },
+  "devDependencies": {
+    "lerna": "^4.0.0"
   }
 }

--- a/packages/etcd/package.json
+++ b/packages/etcd/package.json
@@ -13,7 +13,8 @@
 		"rules": {
 			"unicorn/prefer-module": 0,
 			"unicorn/no-array-reduce": 0,
-			"unicorn/prefer-object-from-entries": 0
+			"unicorn/prefer-object-from-entries": 0,
+			"unicorn/prefer-node-protocol": 0
 		}
 	},
 	"ava": {

--- a/packages/etcd/package.json
+++ b/packages/etcd/package.json
@@ -9,7 +9,6 @@
 		"clean": "rm -rf node_modules && rm -rf .nyc_output && rm -rf coverage.lcov"
 	},
 	"xo": {
-		"extends": "xo-lukechilds",
 		"rules": {
 			"unicorn/prefer-module": 0,
 			"unicorn/no-array-reduce": 0,
@@ -51,7 +50,6 @@
 	"devDependencies": {
 		"@keyv/test-suite": "*",
 		"ava": "^4.0.1",
-		"eslint-config-xo-lukechilds": "^1.0.1",
 		"keyv": "*",
 		"nyc": "^15.1.0",
 		"requirable": "^1.0.5",

--- a/packages/etcd/src/index.d.ts
+++ b/packages/etcd/src/index.d.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'events';
+import {EventEmitter} from 'events';
 import Etcd3 from 'etcd3';
 
 declare class KeyvEtcd extends EventEmitter {

--- a/packages/etcd/src/index.d.ts
+++ b/packages/etcd/src/index.d.ts
@@ -1,5 +1,4 @@
-
-import EventEmitter from 'events';
+import { EventEmitter } from 'events';
 import Etcd3 from 'etcd3';
 
 declare class KeyvEtcd extends EventEmitter {

--- a/packages/etcd/src/index.d.ts
+++ b/packages/etcd/src/index.d.ts
@@ -1,5 +1,5 @@
 
-import EventEmitter from 'node:events';
+import EventEmitter from 'events';
 import Etcd3 from 'etcd3';
 
 declare class KeyvEtcd extends EventEmitter {

--- a/packages/etcd/src/index.js
+++ b/packages/etcd/src/index.js
@@ -1,8 +1,8 @@
 'use strict';
 
 const EventEmitter = require('events');
-const { Etcd3 } = require('etcd3');
-const { Policy } = require('cockatiel');
+const {Etcd3} = require('etcd3');
+const {Policy} = require('cockatiel');
 
 class KeyvEtcd extends EventEmitter {
 	constructor(url, options) {
@@ -10,31 +10,29 @@ class KeyvEtcd extends EventEmitter {
 		this.ttlSupport = options && typeof options.ttl === 'number';
 		url = url || {};
 		if (typeof url === 'string') {
-			url = { url };
+			url = {url};
 		}
 
 		if (url.uri) {
-			url = Object.assign({ url: url.uri }, url);
+			url = {url: url.uri, ...url};
 		}
 
 		if (url.ttl) {
 			this.ttlSupport = typeof url.ttl === 'number' ? url.ttl : false;
 		}
 
-		this.opts = Object.assign(
-			{
-				url: '127.0.0.1:2379',
-			},
-			url,
-			options,
-		);
+		this.opts = {
+			url: '127.0.0.1:2379',
+			...url,
+			...options,
+		};
 
 		this.opts.url = this.opts.url.replace(/^etcd:\/\//, '');
 		const policy = Policy.handleAll().retry();
 		policy.onFailure(error => {
 			this.emit('error', error.reason);
 		});
-		this.client = new Etcd3(options = { hosts: this.opts.url,
+		this.client = new Etcd3(options = {hosts: this.opts.url,
 			faultHandling: {
 				host: () => policy,
 				global: policy,

--- a/packages/etcd/test/test.js
+++ b/packages/etcd/test/test.js
@@ -2,13 +2,13 @@ const test = require('ava');
 const KeyvEtcd = require('this');
 const Keyv = require('keyv');
 const keyvTestSuite = require('@keyv/test-suite').default;
-const { keyvOfficialTests } = require('@keyv/test-suite');
+const {keyvOfficialTests} = require('@keyv/test-suite');
 
 const etcdURL = 'etcd://127.0.0.1:2379';
 
 keyvOfficialTests(test, Keyv, etcdURL, 'etcd://foo');
 
-const store = () => new KeyvEtcd({ uri: etcdURL, busyTimeout: 3000 });
+const store = () => new KeyvEtcd({uri: etcdURL, busyTimeout: 3000});
 
 keyvTestSuite(test, Keyv, store);
 
@@ -27,7 +27,7 @@ function sleep(ms) {
 
 test.serial('KeyvEtcd respects default tll option', async t => {
 	const store = new Map();
-	const keyv = new KeyvEtcd({ store, ttl: 1000 });
+	const keyv = new KeyvEtcd({store, ttl: 1000});
 	await keyv.set('foo', 'bar');
 	t.is(await keyv.get('foo'), 'bar');
 	await sleep(3000);

--- a/packages/keyv/package.json
+++ b/packages/keyv/package.json
@@ -9,7 +9,6 @@
 		"clean": "rm -rf node_modules && rm -rf .nyc_output && rm -rf coverage.lcov && rm -rf ./test/testdb.sqlite"
 	},
 	"xo": {
-		"extends": "xo-lukechilds",
 		"rules": {
 			"unicorn/prefer-module": 0,
 			"unicorn/prefer-node-protocol": 0
@@ -39,7 +38,6 @@
 	"devDependencies": {
 		"@keyv/test-suite": "*",
 		"ava": "^4.1.0",
-		"eslint-config-xo-lukechilds": "^1.0.1",
 		"eslint-plugin-promise": "^6.0.0",
 		"nyc": "^15.1.0",
 		"pify": "5.0.0",

--- a/packages/keyv/package.json
+++ b/packages/keyv/package.json
@@ -11,7 +11,8 @@
 	"xo": {
 		"extends": "xo-lukechilds",
 		"rules": {
-			"unicorn/prefer-module": 0
+			"unicorn/prefer-module": 0,
+			"unicorn/prefer-node-protocol": 0
 		}
 	},
 	"repository": {

--- a/packages/keyv/src/index.d.ts
+++ b/packages/keyv/src/index.d.ts
@@ -1,9 +1,9 @@
-import EventEmitter from 'events';
+import { EventEmitter } from 'events';
 
-declare class Keyv extends EventEmitter {
+declare class Keyv<T = any> extends EventEmitter {
 	constructor(uri: string, options: Keyv.Options);
-	get(key: string, options: any): Promise<any>;
-	set(key: string, value: any, ttl: number): Promise<boolean>;
+	get(key: string, options: any): Promise<T>;
+	set(key: string, value: T, ttl: number): Promise<boolean>;
 	delete(key: string): Promise<boolean>;
 	clear(): Promise<void>;
 	has(key: string): Promise<boolean>;
@@ -16,6 +16,8 @@ declare namespace Keyv {
 		deserialize?: ((data: string) => any | undefined) | undefined;
 		ttl?: number | undefined;
 	}
+
+	type Store<T> = Keyv<T>;
 }
 
 export = Keyv;

--- a/packages/keyv/src/index.d.ts
+++ b/packages/keyv/src/index.d.ts
@@ -2,8 +2,8 @@ import { EventEmitter } from 'events';
 
 declare class Keyv<T = any> extends EventEmitter {
 	constructor(uri: string, options: Keyv.Options);
-	get(key: string, options: any): Promise<T>;
-	set(key: string, value: T, ttl: number): Promise<boolean>;
+	get(key: string, options?: any): Promise<T>;
+	set(key: string, value: T, ttl?: number): Promise<boolean>;
 	delete(key: string): Promise<boolean>;
 	clear(): Promise<void>;
 	has(key: string): Promise<boolean>;

--- a/packages/keyv/src/index.d.ts
+++ b/packages/keyv/src/index.d.ts
@@ -1,4 +1,4 @@
-import EventEmitter from 'node:events';
+import EventEmitter from 'events';
 
 declare class Keyv extends EventEmitter {
 	constructor(uri: string, options: Keyv.Options);

--- a/packages/keyv/src/index.d.ts
+++ b/packages/keyv/src/index.d.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'events';
+import {EventEmitter} from 'events';
 
 declare class Keyv<T = any> extends EventEmitter {
 	constructor(uri: string, options: Keyv.Options);

--- a/packages/keyv/src/index.js
+++ b/packages/keyv/src/index.js
@@ -38,21 +38,21 @@ class Keyv extends EventEmitter {
 			namespace: 'keyv',
 			serialize: JSONB.stringify,
 			deserialize: JSONB.parse,
-			...((typeof uri === 'string') ? { uri } : uri),
+			...((typeof uri === 'string') ? {uri} : uri),
 			...options,
 		};
 
 		if (!this.opts.store) {
-			const adapterOptions = { ...this.opts };
+			const adapterOptions = {...this.opts};
 			this.opts.store = loadStore(adapterOptions);
 		}
 
 		if (this.opts.compress) {
 			const brotli = compressBrotli(this.opts.compress.opts);
-			this.opts.serialize = async ({ value, expires }) => brotli.serialize({ value: await brotli.compress(value), expires });
+			this.opts.serialize = async ({value, expires}) => brotli.serialize({value: await brotli.compress(value), expires});
 			this.opts.deserialize = async data => {
-				const { value, expires } = brotli.deserialize(data);
-				return { value: await brotli.decompress(value), expires };
+				const {value, expires} = brotli.deserialize(data);
+				return {value: await brotli.decompress(value), expires};
 			};
 		}
 
@@ -113,7 +113,7 @@ class Keyv extends EventEmitter {
 	}
 
 	get(key, options) {
-		const { store } = this.opts;
+		const {store} = this.opts;
 		const isArray = Array.isArray(key);
 		const keyPrefixed = isArray ? this._getKeyPrefixArray(key) : this._getKeyPrefix(key);
 		if (isArray && store.getMany === undefined) {
@@ -201,7 +201,7 @@ class Keyv extends EventEmitter {
 			ttl = undefined;
 		}
 
-		const { store } = this.opts;
+		const {store} = this.opts;
 
 		return Promise.resolve()
 			.then(() => {
@@ -210,7 +210,7 @@ class Keyv extends EventEmitter {
 					this.emit('error', 'symbol cannot be serialized');
 				}
 
-				value = { value, expires };
+				value = {value, expires};
 				return this.opts.serialize(value);
 			})
 			.then(value => store.set(keyPrefixed, value, ttl))
@@ -218,7 +218,7 @@ class Keyv extends EventEmitter {
 	}
 
 	delete(key) {
-		const { store } = this.opts;
+		const {store} = this.opts;
 		if (Array.isArray(key)) {
 			const keyPrefixed = this._getKeyPrefixArray(key);
 			if (store.deleteMany === undefined) {
@@ -241,14 +241,14 @@ class Keyv extends EventEmitter {
 	}
 
 	clear() {
-		const { store } = this.opts;
+		const {store} = this.opts;
 		return Promise.resolve()
 			.then(() => store.clear());
 	}
 
 	has(key) {
 		const keyPrefixed = this._getKeyPrefix(key);
-		const { store } = this.opts;
+		const {store} = this.opts;
 		return Promise.resolve()
 			.then(async () => {
 				if (typeof store.has === 'function') {

--- a/packages/keyv/test/test.js
+++ b/packages/keyv/test/test.js
@@ -1,13 +1,13 @@
 const test = require('ava');
 const compressBrotli = require('compress-brotli');
-const { default: keyvTestSuite, keyvOfficialTests, keyvIteratorTests } = require('@keyv/test-suite');
+const {default: keyvTestSuite, keyvOfficialTests, keyvIteratorTests} = require('@keyv/test-suite');
 const Keyv = require('this');
 const JSONB = require('json-buffer');
 const tk = require('timekeeper');
 const KeyvSqlite = require('@keyv/sqlite');
 
 keyvOfficialTests(test, Keyv, 'sqlite://test/testdb.sqlite', 'sqlite://non/existent/database.sqlite');
-const store = () => new KeyvSqlite({ uri: 'sqlite://test/testdb.sqlite', busyTimeout: 3000 });
+const store = () => new KeyvSqlite({uri: 'sqlite://test/testdb.sqlite', busyTimeout: 3000});
 keyvTestSuite(test, Keyv, store);
 keyvIteratorTests(test, Keyv, store);
 
@@ -19,7 +19,7 @@ test.serial('Keyv is a class', t => {
 
 test.serial('Keyv accepts storage adapters', async t => {
 	const store = new Map();
-	const keyv = new Keyv({ store });
+	const keyv = new Keyv({store});
 	t.is(store.size, 0);
 	await keyv.set('foo', 'bar');
 	t.is(await keyv.get('foo'), 'bar');
@@ -35,13 +35,13 @@ test.serial('Keyv passes tll info to stores', async t => {
 		storeSet.call(store, key, value, ttl);
 	};
 
-	const keyv = new Keyv({ store });
+	const keyv = new Keyv({store});
 	await keyv.set('foo', 'bar', 100);
 });
 
 test.serial('Keyv respects default tll option', async t => {
 	const store = new Map();
-	const keyv = new Keyv({ store, ttl: 100 });
+	const keyv = new Keyv({store, ttl: 100});
 	await keyv.set('foo', 'bar');
 	t.is(await keyv.get('foo'), 'bar');
 	tk.freeze(Date.now() + 150);
@@ -54,7 +54,7 @@ test.serial('.set(key, val, ttl) overwrites default tll option', async t => {
 	const startTime = Date.now();
 	tk.freeze(startTime);
 	const store = new Map();
-	const keyv = new Keyv({ store, ttl: 200 });
+	const keyv = new Keyv({store, ttl: 200});
 	await keyv.set('foo', 'bar');
 	await keyv.set('fizz', 'buzz', 100);
 	await keyv.set('ping', 'pong', 300);
@@ -77,7 +77,7 @@ test.serial('.set(key, val, ttl) where ttl is "0" overwrites default tll option 
 	const startTime = Date.now();
 	tk.freeze(startTime);
 	const store = new Map();
-	const keyv = new Keyv({ store, ttl: 200 });
+	const keyv = new Keyv({store, ttl: 200});
 	await keyv.set('foo', 'bar', 0);
 	t.is(await keyv.get('foo'), 'bar');
 	tk.freeze(startTime + 250);
@@ -87,10 +87,10 @@ test.serial('.set(key, val, ttl) where ttl is "0" overwrites default tll option 
 
 test.serial('.get(key, {raw: true}) returns the raw object instead of the value', async t => {
 	const store = new Map();
-	const keyv = new Keyv({ store });
+	const keyv = new Keyv({store});
 	await keyv.set('foo', 'bar');
 	const value = await keyv.get('foo');
-	const rawObject = await keyv.get('foo', { raw: true });
+	const rawObject = await keyv.get('foo', {raw: true});
 	t.is(value, 'bar');
 	t.is(rawObject.value, 'bar');
 });
@@ -108,7 +108,7 @@ test.serial('Keyv uses custom serializer when provided instead of json-buffer', 
 		return JSON.parse(data);
 	};
 
-	const keyv = new Keyv({ store, serialize, deserialize });
+	const keyv = new Keyv({store, serialize, deserialize});
 	await keyv.set('foo', 'bar');
 	t.is(await keyv.get('foo'), 'bar');
 });
@@ -127,7 +127,7 @@ test.serial('Keyv supports async serializer/deserializer', async t => {
 		return JSON.parse(data);
 	};
 
-	const keyv = new Keyv({ store, serialize, deserialize });
+	const keyv = new Keyv({store, serialize, deserialize});
 	await keyv.set('foo', 'bar');
 	t.is(await keyv.get('foo'), 'bar');
 });
@@ -150,7 +150,7 @@ test.serial('Keyv should wait for the expired get', async t => {
 		},
 	};
 
-	const keyv = new Keyv({ store });
+	const keyv = new Keyv({store});
 
 	// Round 1
 	const v1 = await keyv.get('foo');
@@ -183,7 +183,7 @@ test.serial('Keyv should wait for the expired get', async t => {
 });
 
 test.serial('Keyv has should return if adapter does not support has', async t => {
-	const keyv = new Keyv({ store: store() });
+	const keyv = new Keyv({store: store()});
 	keyv.opts.store.has = undefined;
 	await keyv.set('foo', 'bar');
 	t.is(await keyv.has('foo'), true);
@@ -191,7 +191,7 @@ test.serial('Keyv has should return if adapter does not support has', async t =>
 });
 
 test.serial('.delete([keys]) should delete multiple key for storage adapter not supporting deleteMany', async t => {
-	const keyv = new Keyv({ store: new Map() });
+	const keyv = new Keyv({store: new Map()});
 	await keyv.set('foo', 'bar');
 	await keyv.set('foo1', 'bar1');
 	await keyv.set('foo2', 'bar2');
@@ -202,12 +202,12 @@ test.serial('.delete([keys]) should delete multiple key for storage adapter not 
 });
 
 test.serial('.delete([keys]) with nonexistent keys resolves to false for storage adapter not supporting deleteMany', async t => {
-	const keyv = new Keyv({ store: new Map() });
+	const keyv = new Keyv({store: new Map()});
 	t.is(await keyv.delete(['foo', 'foo1', 'foo2']), false);
 });
 
 test.serial('keyv.get([keys]) should return array values', async t => {
-	const keyv = new Keyv({ store: new Map() });
+	const keyv = new Keyv({store: new Map()});
 	await keyv.set('foo', 'bar');
 	await keyv.set('foo1', 'bar1');
 	await keyv.set('foo2', 'bar2');
@@ -219,7 +219,7 @@ test.serial('keyv.get([keys]) should return array values', async t => {
 });
 
 test.serial('keyv.get([keys]) should return array value undefined when expires', async t => {
-	const keyv = new Keyv({ store: new Map() });
+	const keyv = new Keyv({store: new Map()});
 	await keyv.set('foo', 'bar');
 	await keyv.set('foo1', 'bar1', 1);
 	await keyv.set('foo2', 'bar2');
@@ -237,7 +237,7 @@ test.serial('keyv.get([keys]) should return array value undefined when expires',
 });
 
 test.serial('keyv.get([keys]) should return array value undefined when expires sqlite', async t => {
-	const keyv = new Keyv({ store: store() });
+	const keyv = new Keyv({store: store()});
 	await keyv.clear();
 	await keyv.set('foo', 'bar');
 	await keyv.set('foo1', 'bar1', 1);
@@ -256,7 +256,7 @@ test.serial('keyv.get([keys]) should return array value undefined when expires s
 });
 
 test.serial('keyv.get([keys]) should return array values with undefined', async t => {
-	const keyv = new Keyv({ store: new Map() });
+	const keyv = new Keyv({store: new Map()});
 	await keyv.set('foo', 'bar');
 	await keyv.set('foo2', 'bar2');
 	const values = await keyv.get(['foo', 'foo1', 'foo2']);
@@ -267,17 +267,17 @@ test.serial('keyv.get([keys]) should return array values with undefined', async 
 });
 
 test.serial('keyv.get([keys]) should return empty array for all no existent keys', async t => {
-	const keyv = new Keyv({ store: new Map() });
+	const keyv = new Keyv({store: new Map()});
 	const values = await keyv.get(['foo', 'foo1', 'foo2']);
 	t.is(Array.isArray(values), true);
 	t.deepEqual(values, []);
 });
 
 test('pass compress options', async t => {
-	const compressOptions = { enable: false };
+	const compressOptions = {enable: false};
 	const brotli = compressBrotli(compressOptions);
-	const compress = { compress: true, opts: compressOptions };
-	const keyv = new Keyv({ store: new Map(), compress });
+	const compress = {compress: true, opts: compressOptions};
+	const keyv = new Keyv({store: new Map(), compress});
 	const compressed = await brotli.compress('bar');
 	const decompressed = await brotli.decompress(compressed);
 
@@ -285,16 +285,16 @@ test('pass compress options', async t => {
 	t.is(await keyv.get('foo'), 'bar');
 
 	t.deepEqual(
-		await keyv.opts.deserialize(JSONB.stringify({ value: 'bar', expires: null })),
+		await keyv.opts.deserialize(JSONB.stringify({value: 'bar', expires: null})),
 		await brotli.deserialize(
-			JSONB.stringify({ value: decompressed, expires: null }),
+			JSONB.stringify({value: decompressed, expires: null}),
 		),
 	);
 });
 
 test('enable compression', async t => {
-	const compress = { compress: true };
-	const keyv = new Keyv({ store: new Map(), namespace: null, compress });
+	const compress = {compress: true};
+	const keyv = new Keyv({store: new Map(), namespace: null, compress});
 	await keyv.set('foo', 'bar');
 
 	t.is(

--- a/packages/memcache/src/index.d.ts
+++ b/packages/memcache/src/index.d.ts
@@ -1,4 +1,4 @@
-import EventEmitter from 'node:events';
+import EventEmitter from 'events';
 
 declare class KeyvMemcache extends EventEmitter {
     ttlSupport: boolean;

--- a/packages/memcache/src/index.d.ts
+++ b/packages/memcache/src/index.d.ts
@@ -1,4 +1,4 @@
-import EventEmitter from 'events';
+import { EventEmitter } from 'events';
 
 declare class KeyvMemcache extends EventEmitter {
     ttlSupport: boolean;

--- a/packages/memcache/src/index.d.ts
+++ b/packages/memcache/src/index.d.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'events';
+import {EventEmitter} from 'events';
 
 declare class KeyvMemcache extends EventEmitter {
     ttlSupport: boolean;

--- a/packages/memcache/test/test.js
+++ b/packages/memcache/test/test.js
@@ -1,184 +1,184 @@
-const test = require("ava");
-const Keyv = require("keyv");
-const KeyvMemcache = require("this");
-const promisify = require('util').promisify;
+const test = require('ava');
+const Keyv = require('keyv');
+const KeyvMemcache = require('this');
+const {promisify} = require('util');
 
-const kvat = require("@keyv/test-suite");
+const kvat = require('@keyv/test-suite');
 
+// eslint-disable-next-line no-promise-executor-return
 const snooze = ms => new Promise(resolve => setTimeout(resolve, ms));
 
-//handle all the tests with listeners.
+// Handle all the tests with listeners.
 require('events').EventEmitter.prototype._maxListeners = 200;
 
-let uri = "localhost:11211";
+let uri = 'localhost:11211';
 
-if(process.env.URI) {
-    uri = process.env.URI;
+if (process.env.URI) {
+	uri = process.env.URI;
 }
 
 const keyvMemcache = new KeyvMemcache(uri);
 
-
 test.serial('keyv get / no expired', async t => {
-    const keyv = new Keyv({store: keyvMemcache});
+	const keyv = new Keyv({store: keyvMemcache});
 
-    await keyv.set('foo', 'bar');
+	await keyv.set('foo', 'bar');
 
-    let val = await keyv.get('foo');
+	const val = await keyv.get('foo');
 
-    t.is(val, 'bar');
+	t.is(val, 'bar');
 });
 
-
 test.serial('testing defaults', async t => {
-    const m = new KeyvMemcache();
-    t.is(m.opts.url, 'localhost:11211');
+	const m = new KeyvMemcache();
+	t.is(m.opts.url, 'localhost:11211');
 });
 
 test.serial('keyv clear', async t => {
-    const keyv = new Keyv({store: keyvMemcache});
-    await keyv.clear();
-    t.is(await keyv.get('foo'), undefined);
+	const keyv = new Keyv({store: keyvMemcache});
+	await keyv.clear();
+	t.is(await keyv.get('foo'), undefined);
 });
 
 test.serial('keyv get', async t => {
-    const keyv = new Keyv({store: keyvMemcache});
-    await keyv.clear();
-    t.is(await keyv.get('foo'), undefined);
-    await keyv.set('foo', 'bar');
-    t.is(await keyv.get('foo'), 'bar');
+	const keyv = new Keyv({store: keyvMemcache});
+	await keyv.clear();
+	t.is(await keyv.get('foo'), undefined);
+	await keyv.set('foo', 'bar');
+	t.is(await keyv.get('foo'), 'bar');
 });
 
 test('get namespace', t => {
-    const keyv = new Keyv({store: keyvMemcache});
-    t.is(keyvMemcache._getNamespace(), 'namespace:keyv');
+	// eslint-disable-next-line no-unused-vars
+	const keyv = new Keyv({store: keyvMemcache});
+	t.is(keyvMemcache._getNamespace(), 'namespace:keyv');
 });
 test('format key for no namespace', t => {
-    t.is(new KeyvMemcache(uri).formatKey("foo"), 'foo');
+	t.is(new KeyvMemcache(uri).formatKey('foo'), 'foo');
 });
 
 test('format key for namespace', t => {
-    const keyv = new Keyv({store: keyvMemcache});
-    t.is(keyvMemcache.formatKey("foo"), 'keyv:foo');
+	// eslint-disable-next-line no-unused-vars
+	const keyv = new Keyv({store: keyvMemcache});
+	t.is(keyvMemcache.formatKey('foo'), 'keyv:foo');
 });
 
 test.serial('keyv get with namespace', async t => {
-    const keyv1 = new Keyv({store: keyvMemcache, namespace: "keyv1"});
-    const keyv2 = new Keyv({store: keyvMemcache, namespace: "2"});
+	const keyv1 = new Keyv({store: keyvMemcache, namespace: 'keyv1'});
+	const keyv2 = new Keyv({store: keyvMemcache, namespace: '2'});
 
-    await keyv1.set('foo', 'bar');
-    t.is(await keyv1.get('foo'), 'bar');
+	await keyv1.set('foo', 'bar');
+	t.is(await keyv1.get('foo'), 'bar');
 
-    await keyv2.set('foo', 'bar2');
-    t.is(await keyv2.get('foo'), 'bar2');
-
+	await keyv2.set('foo', 'bar2');
+	t.is(await keyv2.get('foo'), 'bar2');
 });
 
 test.serial('keyv get / should still exist', async t => {
-    const keyv = new Keyv({store: keyvMemcache});
+	const keyv = new Keyv({store: keyvMemcache});
 
-    await keyv.set('foo-expired', 'bar-expired', 10000);
+	await keyv.set('foo-expired', 'bar-expired', 10000);
 
-    await snooze(2000);
+	await snooze(2000);
 
-    let val = await keyv.get('foo-expired');
+	const val = await keyv.get('foo-expired');
 
-    t.is(val, "bar-expired");
+	t.is(val, 'bar-expired');
 });
 
 test.serial('keyv get / expired existing', async t => {
-    const keyv = new Keyv({store: keyvMemcache});
+	const keyv = new Keyv({store: keyvMemcache});
 
-    await keyv.set('foo-expired', 'bar-expired', 1000);
+	await keyv.set('foo-expired', 'bar-expired', 1000);
 
-    await snooze(3000);
+	await snooze(3000);
 
-    let val = await keyv.get('foo-expired');
+	const val = await keyv.get('foo-expired');
 
-    t.is(val, undefined);
+	t.is(val, undefined);
 });
 
 test.serial('keyv get / expired existing with bad number', async t => {
-    const keyv = new Keyv({store: keyvMemcache});
+	const keyv = new Keyv({store: keyvMemcache});
 
-    await keyv.set('foo-expired', 'bar-expired', 1);
+	await keyv.set('foo-expired', 'bar-expired', 1);
 
-    await snooze(1000);
+	await snooze(1000);
 
-    let val = await keyv.get('foo-expired');
+	const val = await keyv.get('foo-expired');
 
-    t.is(val, undefined);
+	t.is(val, undefined);
 });
 
 test.serial('keyv get / expired', async t => {
-    const keyv = new Keyv({store: keyvMemcache});
+	const keyv = new Keyv({store: keyvMemcache});
 
-    await keyv.set('foo-expired', 'bar-expired', 1000);
+	await keyv.set('foo-expired', 'bar-expired', 1000);
 
-    await snooze(1000);
+	await snooze(1000);
 
-    let val = await keyv.get('foo-expired');
+	const val = await keyv.get('foo-expired');
 
-    t.is(val, undefined);
+	t.is(val, undefined);
 });
 
 const withCallback = fn => async t => {
-    await promisify(fn)(t);
+	await promisify(fn)(t);
 };
 
 test('clear should emit an error', withCallback(async (t, end) => {
-    const keyv = new Keyv({store: new KeyvMemcache("baduri:11211")});
+	const keyv = new Keyv({store: new KeyvMemcache('baduri:11211')});
 
-    keyv.on("error", () => {
-        t.pass();
-        end();
-    });
+	keyv.on('error', () => {
+		t.pass();
+		end();
+	});
 
-    try {
-    await keyv.clear();
-    } catch (err) {}
+	try {
+		await keyv.clear();
+	} catch (_) {}
 }));
 
 test('delete should emit an error', withCallback(async (t, end) => {
-    var opts = { logger: { log: function(){}}};
-    const keyv = new Keyv({store: new KeyvMemcache("baduri:11211", opts)});
+	const opts = {logger: {log() {}}};
+	const keyv = new Keyv({store: new KeyvMemcache('baduri:11211', opts)});
 
-    keyv.on("error", () => {
-        t.pass();
-        end();
-    });
+	keyv.on('error', () => {
+		t.pass();
+		end();
+	});
 
-    try {
-    await keyv.delete("foo");
-    } catch (err) {}
+	try {
+		await keyv.delete('foo');
+	} catch (_) {}
 }));
 
 test('set should emit an error', withCallback(async (t, end) => {
-    var opts = { logger: { log: function(){}}};
-    const keyv = new Keyv({store: new KeyvMemcache("baduri:11211", opts)});
+	const opts = {logger: {log() {}}};
+	const keyv = new Keyv({store: new KeyvMemcache('baduri:11211', opts)});
 
-    keyv.on("error", () => {
-        t.pass();
-        end();
-    });
+	keyv.on('error', () => {
+		t.pass();
+		end();
+	});
 
-    try {
-    await keyv.set("foo", "bar");
-    } catch (err) {}
+	try {
+		await keyv.set('foo', 'bar');
+	} catch (_) {}
 }));
 
 test('get should emit an error', withCallback(async (t, end) => {
-    var opts = { logger: { log: function(){}}};
-    const keyv = new Keyv({store: new KeyvMemcache("baduri:11211", opts)});
+	const opts = {logger: {log() {}}};
+	const keyv = new Keyv({store: new KeyvMemcache('baduri:11211', opts)});
 
-    keyv.on("error", () => {
-        t.pass();
-        end();
-    });
+	keyv.on('error', () => {
+		t.pass();
+		end();
+	});
 
-    try {
-    await keyv.get("foo");
-    } catch (err) {}
+	try {
+		await keyv.get('foo');
+	} catch (_) {}
 }));
 
 const store = () => keyvMemcache;

--- a/packages/mongo/package.json
+++ b/packages/mongo/package.json
@@ -13,7 +13,8 @@
 		"rules": {
 			"unicorn/prefer-module": 0,
 			"unicorn/no-array-reduce": 0,
-			"unicorn/prefer-object-from-entries": 0
+			"unicorn/prefer-object-from-entries": 0,
+			"unicorn/prefer-node-protocol": 0
 		}
 	},
 	"ava": {

--- a/packages/mongo/package.json
+++ b/packages/mongo/package.json
@@ -9,7 +9,6 @@
 		"clean": "rm -rf node_modules && rm -rf .nyc_output && rm -rf coverage.lcov"
 	},
 	"xo": {
-		"extends": "xo-lukechilds",
 		"rules": {
 			"unicorn/prefer-module": 0,
 			"unicorn/no-array-reduce": 0,
@@ -51,7 +50,6 @@
 	"devDependencies": {
 		"@keyv/test-suite": "*",
 		"ava": "^4.1.0",
-		"eslint-config-xo-lukechilds": "^1.0.1",
 		"keyv": "*",
 		"nyc": "^15.1.0",
 		"requirable": "^1.0.5",

--- a/packages/mongo/src/index.d.ts
+++ b/packages/mongo/src/index.d.ts
@@ -1,4 +1,4 @@
-import EventEmitter from 'node:events';
+import EventEmitter from 'events';
 import GridFSBucket from 'mongodb';
 
 declare class KeyvMongo extends EventEmitter {

--- a/packages/mongo/src/index.d.ts
+++ b/packages/mongo/src/index.d.ts
@@ -1,4 +1,4 @@
-import EventEmitter from 'events';
+import { EventEmitter } from 'events';
 import GridFSBucket from 'mongodb';
 
 declare class KeyvMongo extends EventEmitter {

--- a/packages/mongo/src/index.d.ts
+++ b/packages/mongo/src/index.d.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'events';
+import {EventEmitter} from 'events';
 import GridFSBucket from 'mongodb';
 
 declare class KeyvMongo extends EventEmitter {

--- a/packages/mongo/test/test.js
+++ b/packages/mongo/test/test.js
@@ -1,11 +1,10 @@
-// @ts-ignore
 const test = require('ava');
 const keyvTestSuite = require('@keyv/test-suite').default;
-const { keyvOfficialTests, keyvIteratorTests } = require('@keyv/test-suite');
+const {keyvOfficialTests, keyvIteratorTests} = require('@keyv/test-suite');
 const Keyv = require('keyv');
 const KeyvMongo = require('this');
 
-const options = { useNewUrlParser: true, useUnifiedTopology: true, serverSelectionTimeoutMS: 5000 };
+const options = {useNewUrlParser: true, useUnifiedTopology: true, serverSelectionTimeoutMS: 5000};
 
 const mongoURL = 'mongodb://127.0.0.1:27017';
 
@@ -24,13 +23,13 @@ test('default options', t => {
 });
 
 test('default options with url.uri', t => {
-	const store = new KeyvMongo({ uri: mongoURL });
+	const store = new KeyvMongo({uri: mongoURL});
 	t.is(store.opts.uri, mongoURL);
 	t.is(store.opts.url, mongoURL);
 });
 
 test('Collection option merges into default options', t => {
-	const store = new KeyvMongo({ collection: 'foo' });
+	const store = new KeyvMongo({collection: 'foo'});
 	t.deepEqual(store.opts, {
 		url: mongoURL,
 		collection: 'foo',
@@ -38,14 +37,14 @@ test('Collection option merges into default options', t => {
 });
 
 test('useGridFS .has(key) where key is the key we are looking for', async t => {
-	const keyv = new KeyvMongo({ useGridFS: true, collection: 'foo' });
+	const keyv = new KeyvMongo({useGridFS: true, collection: 'foo'});
 	await keyv.set('foo', 'bar');
 	t.is(await keyv.has('foo'), true);
 	t.is(await keyv.has('fizz'), false);
 });
 
 test('useGridFS option merges into default options', t => {
-	const store = new KeyvMongo({ useGridFS: true, collection: 'foo' });
+	const store = new KeyvMongo({useGridFS: true, collection: 'foo'});
 	t.deepEqual(store.opts, {
 		url: mongoURL,
 		useGridFS: true,
@@ -54,7 +53,7 @@ test('useGridFS option merges into default options', t => {
 });
 
 test('Collection option merges into default options if URL is passed', t => {
-	const store = new KeyvMongo(mongoURL, { collection: 'foo' });
+	const store = new KeyvMongo(mongoURL, {collection: 'foo'});
 	t.deepEqual(store.opts, {
 		url: mongoURL,
 		collection: 'foo',
@@ -67,12 +66,12 @@ test('.delete() with no args doesn\'t empty the collection', async t => {
 });
 
 test('.delete() with key as number', async t => {
-	const store = new KeyvMongo(mongoURL, { collection: 'foo' });
+	const store = new KeyvMongo(mongoURL, {collection: 'foo'});
 	t.false(await store.delete(123));
 });
 
 test.serial('Stores value in GridFS', async t => {
-	const store = new KeyvMongo({ useGridFS: true, ...options });
+	const store = new KeyvMongo({useGridFS: true, ...options});
 	const result = await store.set('key1', 'keyv1', 0);
 	const get = await store.get('key1');
 	t.is(result.filename, 'key1');
@@ -80,37 +79,37 @@ test.serial('Stores value in GridFS', async t => {
 });
 
 test.serial('Gets value from GridFS', async t => {
-	const store = new KeyvMongo({ useGridFS: true, ...options });
+	const store = new KeyvMongo({useGridFS: true, ...options});
 	const result = await store.get('key1');
 	t.is(result, 'keyv1');
 });
 
 test.serial('Deletes value from GridFS', async t => {
-	const store = new KeyvMongo({ useGridFS: true, ...options });
+	const store = new KeyvMongo({useGridFS: true, ...options});
 	const result = await store.delete('key1');
 	t.is(result, true);
 });
 
 test.serial('Deletes non existent value from GridFS', async t => {
-	const store = new KeyvMongo({ useGridFS: true, ...options });
+	const store = new KeyvMongo({useGridFS: true, ...options});
 	const result = await store.delete('no-existent-value');
 	t.is(result, false);
 });
 
 test.serial('Stores value with TTL in GridFS', async t => {
-	const store = new KeyvMongo({ useGridFS: true, ...options });
+	const store = new KeyvMongo({useGridFS: true, ...options});
 	const result = await store.set('key1', 'keyv1', 0);
 	t.is(result.filename, 'key1');
 });
 
 test.serial('Clears expired value from GridFS', async t => {
-	const store = new KeyvMongo({ useGridFS: true, ...options });
+	const store = new KeyvMongo({useGridFS: true, ...options});
 	const cleared = await store.clearExpired();
 	t.is(cleared, true);
 });
 
 test.serial('Clears unused files from GridFS', async t => {
-	const store = new KeyvMongo({ useGridFS: true, ...options });
+	const store = new KeyvMongo({useGridFS: true, ...options});
 	const cleared = await store.clearUnusedFor(5);
 	t.is(cleared, true);
 });
@@ -128,13 +127,13 @@ test.serial('Clears unused files only when GridFS options is true', async t => {
 });
 
 test.serial('Gets non-existent file and return should be undefined', async t => {
-	const store = new KeyvMongo({ useGridFS: true, ...options });
+	const store = new KeyvMongo({useGridFS: true, ...options});
 	const result = await store.get('non-existent-file');
 	t.is(typeof result, 'undefined');
 });
 
 test.serial('Non-string keys are not permitted in delete', async t => {
-	const store = new KeyvMongo({ useGridFS: true, ...options });
+	const store = new KeyvMongo({useGridFS: true, ...options});
 	const result = await store.delete({
 		ok: true,
 	});
@@ -142,7 +141,7 @@ test.serial('Non-string keys are not permitted in delete', async t => {
 });
 
 test.serial('.deleteMany([keys]) should delete multiple gridfs key', async t => {
-	const keyv = new KeyvMongo({ useGridFS: true, ...options });
+	const keyv = new KeyvMongo({useGridFS: true, ...options});
 	await keyv.set('foo', 'bar');
 	await keyv.set('foo1', 'bar1');
 	await keyv.set('foo2', 'bar2');
@@ -153,12 +152,12 @@ test.serial('.deleteMany([keys]) should delete multiple gridfs key', async t => 
 });
 
 test.serial('.deleteMany([keys]) with nonexistent gridfs keys resolves to false', async t => {
-	const keyv = new KeyvMongo({ useGridFS: true, ...options });
+	const keyv = new KeyvMongo({useGridFS: true, ...options});
 	t.is(await keyv.deleteMany(['foo', 'foo1', 'foo2']), false);
 });
 
 test.serial('.getMany([keys]) using GridFS should return array values', async t => {
-	const keyv = new KeyvMongo({ useGridFS: true, ...options });
+	const keyv = new KeyvMongo({useGridFS: true, ...options});
 	await keyv.clearUnusedFor(0);
 	await keyv.set('foo', 'bar');
 	await keyv.set('foo1', 'bar1');
@@ -171,7 +170,7 @@ test.serial('.getMany([keys]) using GridFS should return array values', async t 
 });
 
 test.serial('.getMany([keys]) using GridFS should return array values with undefined', async t => {
-	const keyv = new KeyvMongo({ useGridFS: true, ...options });
+	const keyv = new KeyvMongo({useGridFS: true, ...options});
 	await keyv.clearUnusedFor(0);
 	await keyv.set('foo', 'bar');
 	await keyv.set('foo2', 'bar2');
@@ -183,7 +182,7 @@ test.serial('.getMany([keys]) using GridFS should return array values with undef
 });
 
 test.serial('.getMany([keys]) using GridFS should return empty array for all no existent keys', async t => {
-	const keyv = new KeyvMongo({ useGridFS: true, ...options });
+	const keyv = new KeyvMongo({useGridFS: true, ...options});
 	await keyv.clearUnusedFor(0);
 	const values = await keyv.getMany(['foo', 'foo1', 'foo2']);
 	t.is(Array.isArray(values), true);
@@ -191,7 +190,7 @@ test.serial('.getMany([keys]) using GridFS should return empty array for all no 
 });
 
 test.serial('Clears entire cache store', async t => {
-	const store = new KeyvMongo({ useGridFS: true, ...options });
+	const store = new KeyvMongo({useGridFS: true, ...options});
 	const result = await store.clear();
 	t.is(typeof result, 'undefined');
 });

--- a/packages/mysql/package.json
+++ b/packages/mysql/package.json
@@ -9,7 +9,6 @@
 		"clean": "rm -rf node_modules && rm -rf .nyc_output && rm -rf coverage.lcov"
 	},
 	"xo": {
-		"extends": "xo-lukechilds",
 		"rules": {
 			"unicorn/prefer-module": 0,
 			"unicorn/prefer-node-protocol": 0
@@ -49,7 +48,6 @@
 	"devDependencies": {
 		"@keyv/test-suite": "*",
 		"ava": "^4.0.1",
-		"eslint-config-xo-lukechilds": "^1.0.1",
 		"keyv": "*",
 		"nyc": "^15.1.0",
 		"requirable": "^1.0.5",

--- a/packages/mysql/package.json
+++ b/packages/mysql/package.json
@@ -11,7 +11,8 @@
 	"xo": {
 		"extends": "xo-lukechilds",
 		"rules": {
-			"unicorn/prefer-module": 0
+			"unicorn/prefer-module": 0,
+			"unicorn/prefer-node-protocol": 0
 		}
 	},
 	"ava": {

--- a/packages/mysql/src/index.d.ts
+++ b/packages/mysql/src/index.d.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'events';
+import {EventEmitter} from 'events';
 
 export = KeyvMysql;
 declare class KeyvMysql extends EventEmitter {

--- a/packages/mysql/src/index.d.ts
+++ b/packages/mysql/src/index.d.ts
@@ -1,4 +1,4 @@
-import EventEmitter from 'events';
+import { EventEmitter } from 'events';
 
 export = KeyvMysql;
 declare class KeyvMysql extends EventEmitter {

--- a/packages/mysql/src/index.d.ts
+++ b/packages/mysql/src/index.d.ts
@@ -1,4 +1,4 @@
-import EventEmitter from 'node:events';
+import EventEmitter from 'events';
 
 export = KeyvMysql;
 declare class KeyvMysql extends EventEmitter {

--- a/packages/mysql/src/index.js
+++ b/packages/mysql/src/index.js
@@ -1,28 +1,27 @@
-// @ts-ignore
 'use strict';
 
 const EventEmitter = require('events');
 const mysql = require('mysql2/promise');
-const { pool } = require('./pool.js');
+const {pool} = require('./pool.js');
 
 class KeyvMysql extends EventEmitter {
 	constructor(options) {
 		super();
 		this.ttlSupport = false;
 		if (typeof options === 'string') {
-			options = { uri: options };
+			options = {uri: options};
 		}
 
-		options = { dialect: 'mysql',
-			uri: 'mysql://localhost', ...options };
+		options = {dialect: 'mysql',
+			uri: 'mysql://localhost', ...options};
 
 		options.connect = () => Promise.resolve()
 			.then(() => pool(options.uri))
 			.then(connection => sql => connection.execute(sql)
 				.then(data => data[0]));
 
-		this.opts = { table: 'keyv',
-			keySize: 255, ...options };
+		this.opts = {table: 'keyv',
+			keySize: 255, ...options};
 
 		const createTable = `CREATE TABLE IF NOT EXISTS ${this.opts.table}(id VARCHAR(${Number(this.opts.keySize)}) PRIMARY KEY, value TEXT )`;
 

--- a/packages/mysql/src/pool.js
+++ b/packages/mysql/src/pool.js
@@ -1,4 +1,3 @@
-// @ts-ignore
 const mysql = require('mysql2');
 
 let pool;

--- a/packages/mysql/test/test.js
+++ b/packages/mysql/test/test.js
@@ -1,7 +1,6 @@
-// @ts-ignore
 const test = require('ava');
 const keyvTestSuite = require('@keyv/test-suite').default;
-const { keyvOfficialTests, keyvIteratorTests } = require('@keyv/test-suite');
+const {keyvOfficialTests, keyvIteratorTests} = require('@keyv/test-suite');
 const Keyv = require('keyv');
 const KeyvMysql = require('this');
 
@@ -9,5 +8,5 @@ keyvOfficialTests(test, Keyv, 'mysql://root@localhost/keyv_test', 'mysql://foo')
 
 const store = () => new KeyvMysql('mysql://root@localhost/keyv_test');
 keyvTestSuite(test, Keyv, store);
-const iteratorStore = () => new KeyvMysql({ uri: 'mysql://root@localhost/keyv_test', iterationLimit: 2 });
+const iteratorStore = () => new KeyvMysql({uri: 'mysql://root@localhost/keyv_test', iterationLimit: 2});
 keyvIteratorTests(test, Keyv, iteratorStore);

--- a/packages/postgres/package.json
+++ b/packages/postgres/package.json
@@ -9,7 +9,6 @@
 		"clean": "rm -rf node_modules && rm -rf .nyc_output && rm -rf coverage.lcov"
 	},
 	"xo": {
-		"extends": "xo-lukechilds",
 		"rules": {
 			"unicorn/prefer-module": 0,
 			"unicorn/prefer-node-protocol": 0
@@ -49,7 +48,6 @@
 	"devDependencies": {
 		"@keyv/test-suite": "*",
 		"ava": "^4.0.1",
-		"eslint-config-xo-lukechilds": "^1.0.1",
 		"keyv": "*",
 		"nyc": "^15.1.0",
 		"requirable": "^1.0.5",

--- a/packages/postgres/package.json
+++ b/packages/postgres/package.json
@@ -11,7 +11,8 @@
 	"xo": {
 		"extends": "xo-lukechilds",
 		"rules": {
-			"unicorn/prefer-module": 0
+			"unicorn/prefer-module": 0,
+			"unicorn/prefer-node-protocol": 0
 		}
 	},
 	"ava": {

--- a/packages/postgres/src/index.d.ts
+++ b/packages/postgres/src/index.d.ts
@@ -1,4 +1,4 @@
-import EventEmitter from 'events';
+import { EventEmitter } from 'events';
 
 export = KeyvPostgres;
 declare class KeyvPostgres extends EventEmitter {

--- a/packages/postgres/src/index.d.ts
+++ b/packages/postgres/src/index.d.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'events';
+import {EventEmitter} from 'events';
 
 export = KeyvPostgres;
 declare class KeyvPostgres extends EventEmitter {

--- a/packages/postgres/src/index.d.ts
+++ b/packages/postgres/src/index.d.ts
@@ -1,4 +1,4 @@
-import EventEmitter from 'node:events';
+import EventEmitter from 'events';
 
 export = KeyvPostgres;
 declare class KeyvPostgres extends EventEmitter {

--- a/packages/postgres/src/index.js
+++ b/packages/postgres/src/index.js
@@ -1,15 +1,14 @@
-// @ts-ignore
 'use strict';
 
 const EventEmitter = require('events');
-const { pool } = require('./pool.js');
+const {pool} = require('./pool.js');
 
 class KeyvPostgres extends EventEmitter {
 	constructor(options) {
 		super();
 		this.ttlSupport = false;
-		options = { dialect: 'postgres',
-			uri: 'postgresql://localhost:5432', ...options };
+		options = {dialect: 'postgres',
+			uri: 'postgresql://localhost:5432', ...options};
 
 		options.connect = () => Promise.resolve()
 			.then(() => {
@@ -17,8 +16,8 @@ class KeyvPostgres extends EventEmitter {
 				return (sql, values) => conn.query(sql, values)
 					.then(data => data.rows);
 			});
-		this.opts = { table: 'keyv',
-			keySize: 255, ...options };
+		this.opts = {table: 'keyv',
+			keySize: 255, ...options};
 
 		const createTable = `CREATE TABLE IF NOT EXISTS ${this.opts.table}(key VARCHAR(${Number(this.opts.keySize)}) PRIMARY KEY, value TEXT )`;
 

--- a/packages/postgres/src/pool.js
+++ b/packages/postgres/src/pool.js
@@ -1,5 +1,4 @@
-// @ts-ignore
-const { Pool } = require('pg');
+const {Pool} = require('pg');
 
 let pool;
 let globalUri;
@@ -10,7 +9,7 @@ const pools = uri => {
 		globalUri = uri;
 	}
 
-	pool = pool || new Pool({ connectionString: uri });
+	pool = pool || new Pool({connectionString: uri});
 	return pool;
 };
 

--- a/packages/postgres/test/test.js
+++ b/packages/postgres/test/test.js
@@ -1,13 +1,12 @@
-// @ts-ignore
 const test = require('ava');
 const keyvTestSuite = require('@keyv/test-suite').default;
-const { keyvOfficialTests, keyvIteratorTests } = require('@keyv/test-suite');
+const {keyvOfficialTests, keyvIteratorTests} = require('@keyv/test-suite');
 const Keyv = require('keyv');
 const KeyvPostgres = require('this');
 
 keyvOfficialTests(test, Keyv, 'postgresql://postgres:postgres@localhost:5432/keyv_test', 'postgresql://foo');
 
-const store = () => new KeyvPostgres({ uri: 'postgresql://postgres:postgres@localhost:5432/keyv_test', iterationLimit: 2 });
+const store = () => new KeyvPostgres({uri: 'postgresql://postgres:postgres@localhost:5432/keyv_test', iterationLimit: 2});
 keyvTestSuite(test, Keyv, store);
 keyvIteratorTests(test, Keyv, store);
 

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -11,7 +11,8 @@
 	"xo": {
 		"extends": "xo-lukechilds",
 		"rules": {
-			"unicorn/prefer-module": 0
+			"unicorn/prefer-module": 0,
+			"unicorn/prefer-node-protocol": 0
 		}
 	},
 	"ava": {

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -9,7 +9,6 @@
 		"clean": "rm -rf node_modules && rm -rf .nyc_output && rm -rf coverage.lcov"
 	},
 	"xo": {
-		"extends": "xo-lukechilds",
 		"rules": {
 			"unicorn/prefer-module": 0,
 			"unicorn/prefer-node-protocol": 0
@@ -48,7 +47,6 @@
 		"@keyv/test-suite": "*",
 		"ava": "^4.1.0",
 		"delay": "^5.0.0",
-		"eslint-config-xo-lukechilds": "^1.0.1",
 		"keyv": "*",
 		"nyc": "^15.1.0",
 		"requirable": "^1.0.5",

--- a/packages/redis/src/index.d.ts
+++ b/packages/redis/src/index.d.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'events';
+import {EventEmitter} from 'events';
 
 declare class KeyvRedis extends EventEmitter {
 	readonly ttlSupport: false;

--- a/packages/redis/src/index.d.ts
+++ b/packages/redis/src/index.d.ts
@@ -1,4 +1,4 @@
-import EventEmitter from 'events';
+import { EventEmitter } from 'events';
 
 declare class KeyvRedis extends EventEmitter {
 	readonly ttlSupport: false;

--- a/packages/redis/src/index.d.ts
+++ b/packages/redis/src/index.d.ts
@@ -1,4 +1,4 @@
-import EventEmitter from 'node:events';
+import EventEmitter from 'events';
 
 declare class KeyvRedis extends EventEmitter {
 	readonly ttlSupport: false;

--- a/packages/redis/src/index.js
+++ b/packages/redis/src/index.js
@@ -1,4 +1,3 @@
-// @ts-ignore
 const EventEmitter = require('events');
 const Redis = require('ioredis');
 
@@ -12,7 +11,7 @@ class KeyvRedis extends EventEmitter {
 		if (uri instanceof Redis || uri instanceof Redis.Cluster) {
 			this.redis = uri;
 		} else {
-			options = { ...(typeof uri === 'string' ? { uri } : uri), ...options };
+			options = {...(typeof uri === 'string' ? {uri} : uri), ...options};
 			this.redis = new Redis(options.uri, options);
 		}
 

--- a/packages/redis/test/test.js
+++ b/packages/redis/test/test.js
@@ -1,7 +1,6 @@
-// @ts-ignore
 const test = require('ava');
 const keyvTestSuite = require('@keyv/test-suite').default;
-const { keyvOfficialTests, keyvIteratorTests } = require('@keyv/test-suite');
+const {keyvOfficialTests, keyvIteratorTests} = require('@keyv/test-suite');
 const Keyv = require('keyv');
 const KeyvRedis = require('this');
 const Redis = require('ioredis');

--- a/packages/sqlite/package.json
+++ b/packages/sqlite/package.json
@@ -11,7 +11,8 @@
 	"xo": {
 		"extends": "xo-lukechilds",
 		"rules": {
-			"unicorn/prefer-module": 0
+			"unicorn/prefer-module": 0,
+			"unicorn/prefer-node-protocol": 0
 		}
 	},
 	"ava": {

--- a/packages/sqlite/package.json
+++ b/packages/sqlite/package.json
@@ -9,7 +9,6 @@
 		"clean": "rm -rf node_modules && rm -rf .nyc_output && rm -rf coverage.lcov && rm -rf ./test/testdb.sqlite"
 	},
 	"xo": {
-		"extends": "xo-lukechilds",
 		"rules": {
 			"unicorn/prefer-module": 0,
 			"unicorn/prefer-node-protocol": 0
@@ -48,7 +47,6 @@
 	"devDependencies": {
 		"@keyv/test-suite": "*",
 		"ava": "^4.0.1",
-		"eslint-config-xo-lukechilds": "^1.0.1",
 		"keyv": "*",
 		"nyc": "^15.1.0",
 		"requirable": "^1.0.5",

--- a/packages/sqlite/src/index.d.ts
+++ b/packages/sqlite/src/index.d.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'events';
+import {EventEmitter} from 'events';
 import Database from 'better-sqlite3';
 
 export = KeyvSqlite;

--- a/packages/sqlite/src/index.d.ts
+++ b/packages/sqlite/src/index.d.ts
@@ -1,4 +1,4 @@
-import EventEmitter from 'events';
+import { EventEmitter } from 'events';
 import Database from 'better-sqlite3';
 
 export = KeyvSqlite;

--- a/packages/sqlite/src/index.d.ts
+++ b/packages/sqlite/src/index.d.ts
@@ -1,4 +1,4 @@
-import EventEmitter from 'node:events';
+import EventEmitter from 'events';
 import Database from 'better-sqlite3';
 
 export = KeyvSqlite;

--- a/packages/sqlite/src/index.js
+++ b/packages/sqlite/src/index.js
@@ -1,4 +1,3 @@
-// @ts-ignore
 'use strict';
 
 const EventEmitter = require('events');
@@ -8,12 +7,12 @@ class KeyvSqlite extends EventEmitter {
 	constructor(options) {
 		super();
 		this.ttlSupport = false;
-		options = { dialect: 'sqlite',
-			uri: 'sqlite://:memory:', ...options };
+		options = {dialect: 'sqlite',
+			uri: 'sqlite://:memory:', ...options};
 		options.db = options.uri.replace(/^sqlite:\/\//, '');
 
-		this.opts = { table: 'keyv',
-			keySize: 255, ...options };
+		this.opts = {table: 'keyv',
+			keySize: 255, ...options};
 
 		const createTable = `CREATE TABLE IF NOT EXISTS ${this.opts.table}(key VARCHAR(${Number(this.opts.keySize)}) PRIMARY KEY, value TEXT )`;
 

--- a/packages/sqlite/test/test.js
+++ b/packages/sqlite/test/test.js
@@ -1,18 +1,17 @@
-// @ts-ignore
 const test = require('ava');
 const keyvTestSuite = require('@keyv/test-suite').default;
-const { keyvOfficialTests } = require('@keyv/test-suite');
+const {keyvOfficialTests} = require('@keyv/test-suite');
 const Keyv = require('keyv');
 const KeyvSqlite = require('this');
 
 keyvOfficialTests(test, Keyv, 'sqlite://test/testdb.sqlite', 'sqlite://non/existent/database.sqlite');
 
-const store = () => new KeyvSqlite({ uri: 'sqlite://test/testdb.sqlite', busyTimeout: 3000 });
+const store = () => new KeyvSqlite({uri: 'sqlite://test/testdb.sqlite', busyTimeout: 3000});
 
 keyvTestSuite(test, Keyv, store);
 
 test.serial('Async Iterator single element test', async t => {
-	const keyv = new KeyvSqlite({ uri: 'sqlite://test/testdb.sqlite', busyTimeout: 3000 });
+	const keyv = new KeyvSqlite({uri: 'sqlite://test/testdb.sqlite', busyTimeout: 3000});
 	await keyv.clear();
 	await keyv.set('foo', 'bar');
 	const iterator = keyv.iterator();
@@ -23,7 +22,7 @@ test.serial('Async Iterator single element test', async t => {
 });
 
 test.serial('Async Iterator multiple element test', async t => {
-	const keyv = new KeyvSqlite({ uri: 'sqlite://test/testdb.sqlite', busyTimeout: 3000, iterationLimit: 3 });
+	const keyv = new KeyvSqlite({uri: 'sqlite://test/testdb.sqlite', busyTimeout: 3000, iterationLimit: 3});
 	await keyv.clear();
 	await keyv.set('foo', 'bar');
 	await keyv.set('foo1', 'bar1');
@@ -40,7 +39,7 @@ test.serial('Async Iterator multiple element test', async t => {
 });
 
 test.serial('Async Iterator multiple elements with limit=1 test', async t => {
-	const keyv = new KeyvSqlite({ uri: 'sqlite://test/testdb.sqlite', busyTimeout: 3000, iterationLimit: 1 });
+	const keyv = new KeyvSqlite({uri: 'sqlite://test/testdb.sqlite', busyTimeout: 3000, iterationLimit: 1});
 	await keyv.clear();
 	await keyv.set('foo', 'bar');
 	await keyv.set('foo1', 'bar1');
@@ -61,7 +60,7 @@ test.serial('Async Iterator multiple elements with limit=1 test', async t => {
 });
 
 test.serial('Async Iterator 0 element test', async t => {
-	const keyv = new KeyvSqlite({ uri: 'sqlite://test/testdb.sqlite', busyTimeout: 3000, iterationLimit: 1 });
+	const keyv = new KeyvSqlite({uri: 'sqlite://test/testdb.sqlite', busyTimeout: 3000, iterationLimit: 1});
 	await keyv.clear();
 	const iterator = keyv.iterator('keyv');
 	const key = await iterator.next();

--- a/packages/test-suite/package.json
+++ b/packages/test-suite/package.json
@@ -10,7 +10,6 @@
 		"clean": "rm -rf node_modules && rm -rf .nyc_output && rm -rf coverage.lcov && rm -rf dist && rm -rf ./test/testdb.sqlite"
 	},
 	"xo": {
-		"extends": "xo-lukechilds",
 		"rules": {
 			"unicorn/prefer-module": 0,
 			"unicorn/prefer-node-protocol": 0
@@ -44,7 +43,6 @@
 	},
 	"devDependencies": {
 		"ava": "^4.1.0",
-		"eslint-config-xo-lukechilds": "^1.0.1",
 		"keyv": "*",
 		"nyc": "^15.1.0",
 		"this": "^1.1.0",

--- a/packages/test-suite/package.json
+++ b/packages/test-suite/package.json
@@ -12,7 +12,8 @@
 	"xo": {
 		"extends": "xo-lukechilds",
 		"rules": {
-			"unicorn/prefer-module": 0
+			"unicorn/prefer-module": 0,
+			"unicorn/prefer-node-protocol": 0
 		}
 	},
 	"repository": {

--- a/packages/test-suite/src/api.js
+++ b/packages/test-suite/src/api.js
@@ -3,29 +3,29 @@ const delay = require('delay');
 
 const keyvApiTests = (test, Keyv, store) => {
 	test.beforeEach(async () => {
-		const keyv = new Keyv({ store: store() });
+		const keyv = new Keyv({store: store()});
 		await keyv.clear();
 	});
 
 	test.serial('.set(key, value) returns a Promise', t => {
-		const keyv = new Keyv({ store: store() });
+		const keyv = new Keyv({store: store()});
 		t.true(keyv.set('foo', 'bar') instanceof Promise);
 	});
 
 	test.serial('.set(key, value) resolves to true', async t => {
-		const keyv = new Keyv({ store: store() });
+		const keyv = new Keyv({store: store()});
 		t.is(await keyv.set('foo', 'bar'), true);
 	});
 
 	test.serial('.set(key, value) sets a value', async t => {
-		const keyv = new Keyv({ store: store() });
+		const keyv = new Keyv({store: store()});
 		await keyv.set('foo', 'bar');
 		t.is(await keyv.get('foo'), 'bar');
 	});
 
 	test.serial('.set(key, value, ttl) sets a value that expires', async t => {
 		const ttl = 1000;
-		const keyv = new Keyv({ store: store() });
+		const keyv = new Keyv({store: store()});
 		await keyv.set('foo', 'bar', ttl);
 		t.is(await keyv.get('foo'), 'bar');
 		if (keyv.opts.store.ttlSupport === true) {
@@ -39,23 +39,23 @@ const keyvApiTests = (test, Keyv, store) => {
 	});
 
 	test.serial('.get(key) returns a Promise', t => {
-		const keyv = new Keyv({ store: store() });
+		const keyv = new Keyv({store: store()});
 		t.true(keyv.get('foo') instanceof Promise);
 	});
 
 	test.serial('.get(key) resolves to value', async t => {
-		const keyv = new Keyv({ store: store() });
+		const keyv = new Keyv({store: store()});
 		await keyv.set('foo', 'bar');
 		t.is(await keyv.get('foo'), 'bar');
 	});
 
 	test.serial('.get(key) with nonexistent key resolves to undefined', async t => {
-		const keyv = new Keyv({ store: store() });
+		const keyv = new Keyv({store: store()});
 		t.is(await keyv.get('foo'), undefined);
 	});
 
 	test.serial('.get([keys]) should return array values', async t => {
-		const keyv = new Keyv({ store: store() });
+		const keyv = new Keyv({store: store()});
 		const ttl = 3000;
 		await keyv.set('foo', 'bar', ttl);
 		await keyv.set('foo1', 'bar1', ttl);
@@ -68,7 +68,7 @@ const keyvApiTests = (test, Keyv, store) => {
 	});
 
 	test.serial('.get([keys]) should return array value undefined when expires', async t => {
-		const keyv = new Keyv({ store: new Map() });
+		const keyv = new Keyv({store: new Map()});
 		await keyv.set('foo', 'bar');
 		await keyv.set('foo1', 'bar1', 1);
 		await keyv.set('foo2', 'bar2');
@@ -86,7 +86,7 @@ const keyvApiTests = (test, Keyv, store) => {
 	});
 
 	test.serial('.get([keys]) should return array values with undefined', async t => {
-		const keyv = new Keyv({ store: store() });
+		const keyv = new Keyv({store: store()});
 		const ttl = 3000;
 		await keyv.set('foo', 'bar', ttl);
 		await keyv.set('foo2', 'bar2', ttl);
@@ -98,42 +98,42 @@ const keyvApiTests = (test, Keyv, store) => {
 	});
 
 	test.serial('.get([keys]) should return empty array for all no existent keys', async t => {
-		const keyv = new Keyv({ store: store() });
+		const keyv = new Keyv({store: store()});
 		const values = await keyv.get(['foo', 'foo1', 'foo2']);
 		t.is(Array.isArray(values), true);
 		t.deepEqual(values, []);
 	});
 
 	test.serial('.delete(key) returns a Promise', t => {
-		const keyv = new Keyv({ store: store() });
+		const keyv = new Keyv({store: store()});
 		t.true(keyv.delete('foo') instanceof Promise);
 	});
 
 	test.serial('.delete([key]) returns a Promise', t => {
-		const keyv = new Keyv({ store: store() });
+		const keyv = new Keyv({store: store()});
 		t.true(keyv.delete(['foo', 'foo1']) instanceof Promise);
 	});
 
 	test.serial('.delete(key) resolves to true', async t => {
-		const keyv = new Keyv({ store: store() });
+		const keyv = new Keyv({store: store()});
 		await keyv.set('foo', 'bar');
 		t.is(await keyv.delete('foo'), true);
 	});
 
 	test.serial('.delete(key) with nonexistent key resolves to false', async t => {
-		const keyv = new Keyv({ store: store() });
+		const keyv = new Keyv({store: store()});
 		t.is(await keyv.delete('foo'), false);
 	});
 
 	test.serial('.delete(key) deletes a key', async t => {
-		const keyv = new Keyv({ store: store() });
+		const keyv = new Keyv({store: store()});
 		await keyv.set('foo', 'bar');
 		t.is(await keyv.delete('foo'), true);
 		t.is(await keyv.get('foo'), undefined);
 	});
 
 	test.serial('.deleteMany([keys]) should delete multiple key', async t => {
-		const keyv = new Keyv({ store: store() });
+		const keyv = new Keyv({store: store()});
 		await keyv.set('foo', 'bar');
 		await keyv.set('foo1', 'bar1');
 		await keyv.set('foo2', 'bar2');
@@ -144,26 +144,26 @@ const keyvApiTests = (test, Keyv, store) => {
 	});
 
 	test.serial('.deleteMany([keys]) with nonexistent keys resolves to false', async t => {
-		const keyv = new Keyv({ store: store() });
+		const keyv = new Keyv({store: store()});
 		t.is(await keyv.delete(['foo', 'foo1', 'foo2']), false);
 	});
 
 	test.serial('.clear() returns a Promise', async t => {
-		const keyv = new Keyv({ store: store() });
+		const keyv = new Keyv({store: store()});
 		const returnValue = keyv.clear();
 		t.true(returnValue instanceof Promise);
 		await returnValue;
 	});
 
 	test.serial('.clear() resolves to undefined', async t => {
-		const keyv = new Keyv({ store: store() });
+		const keyv = new Keyv({store: store()});
 		t.is(await keyv.clear(), undefined);
 		await keyv.set('foo', 'bar');
 		t.is(await keyv.clear(), undefined);
 	});
 
 	test.serial('.clear() deletes all key/value pairs', async t => {
-		const keyv = new Keyv({ store: store() });
+		const keyv = new Keyv({store: store()});
 		await keyv.set('foo', 'bar');
 		await keyv.set('fizz', 'buzz');
 		await keyv.clear();
@@ -172,14 +172,14 @@ const keyvApiTests = (test, Keyv, store) => {
 	});
 
 	test.serial('.has(key) where key is the key we are looking for', async t => {
-		const keyv = new Keyv({ store: store() });
+		const keyv = new Keyv({store: store()});
 		await keyv.set('foo', 'bar');
 		t.is(await keyv.has('foo'), true);
 		t.is(await keyv.has('fizz'), false);
 	});
 
 	test.after.always(async () => {
-		const keyv = new Keyv({ store: store() });
+		const keyv = new Keyv({store: store()});
 		await keyv.clear();
 	});
 };

--- a/packages/test-suite/src/index.js
+++ b/packages/test-suite/src/index.js
@@ -1,4 +1,3 @@
-
 const keyvApiTests = require('./api.js');
 const keyvValueTests = require('./values.js');
 const keyvNamepsaceTests = require('./namespace.js');

--- a/packages/test-suite/src/iterator.js
+++ b/packages/test-suite/src/iterator.js
@@ -3,19 +3,19 @@ const delay = require('delay');
 
 const keyvIteratorTests = (test, Keyv, store) => {
 	test.beforeEach(async () => {
-		const keyv = new Keyv({ store: store() });
+		const keyv = new Keyv({store: store()});
 		await keyv.clear();
 	});
 
 	test.serial('.iterator() returns an asyncIterator', t => {
-		const keyv = new Keyv({ store: store() });
+		const keyv = new Keyv({store: store()});
 		t.true(typeof keyv.iterator()[Symbol.asyncIterator] === 'function');
 	});
 
 	test.serial('iterator() iterates over all values', async t => {
-		const keyv = new Keyv({ store: store() });
+		const keyv = new Keyv({store: store()});
 		const map = new Map(
-			Array.from({ length: 5 })
+			Array.from({length: 5})
 				.fill(0)
 				.map((x, i) => [String(i), String(i + 10)]),
 		);
@@ -38,9 +38,9 @@ const keyvIteratorTests = (test, Keyv, store) => {
 		async t => {
 			const KeyvStore = store();
 
-			const keyv1 = new Keyv({ store: KeyvStore, namespace: 'keyv1' });
+			const keyv1 = new Keyv({store: KeyvStore, namespace: 'keyv1'});
 			const map1 = new Map(
-				Array.from({ length: 5 })
+				Array.from({length: 5})
 					.fill(0)
 					.map((x, i) => [String(i), String(i + 10)]),
 			);
@@ -51,9 +51,9 @@ const keyvIteratorTests = (test, Keyv, store) => {
 
 			await Promise.all(toResolve);
 
-			const keyv2 = new Keyv({ store: KeyvStore, namespace: 'keyv2' });
+			const keyv2 = new Keyv({store: KeyvStore, namespace: 'keyv2'});
 			const map2 = new Map(
-				Array.from({ length: 5 })
+				Array.from({length: 5})
 					.fill(0)
 					.map((x, i) => [String(i), String(i + 11)]),
 			);
@@ -76,9 +76,9 @@ const keyvIteratorTests = (test, Keyv, store) => {
 	test.serial(
 		'iterator() doesn\'t yield expired values, and deletes them',
 		async t => {
-			const keyv = new Keyv({ store: store() });
+			const keyv = new Keyv({store: store()});
 			const map = new Map(
-				Array.from({ length: 5 })
+				Array.from({length: 5})
 					.fill(0)
 					.map((x, i) => [String(i), String(i + 10)]),
 			);

--- a/packages/test-suite/src/namespace.js
+++ b/packages/test-suite/src/namespace.js
@@ -1,14 +1,14 @@
 const keyvNamepsaceTests = (test, Keyv, store) => {
 	test.beforeEach(async () => {
-		const keyv1 = new Keyv({ store: store(), namespace: 'keyv1' });
-		const keyv2 = new Keyv({ store: store(), namespace: 'keyv2' });
+		const keyv1 = new Keyv({store: store(), namespace: 'keyv1'});
+		const keyv2 = new Keyv({store: store(), namespace: 'keyv2'});
 		await keyv1.clear();
 		await keyv2.clear();
 	});
 
 	test.serial('namespaced set/get don\'t collide', async t => {
-		const keyv1 = new Keyv({ store: store(), namespace: 'keyv1' });
-		const keyv2 = new Keyv({ store: store(), namespace: 'keyv2' });
+		const keyv1 = new Keyv({store: store(), namespace: 'keyv1'});
+		const keyv2 = new Keyv({store: store(), namespace: 'keyv2'});
 		await keyv1.set('foo', 'keyv1');
 		await keyv2.set('foo', 'keyv2');
 		t.is(await keyv1.get('foo'), 'keyv1');
@@ -16,8 +16,8 @@ const keyvNamepsaceTests = (test, Keyv, store) => {
 	});
 
 	test.serial('namespaced delete only deletes from current namespace', async t => {
-		const keyv1 = new Keyv({ store: store(), namespace: 'keyv1' });
-		const keyv2 = new Keyv({ store: store(), namespace: 'keyv2' });
+		const keyv1 = new Keyv({store: store(), namespace: 'keyv1'});
+		const keyv2 = new Keyv({store: store(), namespace: 'keyv2'});
 		await keyv1.set('foo', 'keyv1');
 		await keyv2.set('foo', 'keyv2');
 		t.is(await keyv1.delete('foo'), true);
@@ -26,8 +26,8 @@ const keyvNamepsaceTests = (test, Keyv, store) => {
 	});
 
 	test.serial('namespaced clear only clears current namespace', async t => {
-		const keyv1 = new Keyv({ store: store(), namespace: 'keyv1' });
-		const keyv2 = new Keyv({ store: store(), namespace: 'keyv2' });
+		const keyv1 = new Keyv({store: store(), namespace: 'keyv1'});
+		const keyv2 = new Keyv({store: store(), namespace: 'keyv2'});
 		await keyv1.set('foo', 'keyv1');
 		await keyv1.set('bar', 'keyv1');
 		await keyv2.set('foo', 'keyv2');
@@ -40,8 +40,8 @@ const keyvNamepsaceTests = (test, Keyv, store) => {
 	});
 
 	test.after.always(async () => {
-		const keyv1 = new Keyv({ store: store(), namespace: 'keyv1' });
-		const keyv2 = new Keyv({ store: store(), namespace: 'keyv2' });
+		const keyv1 = new Keyv({store: store(), namespace: 'keyv1'});
+		const keyv2 = new Keyv({store: store(), namespace: 'keyv2'});
 		await keyv1.clear();
 		await keyv2.clear();
 	});

--- a/packages/test-suite/src/official.js
+++ b/packages/test-suite/src/official.js
@@ -1,4 +1,4 @@
-const promisify = require('util').promisify;
+const {promisify} = require('util');
 
 const keyvOfficialTests = (test, Keyv, goodUri, badUri, options = {}) => { // eslint-disable-line max-params
 	test.serial('connection string automatically requires storage adapter', async t => {

--- a/packages/test-suite/src/values.js
+++ b/packages/test-suite/src/values.js
@@ -3,64 +3,64 @@ const bigNumber = require('bignumber.js');
 
 const keyvValueTests = (test, Keyv, store) => {
 	test.beforeEach(async () => {
-		const keyv = new Keyv({ store: store() });
+		const keyv = new Keyv({store: store()});
 		await keyv.clear();
 	});
 
 	test.serial('value can be false', async t => {
-		const keyv = new Keyv({ store: store() });
+		const keyv = new Keyv({store: store()});
 		await keyv.set('foo', false);
 		t.is(await keyv.get('foo'), false);
 	});
 
 	test.serial('value can be null', async t => {
-		const keyv = new Keyv({ store: store() });
+		const keyv = new Keyv({store: store()});
 		await keyv.set('foo', null);
 		t.is(await keyv.get('foo'), null);
 	});
 
 	test.serial('value can be undefined', async t => {
-		const keyv = new Keyv({ store: store() });
+		const keyv = new Keyv({store: store()});
 		await keyv.set('foo', undefined);
 		t.is(await keyv.get('foo'), undefined);
 	});
 
 	test.serial('value can be a number', async t => {
-		const keyv = new Keyv({ store: store() });
+		const keyv = new Keyv({store: store()});
 		await keyv.set('foo', 0);
 		t.is(await keyv.get('foo'), 0);
 	});
 
 	test.serial('value can be an object', async t => {
-		const keyv = new Keyv({ store: store() });
-		const value = { fizz: 'buzz' };
+		const keyv = new Keyv({store: store()});
+		const value = {fizz: 'buzz'};
 		await keyv.set('foo', value);
 		t.deepEqual(await keyv.get('foo'), value);
 	});
 
 	test.serial('value can be a buffer', async t => {
-		const keyv = new Keyv({ store: store() });
+		const keyv = new Keyv({store: store()});
 		const buf = require('buffer').Buffer.from('bar');
 		await keyv.set('foo', buf);
 		t.true(buf.equals(await keyv.get('foo')));
 	});
 
 	test.serial('value can be an object containing a buffer', async t => {
-		const keyv = new Keyv({ store: store() });
-		const value = { buff: require('buffer').Buffer.from('buzz') };
+		const keyv = new Keyv({store: store()});
+		const value = {buff: require('buffer').Buffer.from('buzz')};
 		await keyv.set('foo', value);
 		t.deepEqual(await keyv.get('foo'), value);
 	});
 
 	test.serial('value can contain quotes', async t => {
-		const keyv = new Keyv({ store: store() });
+		const keyv = new Keyv({store: store()});
 		const value = '"';
 		await keyv.set('foo', value);
 		t.deepEqual(await keyv.get('foo'), value);
 	});
 
 	test.serial('value can not be symbol', async t => {
-		const keyv = new Keyv({ store: store() });
+		const keyv = new Keyv({store: store()});
 		const value = Symbol('value');
 		try {
 			await keyv.set('foo', value);
@@ -75,16 +75,16 @@ const keyvValueTests = (test, Keyv, store) => {
 			store().opts.deserialize = JSONbig.parse;
 		}
 
-		const keyv = new Keyv({ store: store(),
+		const keyv = new Keyv({store: store(),
 			serialize: JSONbig.stringify,
-			deserialize: JSONbig.parse });
+			deserialize: JSONbig.parse});
 		const value = BigInt('9223372036854775807');
 		await keyv.set('foo', value);
 		t.deepEqual(await keyv.get('foo'), bigNumber(value));
 	});
 
 	test.after.always(async () => {
-		const keyv = new Keyv({ store: store() });
+		const keyv = new Keyv({store: store()});
 		await keyv.clear();
 	});
 };

--- a/packages/test-suite/test/unit.js
+++ b/packages/test-suite/test/unit.js
@@ -1,7 +1,7 @@
 const test = require('ava');
 const Keyv = require('keyv');
 const keyvTestSuite = require('this').default;
-const { keyvOfficialTests, keyvIteratorTests } = require('this');
+const {keyvOfficialTests, keyvIteratorTests} = require('this');
 
 keyvOfficialTests(test, Keyv, 'sqlite://test/testdb.sqlite', 'sqlite://non/existent/database.sqlite');
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -68,7 +68,7 @@
         /* Interop Constraints */
         // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
         // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
-        "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility. */
+        // "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility. */
         // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
         "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
 


### PR DESCRIPTION
Hello, I'm currently having problems using a dependent of this. The cause is that imports are being made from `node:events`, a notation that is only supported in very new versions of the `@types/node` package (I think 16.6 and up). To support node 12 and 14, I changed the imports to `events` and used the named import (the default import was actually broken for me).

Additionally, I resolved a compatibility issue for people that used the `@types/keyv` package - the new definitions were missing the `Store` type. Aliasing it to the "new" `Keyv` type works fine for now, but there should be some minor refactoring for this in the future, probably.

Fixes #268 