### PR TITLE
#311 🐛 Fix loadStore to support mongodb+srv:// URIs

### DIFF
--- a/packages/keyv/src/index.js
+++ b/packages/keyv/src/index.js
@@ -18,7 +18,7 @@ const loadStore = options => {
 		tiered: '@keyv/tiered',
 	};
 	if (options.adapter || options.uri) {
-		const adapter = options.adapter || /^[^:]*/.exec(options.uri)[0];
+		const adapter = options.adapter || /^[^:+]*/.exec(options.uri)[0];
 		return new (require(adapters[adapter]))(options);
 	}
 


### PR DESCRIPTION
Resolves #311 with a simple regex change to loadStore() function that selects adapter based on URI prefix.

All tests passing.