### PR TITLE
Add support for rediss protocol

### DIFF
--- a/packages/keyv/src/index.js
+++ b/packages/keyv/src/index.js
@@ -7,6 +7,7 @@ const compressBrotli = require('compress-brotli');
 const loadStore = options => {
 	const adapters = {
 		redis: '@keyv/redis',
+		rediss: '@keyv/redis',
 		mongodb: '@keyv/mongo',
 		mongo: '@keyv/mongo',
 		sqlite: '@keyv/sqlite',


### PR DESCRIPTION
Hello,

I am new to Keyv and noticed that the rediss protocol is not supported.
I got an error when passing a rediss protocol URI.

```
> kv = new Keyv("rediss://example.com")
Uncaught:
TypeError [ERR_INVALID_ARG_TYPE]: The "id" argument must be of type string. Received undefined
    at __node_internal_captureLargerStackTrace (node:internal/errors:465:5)
    at new NodeError (node:internal/errors:372:5)
    at validateString (node:internal/validators:120:11)
    at Module.require (node:internal/modules/cjs/loader:998:3)
    at require (node:internal/modules/cjs/helpers:102:18)
    at loadStore (/Users/airtoxin/repositories/app/node_modules/keyv/src/index.js:22:15)
    at new Keyv (/Users/airtoxin/repositories/app/node_modules/keyv/src/index.js:50:22) {
  code: 'ERR_INVALID_ARG_TYPE'
}
```

This PR improves this.

Of cource, redis protocol can be properly instantiated.

```
> kv = new Keyv("redis://example.com")
Keyv {
  _events: [Object: null prototype] {},
  _eventsCount: 0,
  _maxListeners: undefined,
  opts: {
    namespace: 'keyv',
    serialize: [Function: stringify],
    deserialize: [Function (anonymous)],
    uri: 'redis://example.com',
    store: KeyvRedis {
      _events: [Object: null prototype],
      _eventsCount: 1,
      _maxListeners: undefined,
      ttlSupport: true,
      opts: [Object],
      redis: [Commander],
      namespace: 'keyv',
      [Symbol(kCapture)]: false
    }
  },
  iterator: [AsyncGeneratorFunction (anonymous)],
  [Symbol(kCapture)]: false
}
```

Maybe related: https://github.com/jaredwray/keyv/issues/308