### PR TITLE
Add multi-key get typings overload

### DIFF
--- a/packages/keyv/src/index.d.ts
+++ b/packages/keyv/src/index.d.ts
@@ -27,10 +27,19 @@ declare class Keyv<Value = any, Options extends Record<string, any> = Record<str
 	constructor(uri?: string, options?: Keyv.Options<Value> & Options);
 
 	/** Returns the value. */
-	get<Raw extends boolean = false>(key: string | string[], options?: {raw?: Raw}):
+	get<Raw extends boolean = false>(key: string, options?: {raw?: Raw}):
 	Promise<(Raw extends false
 		? Value
 		: Keyv.DeserializedData<Value>) | undefined>;
+
+	/** getMany by providing an array of keys */
+	get<Raw extends boolean = false>(
+		key: string[],
+		options?: { raw?: Raw }
+	): Promise<
+		((Raw extends false ? Value : Keyv.DeserializedData<Value>) | undefined)[]
+	>;
+	
 	/**
      * Set a value.
      *


### PR DESCRIPTION
`Keyv` supports the use of `get` in an overloaded manner. Pass a single key, get a single result; pass an array of keys, get an array of results.

The current typings as they're written return a singular `Value` in both cases. By overloading this method, we can get the correct return type `string -> Value | undefined`, `string[] -> (Value | undefined)[]`.