### PR TITLE
Add missing `getMany` optional method on Store interface

### DIFF
--- a/packages/keyv/src/index.d.ts
+++ b/packages/keyv/src/index.d.ts
@@ -92,12 +92,17 @@ declare namespace Keyv {
 		value: Value; expires: number | undefined;
 	}
 
+	type StoredData<Value> = DeserializedData<Value> | string | undefined | undefined;
+
 	interface Store<Value> {
 		get(key: string): Value | Promise<Value | undefined> | undefined;
 		set(key: string, value: Value, ttl?: number): any;
 		delete(key: string): boolean | Promise<boolean>;
 		clear(): void | Promise<void>;
 		has?(key: string): boolean | Promise<boolean>;
+		getMany?(
+			keys: string[]
+		): Array<StoredData<Value>> | Promise<Array<StoredData<Value>>> | undefined;
 	}
 }
 


### PR DESCRIPTION
I'm a little unsure about the `StoredData` type I landed on, it's what I gathered based on the src here:
https://github.com/jaredwray/keyv/blob/main/packages/keyv/src/index.js#L155-L174

Also, `xo` is breaking my type:
I want:
`type StoredData<Value> = DeserializedData<Value> | string | null | undefined;`
...but it mistakenly replaces with:
`type StoredData<Value> = DeserializedData<Value> | string | undefined | undefined;`

Just a consideration: `prettier` tends to be the formatting standard in JS/TS and I've never seen an issue as glaring as ^ that while using it.