### PR TITLE
Make iterator’s `namespace` parameter optional

### DIFF
--- a/packages/keyv/src/index.d.ts
+++ b/packages/keyv/src/index.d.ts
@@ -57,7 +57,7 @@ declare class Keyv<Value = any, Options extends Record<string, any> = Record<str
 	/** Check if key exists in current namespace. */
 	has(key: string): Promise<boolean>;
 	/** Iterator */
-	iterator(namespace: string | undefined): AsyncGenerator<any, void, any>;
+	iterator(namespace?: string): AsyncGenerator<any, void, any>;
 	/**
 	 * Closes the connection.
 	 *


### PR DESCRIPTION
Right now, calling `keyv.iterator()` from TypeScript code will result in a missing argument error:

<img width="888" alt="image" src="https://user-images.githubusercontent.com/193136/174470017-4ca48f43-87c8-48da-b017-fa3660f3c754.png">
