### PR TITLE
Reintroduce `getMany` optional method

### DIFF
--- a/packages/keyv/src/index.d.ts
+++ b/packages/keyv/src/index.d.ts
@@ -92,12 +92,17 @@ declare namespace Keyv {
 		value: Value; expires: number | undefined;
 	}
 
+	type StoredData<Value> = DeserializedData<Value> | string | undefined | undefined;
+
 	interface Store<Value> {
 		get(key: string): Value | Promise<Value | undefined> | undefined;
 		set(key: string, value: Value, ttl?: number): any;
 		delete(key: string): boolean | Promise<boolean>;
 		clear(): void | Promise<void>;
 		has?(key: string): boolean | Promise<boolean>;
+		getMany?(
+			keys: string[]
+		): Array<StoredData<Value>> | Promise<Array<StoredData<Value>>> | undefined;
 	}
 }
 

--- a/packages/keyv/src/index.d.ts
+++ b/packages/keyv/src/index.d.ts
@@ -92,7 +92,7 @@ declare namespace Keyv {
 		value: Value; expires: number | undefined;
 	}
 
-	type StoredData<Value> = DeserializedData<Value> | string | undefined | undefined;
+	type StoredData<Value> = DeserializedData<Value> | string | null | undefined;
 
 	interface Store<Value> {
 		get(key: string): Value | Promise<Value | undefined> | undefined;

--- a/packages/keyv/src/index.d.ts
+++ b/packages/keyv/src/index.d.ts
@@ -92,7 +92,7 @@ declare namespace Keyv {
 		value: Value; expires: number | undefined;
 	}
 
-	type StoredData<Value> = DeserializedData<Value> | string | null | undefined;
+	type StoredData<Value> = DeserializedData<Value> | string | undefined;
 
 	interface Store<Value> {
 		get(key: string): Value | Promise<Value | undefined> | undefined;


### PR DESCRIPTION
Reinstates https://github.com/jaredwray/keyv/pull/362

The `undefined | undefined` type was happening via `xo`'s fix option due to a lint config which forbids the use of `null` (and converts to `undefined` (`@typescript-eslint/ban-types`). In hindsight, I'm not sure the `null` was correct there to begin with.