### PR TITLE
redis - removing @types/keyv as no longer needed

### DIFF
--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -61,7 +61,6 @@
 		"@keyv/test-suite": "*",
 		"ava": "^5.0.1",
 		"delay": "^5.0.0",
-		"@types/keyv": "^3.1.4",
 		"keyv": "*",
 		"nyc": "^15.1.0",
 		"ts-node": "^10.9.1",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](https://github.com/jaredwray/keyv/blob/main/CONTRIBUTING.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
redis - removing @types/keyv as no longer needed