### PR TITLE
Redis: Fix return on `set`

### DIFF
--- a/packages/redis/src/index.js
+++ b/packages/redis/src/index.js
@@ -52,8 +52,9 @@ class KeyvRedis extends EventEmitter {
 				return this.redis.set(key, value);
 			})
 			.then(() => {
-				this.redis.sadd(this._getNamespace(), key);
-			});
+				return this.redis.sadd(this._getNamespace(), key);
+			})
+			.then(() => undefined)
 	}
 
 	delete(key) {

--- a/packages/redis/src/index.js
+++ b/packages/redis/src/index.js
@@ -51,10 +51,8 @@ class KeyvRedis extends EventEmitter {
 
 				return this.redis.set(key, value);
 			})
-			.then(() => {
-				return this.redis.sadd(this._getNamespace(), key);
-			})
-			.then(() => undefined)
+			.then(() => this.redis.sadd(this._getNamespace(), key))
+			.then(() => undefined);
 	}
 
 	delete(key) {


### PR DESCRIPTION
When using `commandTimeout` on `ioredis` and if timeout is reached, this will throw an unhandled promise rejection. It is required to return the promise from that otherwise it's not possible to catch it.

> Edit:
We can listen to `process.on('unhandledrejection')` but this error happens for a `request` and we don't have the `response` object in that event handler.

**Please check if the PR fulfills these requirements**
- [ ] Followed the [Contributing](https://github.com/jaredwray/keyv/blob/main/CONTRIBUTING.md) guidelines.
- [ ] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix