### PR TITLE
typings: Correctly type `Keyv.get([])` signature to include `undefined` return type

### DIFF
--- a/packages/keyv/src/index.d.ts
+++ b/packages/keyv/src/index.d.ts
@@ -37,7 +37,7 @@ declare class Keyv<Value = any, Options extends Record<string, any> = Record<str
 		key: string[],
 		options?: {raw?: Raw}
 	): Promise<
-	Array<(Raw extends false ? Value : Keyv.DeserializedData<Value>) | undefined>
+	Array<(Raw extends false ? Value : Keyv.DeserializedData<Value>) | undefined> | undefined
 	>;
 
 	/**

--- a/packages/test-suite/src/api.ts
+++ b/packages/test-suite/src/api.ts
@@ -60,9 +60,9 @@ const keyvApiTests = (test: TestFn<any>, Keyv: typeof KeyvModule, store: KeyvSto
 		await keyv.set('foo2', 'bar2', ttl);
 		const values = await keyv.get(['foo', 'foo1', 'foo2']);
 		t.is(Array.isArray(values), true);
-		t.is(values[0], 'bar');
-		t.is(values[1], 'bar1');
-		t.is(values[2], 'bar2');
+		t.is(values?.[0], 'bar');
+		t.is(values?.[1], 'bar1');
+		t.is(values?.[2], 'bar2');
 	});
 
 	test.serial('.get([keys]) should return array value undefined when expires', async t => {
@@ -78,9 +78,9 @@ const keyvApiTests = (test: TestFn<any>, Keyv: typeof KeyvModule, store: KeyvSto
 		});
 		const values = await keyv.get(['foo', 'foo1', 'foo2']);
 		t.is(Array.isArray(values), true);
-		t.is(values[0], 'bar');
-		t.is(values[1], undefined);
-		t.is(values[2], 'bar2');
+		t.is(values?.[0], 'bar');
+		t.is(values?.[1], undefined);
+		t.is(values?.[2], 'bar2');
 	});
 
 	test.serial('.get([keys]) should return array values with undefined', async t => {
@@ -90,9 +90,9 @@ const keyvApiTests = (test: TestFn<any>, Keyv: typeof KeyvModule, store: KeyvSto
 		await keyv.set('foo2', 'bar2', ttl);
 		const values = await keyv.get(['foo', 'foo1', 'foo2']);
 		t.is(Array.isArray(values), true);
-		t.is(values[0], 'bar');
-		t.is(values[1], undefined);
-		t.is(values[2], 'bar2');
+		t.is(values?.[0], 'bar');
+		t.is(values?.[1], undefined);
+		t.is(values?.[2], 'bar2');
 	});
 
 	test.serial('.get([keys]) should return undefined array for all no existent keys', async t => {

--- a/packages/test-suite/src/api.ts
+++ b/packages/test-suite/src/api.ts
@@ -2,6 +2,7 @@ import tk from 'timekeeper';
 import type {TestFn} from 'ava';
 import type KeyvModule from 'keyv';
 import type {KeyvStoreFn} from './types';
+import assert from 'assert';
 
 const keyvApiTests = (test: TestFn<any>, Keyv: typeof KeyvModule, store: KeyvStoreFn) => {
 	test.beforeEach(async () => {
@@ -60,9 +61,10 @@ const keyvApiTests = (test: TestFn<any>, Keyv: typeof KeyvModule, store: KeyvSto
 		await keyv.set('foo2', 'bar2', ttl);
 		const values = await keyv.get(['foo', 'foo1', 'foo2']);
 		t.is(Array.isArray(values), true);
-		t.is(values?.[0], 'bar');
-		t.is(values?.[1], 'bar1');
-		t.is(values?.[2], 'bar2');
+		assert(values);
+		t.is(values[0], 'bar');
+		t.is(values[1], 'bar1');
+		t.is(values[2], 'bar2');
 	});
 
 	test.serial('.get([keys]) should return array value undefined when expires', async t => {
@@ -78,9 +80,10 @@ const keyvApiTests = (test: TestFn<any>, Keyv: typeof KeyvModule, store: KeyvSto
 		});
 		const values = await keyv.get(['foo', 'foo1', 'foo2']);
 		t.is(Array.isArray(values), true);
-		t.is(values?.[0], 'bar');
-		t.is(values?.[1], undefined);
-		t.is(values?.[2], 'bar2');
+		assert(values);
+		t.is(values[0], 'bar');
+		t.is(values[1], undefined);
+		t.is(values[2], 'bar2');
 	});
 
 	test.serial('.get([keys]) should return array values with undefined', async t => {
@@ -90,9 +93,10 @@ const keyvApiTests = (test: TestFn<any>, Keyv: typeof KeyvModule, store: KeyvSto
 		await keyv.set('foo2', 'bar2', ttl);
 		const values = await keyv.get(['foo', 'foo1', 'foo2']);
 		t.is(Array.isArray(values), true);
-		t.is(values?.[0], 'bar');
-		t.is(values?.[1], undefined);
-		t.is(values?.[2], 'bar2');
+		assert(values);
+		t.is(values[0], 'bar');
+		t.is(values[1], undefined);
+		t.is(values[2], 'bar2');
 	});
 
 	test.serial('.get([keys]) should return undefined array for all no existent keys', async t => {

--- a/packages/test-suite/src/api.ts
+++ b/packages/test-suite/src/api.ts
@@ -1,8 +1,8 @@
+import assert from 'assert';
 import tk from 'timekeeper';
 import type {TestFn} from 'ava';
 import type KeyvModule from 'keyv';
 import type {KeyvStoreFn} from './types';
-import assert from 'assert';
 
 const keyvApiTests = (test: TestFn<any>, Keyv: typeof KeyvModule, store: KeyvStoreFn) => {
 	test.beforeEach(async () => {


### PR DESCRIPTION
Fixes #720

**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](https://github.com/jaredwray/keyv/blob/main/CONTRIBUTING.md) guidelines.
- [ ] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This change introduces a "bug fix" to the typings of the `Keyv.get([])` signature. Because `Store.getMany()` can return `undefined`, `Keyv.get([])` should include that in its possible return types.

This does mean that consumers of these types will incur TS errors on their plural `get()` usages when they upgrade / install this patch, but those errors have always existed in runtime so I would consider this a fix which aligns the types with reality.

Demo of current bad behavior: https://codesandbox.io/p/sandbox/typescript-node-forked-dpx2ge