### PR TITLE
fix: according to the redis documentation, an iterator must not be co…

### DIFF
--- a/packages/redis/src/index.js
+++ b/packages/redis/src/index.js
@@ -76,15 +76,14 @@ class KeyvRedis extends EventEmitter {
 		const get = this.redis.mget.bind(this.redis);
 		async function * iterate(curs, pattern) {
 			const [cursor, keys] = await scan(curs, 'MATCH', pattern);
-			if (keys.length === 0) {
-				return;
-			}
 
-			const values = await get(keys);
-			for (const [i] of keys.entries()) {
-				const key = keys[i];
-				const value = values[i];
-				yield [key, value];
+			if (keys.length > 0) {
+				const values = await get(keys);
+				for (const [i] of keys.entries()) {
+					const key = keys[i];
+					const value = values[i];
+					yield [key, value];
+				}
 			}
 
 			if (cursor !== '0') {


### PR DESCRIPTION
…nsidered finished unless it returns a cursor value of 0, even if the returned page has no entries

**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](https://github.com/jaredwray/keyv/blob/main/CONTRIBUTING.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?**

According to the redis documentation, an iterator must not be considered finished unless it returns a cursor value of 0, even if the returned page has no entries.

![image](https://user-images.githubusercontent.com/2115696/227487823-c43669d0-51d9-455f-a350-9b2232a0b076.png)

