### PR TITLE
Fix mysql2 invalid configuration (#788)

### DIFF
--- a/packages/mysql/src/index.js
+++ b/packages/mysql/src/index.js
@@ -4,7 +4,7 @@ const EventEmitter = require('events');
 const mysql = require('mysql2/promise');
 const {pool, endPool} = require('./pool.js');
 
-const keyvMysqlKeys = new Set(['uri', 'dialect', 'connect']);
+const keyvMysqlKeys = new Set(['adapter', 'compression', 'connect', 'dialect', 'keySize', 'table', 'ttl', 'uri']);
 
 class KeyvMysql extends EventEmitter {
 	constructor(options) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](https://github.com/jaredwray/keyv/blob/main/CONTRIBUTING.md) guidelines.
- [ ] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Exclude configuration options specific to keyv from the mysql2 connection options. This change fixes mysql2 invalid configuration warnings. MySQL2 will likely throw an error in future version. 

The change require neither additional tests nor documentation. The tests run with 100% code coverage.