### PR TITLE
Replace `get<Raw>(...)` with an overload

### DIFF
--- a/packages/keyv/src/index.d.ts
+++ b/packages/keyv/src/index.d.ts
@@ -27,18 +27,14 @@ declare class Keyv<Value = any, Options extends Record<string, any> = Record<str
 	constructor(uri?: string, options?: Keyv.Options<Value> & Options);
 
 	/** Returns the value. */
-	get<Raw extends boolean = false>(key: string, options?: {raw?: Raw}):
-	Promise<(Raw extends false
-		? Value
-		: Keyv.DeserializedData<Value>) | undefined>;
+	get(key: string, options?: {raw?: false}): Promise<Value | undefined>;
+	/** Returns the raw value. */
+	get(key: string, options: {raw: true}): Promise<Keyv.DeserializedData<Value> | undefined>;
 
 	/** Returns an array of values. Uses `store.getMany` if it exists, otherwise uses parallel calls to `store.get`. */
-	get<Raw extends boolean = false>(
-		key: string[],
-		options?: {raw?: Raw}
-	): Promise<
-	Array<(Raw extends false ? Value : Keyv.DeserializedData<Value>) | undefined>
-	>;
+	get(key: string[], options?: {raw?: false}): Promise<Array<Value | undefined>>;
+	/** Returns an array of raw values. Uses `store.getMany` if it exists, otherwise uses parallel calls to `store.get`. */
+	get(key: string[], options: {raw: true}): Promise<Array<Keyv.DeserializedData<Value> | undefined>>;
 
 	/**
      * Set a value.


### PR DESCRIPTION
One overload with `options?: { raw?: false }` and one with `options: { raw: true }` allows being specific about the return type for each.

So, the behavior is unchanged but it becomes easier for external libraries to write an interface with a correct *partial* implementation.

My use-case: I'm working on a library that expects a keyv-like object passed in. The user is allowed to pass in a different implementation, as long as the basic `get`, `set` and `delete` exist. But they don't need to provide an implementation for the `{ raw: true }` variant. So, I'm trying to write an interface that corresponds to that, which `new Keyv<string>(...)` conforms to. This is hard/impossible to do without some `as any` hacks right now, but the change in this commit makes it possible.

I tried this by modifying node_modules on my project and it worked, but I'm hoping CI will flag any type errors I missed. Will check the boxes below once green.

[TypeScript playground](https://www.typescriptlang.org/play?ts=5.0.3&ssl=41&ssc=1&pln=42&pc=1#code/PTAEEsDtQQ1AbcAjATjFBPUB3cAXACwHsBXPWUAEwFMAHayGyAYyyOgAMBrajANw4AaHNVABbcAHMC5bDEjk8RKtQBmUUXADOYmPHigtJJFurkiq0IVHdeAiAuopVMZtS0AoEIeUNKAWhJTFC1QZnlQWhgtUKgKDgBpOw4HLTx5N2EiFFAgzSpwVVUnBnJwMVp4ajFSmDxwdg9qAA9abLLHZ1dRABF3J3A9cAAvakoeupgAHgA1PRJqAD5QAG8PUFA+eeoALlA5+AX10BbacBR3PcgSMSQnUAAfXMY1DUoPAF8PJtb2hzwnC43KAkvwADLgHizbbLNYbSRmAAUPAwewOCwAlHsAAooIgSUzQw6iJ4kF7qSBjRbHBF4ZG8NHbLK0ersLR7FZobB7PAoBYfLGgXH48CEvrBQaIUbjSZEhbLUnkt7UjamOkoxnE4RbYmahbCU7nDAAWS0AH4rjc7ihBcKCdQpkgiEQqvIVSoqgD6aj9ttbXj7Y7na7IO7mK6UIj-SLCXwiOBKNSvh5ym0UORQXxQKoA6AAOQovh576nP7MNnkVRk5isyAAFRgXCgkgAgpmITwAPJIABW1BroAAvKBEURe-28Ht25CHWkUM3Fhih7Dk1WWLWG03IK3p13xzXEZTsCC7FM5wuo0vvHgMPQTig8Shvt4YLRKlhrLlaJQ6u5s7mZDwWh2RASR8AIYwADpyzEYAe3QMZsDQDBgELYBaBIfRgAADgABgAVnEeQSD0eAMA8G87wAVW-X9KEzOUliHUBOwkPApkzYQ81pPNlgAMlWY4AEhgAAKlE0AACUzBIFBIFCT8dQWSDQFE4APCE2lvT2c9t2ZWtzQ5LkLWzPRTAFHEA1FB10RJZ4aApKkAG4NLEiTpLwWT5KsAhRC5TZthUtSNK0jVDF5Zt9IaeSjJgbkrD5agLKFKzCUzSDxQGIZpQmdJGIVezXkpRMXNc8SpJkuTQgidBkNACwAuJLQVKo0xQg4NJsmoSDaWNeQMBSQoIHIFpRTwLQsmsFBcFMXI2sidBSOoAxwn0BTlA6pQLh6swOCC9TNKRMLdMkABtABdKK2RMzk4pMlx4HM6NAxbB8YAwRjHkKxzE0WFyRPKjyvOq6Bave+rLH8pT3Ba+bNq6na8D6yABogSx8BOZoxom+qppm0Q8lCKI0H0ZawlI9bQHh7baT21SDtChlwvnbcLqumLVi5HlEuSu1rKmV7kI4uwMv6edsrGXLplsgqyQc5U-s+b4aHDBCwgrUAaJ-AF6LsDljiPKY60WKM9i1uiGONpWPDXGtos3Zs2zsDtqG7PsDyPTXaJ1hiTpNjErzASAiGPbBsi4TwvDAXQeEMWTRCgYoHzGKxbz-NXy2TgdcEIUBg-qllopxnOCCp274oe8yUnkSgcHAsuuYS-kOA8ct5PIEhvZT4dPfNn3Tz9qNW41gB9OcdIi7cvrloru9gOQMc77WxkRxE81UZ08wxYf29AMfeQAJgnlnJGnpViuYuKYEXrvKFX9fN+Ecu9krpLt7btI99KTAOWh4-mycpjM4FxDJ5ytE4D4Z95YX2HFfG+y875aQfkQPMT9G68n5NvIAA) demonstrating the problem.

**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](https://github.com/jaredwray/keyv/blob/main/CONTRIBUTING.md) guidelines.
- ~[ ] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.~ **N/A - type-only change**
- ~[ ] Docs have been added / updated (for bug fixes / features)~ **N/A - type-only change**

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Change to the **implementation detail** of the `get` type. No change in how `get` can be used, just makes it easier to create a simple partial interface that `Keyv` conforms to.