### PR TITLE
fix: maximum call stack size exceeded

### DIFF
--- a/packages/redis/src/index.ts
+++ b/packages/redis/src/index.ts
@@ -81,27 +81,21 @@ class KeyvRedis<Value = any> extends EventEmitter {
 	}
 
 	async * iterator(namespace?: string): IteratorOutput {
-		const scan = this.redis.scan.bind(this.redis);
-		const get = this.redis.mget.bind(this.redis);
-		// @ts-expect-error - iterator
-		async function * iterate(curs, pattern) {
-			const [cursor, keys] = await scan(curs, 'MATCH', pattern);
-
-			if (keys.length > 0) {
-				const values = await get(keys);
-				for (const [i] of keys.entries()) {
-					const key = keys[i];
-					const value = values[i];
-					yield [key, value];
+			const scan = this.redis.scan.bind(this.redis);
+			const get = this.redis.mget.bind(this.redis);
+			let cursor = '0';
+			do {
+				const [curs, keys] = await scan(cursor, 'MATCH', `${namespace!}:*`);
+				cursor = curs;
+				if (keys.length > 0) {
+					const values = await get(keys);
+					for (const [i] of keys.entries()) {
+						const key = keys[i];
+						const value = values[i];
+						yield [key, value];
+					}
 				}
-			}
-
-			if (cursor !== '0') {
-				yield * iterate(cursor, pattern);
-			}
-		}
-
-		yield * iterate(0, `${namespace!}:*`);
+			} while (cursor !== '0');
 	}
 
 	async has(key: string): HasOutput {

--- a/packages/redis/src/index.ts
+++ b/packages/redis/src/index.ts
@@ -81,21 +81,23 @@ class KeyvRedis<Value = any> extends EventEmitter {
 	}
 
 	async * iterator(namespace?: string): IteratorOutput {
-			const scan = this.redis.scan.bind(this.redis);
-			const get = this.redis.mget.bind(this.redis);
-			let cursor = '0';
-			do {
-				const [curs, keys] = await scan(cursor, 'MATCH', `${namespace!}:*`);
-				cursor = curs;
-				if (keys.length > 0) {
-					const values = await get(keys);
-					for (const [i] of keys.entries()) {
-						const key = keys[i];
-						const value = values[i];
-						yield [key, value];
-					}
+		const scan = this.redis.scan.bind(this.redis);
+		const get = this.redis.mget.bind(this.redis);
+		let cursor = '0';
+		do {
+			// eslint-disable-next-line no-await-in-loop
+			const [curs, keys] = await scan(cursor, 'MATCH', `${namespace!}:*`);
+			cursor = curs;
+			if (keys.length > 0) {
+				// eslint-disable-next-line no-await-in-loop
+				const values = await get(keys);
+				for (const [i] of keys.entries()) {
+					const key = keys[i];
+					const value = values[i];
+					yield [key, value];
 				}
-			} while (cursor !== '0');
+			}
+		} while (cursor !== '0');
 	}
 
 	async has(key: string): HasOutput {


### PR DESCRIPTION
Unfortunately, if the redis database has many entries, the current approach using recursion can run into a maximum call stack size exceeded exception.

![image](https://github.com/jaredwray/keyv/assets/2115696/3df18745-cab6-4306-aea5-d42103eb4be2)
