### PR TITLE
fix: add `disconnect` to memcache driver

### DIFF
--- a/packages/memcache/src/index.ts
+++ b/packages/memcache/src/index.ts
@@ -163,6 +163,10 @@ class KeyvMemcache<Value = any> extends EventEmitter implements Store<Value> {
 			});
 		});
 	}
+
+	async disconnect(): Promise<void> {
+		this.client.quit();
+	}
 }
 
 export = KeyvMemcache;

--- a/packages/memcache/test/test.ts
+++ b/packages/memcache/test/test.ts
@@ -214,10 +214,13 @@ test.serial('close connection successfully', async t => {
 	/**
 	 * Since the memjs library doesn't throw an error when trying to get or set on a closed connection,
    * we need to set up a "fallback" error that will occur if the operation doesn't complete within a reasonable timeframe.
-	 * 
+	 *
 	 * At least this way we can be sure that calling .disconnect() is really closing the connection
 	 */
-	const delayedFailure = new Promise((_, reject) => setTimeout(() => reject(new Error('Operation timed out')), 3000));
+	const delayedFailure = new Promise((_, reject) => setTimeout(() => {
+		reject(new Error('Operation timed out'));
+	}, 3000));
+
 	try {
 		await Promise.race([keyv.get('foo'), delayedFailure]);
 		t.fail();

--- a/packages/memcache/test/test.ts
+++ b/packages/memcache/test/test.ts
@@ -215,7 +215,7 @@ test.serial('close connection successfully', async t => {
 	 * Since the memjs library doesn't throw an error when trying to get or set on a closed connection,
    * we need to set up a "fallback" error that will occur if the operation doesn't complete within a reasonable timeframe.
 	 * 
-	 * At least this way we can be sure that calling .disconnect()
+	 * At least this way we can be sure that calling .disconnect() is really closing the connection
 	 */
 	const delayedFailure = new Promise((_, reject) => setTimeout(() => reject(new Error('Operation timed out')), 3000));
 	try {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](https://github.com/jaredwray/keyv/blob/main/CONTRIBUTING.md) guidelines.
- [ ] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Without this change, this code was never exiting : 

```ts
import Keyv from 'keyv';
import KeyvMemcache from './src/index';

let uri = 'localhost:11211';
const keyvMemcache = new KeyvMemcache(uri);
const keyv = new Keyv({store: keyvMemcache});

keyv.get('foo').then(() => {
  keyv.disconnect()
})
```

So just added a `disconnect` method to the memcache driver, and now works fine

---

Wanted to add a test for the same : 

```ts
test.serial('close connection successfully', async t => {
	const keyv = new Keyv({store: keyvMemcache});
	t.is(await keyv.get('foo'), undefined);
	await keyv.disconnect();
	try {
		await keyv.get('foo', 34);
		t.fail();
	} catch {
		t.pass();
	}
});
```

but it doesn't work. memjs throws 0 errors when you do a `.get` or `.set` when the connection is closed. So not sure how to handle this


