### PR TITLE
Fix: Redis race conditions with .set, .delete. and .clear when useRedisSets=true

### DIFF
--- a/packages/redis/src/index.ts
+++ b/packages/redis/src/index.ts
@@ -73,22 +73,37 @@ class KeyvRedis<Value = any> extends EventEmitter {
 
 		key = this._getKeyName(key);
 
-		if (typeof ttl === 'number') {
-			await this.redis.set(key, value, 'PX', ttl);
-		} else {
-			await this.redis.set(key, value);
-		}
+		const set = async (redis: any) => {
+			if (typeof ttl === 'number') {
+				await redis.set(key, value, 'PX', ttl);
+			} else {
+				await redis.set(key, value);
+			}
+		};
 
 		if (this.opts.useRedisSets) {
-			await this.redis.sadd(this._getNamespace(), key);
+			const trx = await this.redis.multi();
+			await set(trx);
+			await trx.sadd(this._getNamespace(), key);
+			await trx.exec();
+		} else {
+			await set(this.redis);
 		}
 	}
 
 	async delete(key: string): DeleteOutput {
 		key = this._getKeyName(key);
-		const items: number = await this.redis.del(key);
+		let items = 0;
+		const del = async (redis: any) => redis.del(key);
+
 		if (this.opts.useRedisSets) {
-			await this.redis.srem(this._getNamespace(), key);
+			const trx = this.redis.multi();
+			await del(trx);
+			await trx.srem(this._getNamespace(), key);
+			const r = await trx.exec();
+			items = r[0][1];
+		} else {
+			items = await del(this.redis);
 		}
 
 		return items > 0;
@@ -104,7 +119,12 @@ class KeyvRedis<Value = any> extends EventEmitter {
 	async clear(): ClearOutput {
 		if (this.opts.useRedisSets) {
 			const keys: string[] = await this.redis.smembers(this._getNamespace());
-			await this.redis.del([...keys, this._getNamespace()]);
+			if (keys.length > 0) {
+				await Promise.all([
+					this.redis.del([...keys]),
+					this.redis.srem(this._getNamespace(), [...keys]),
+				]);
+			}
 		} else {
 			const pattern = 'sets:*';
 			const keys: string[] = await this.redis.keys(pattern);


### PR DESCRIPTION
When using Redis and `useRedisSets=true`, it's possible to end up with a mismatch between the keys listed in the namespace set and the actual key/values in Redis.

**Quick Review of Current Functionality**

- The `set` op takes place in two steps, the key/value is set and then the key is added to the namespace set. 

- The `delete` op takes place in two steps, the key/value is deleted and then the key is removed from the namespace set.

- The `clear` op takes place in two steps, the keys are retrieved from the namespace set and then they are deleted (including the namespace set itself).

Problems can arise when steps become intermixed and state changes take place in between steps 1 of 2 of certain ops.


**Example Problem 1 - key/value in Redis but key not listed in namespace set (actual experience)**

System 1 calls `set` to save a value and at the same time System 2 calls `clear`. 

Order of ops:

1. `set` step 1 takes place - key/value saved
2. `clear` step 1 takes place - all keys in the namespace set are retrieved **(except the key from op 1 since it hasn't been added to the namespace set yet)**
3. `set` step 2 takes place - key is added to namespace set
4. `clear` step 2 takes place - all keys retrieved from step 2 are deleted as well as the namespace set itself

The key in the namespace set gets deleted in error.

**Example Problem 2 - key in namespace set, but actual key/value doesn't exist (theoretical)**

1. `set` step 1 takes place - key/value saved 
2. `delete` step 1 takes place - key/value deleted
3. `delete` step 2 takes place - key deleted from namespace set
4. `set` step 2 takes place - key added to namespace set

The key in the namespace set **didn't** get deleted, in error.

**Solution**

Run both `set` and `delete` in transactions.

For `clear`, using a transaction doesn't seem possible. As an alternative, instead of deleting the entire namespace set in step 2 we can just remove the specific keys that we retrieved from step 1. This will ensure that any new keys added after step 1 will still remain in the namespace set, but if nothing was added then the set will be empty after step 2 and automatically removed by Redis.


**Please check if the PR fulfills these requirements**
- [X] Followed the [Contributing](https://github.com/jaredwray/keyv/blob/main/CONTRIBUTING.md) guidelines.
- [ ] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** Bug fix
