### PR TITLE
feat: [GH-910] Switch to use Redis UNLINK instead of DEL

### DIFF
--- a/packages/redis/src/index.ts
+++ b/packages/redis/src/index.ts
@@ -95,16 +95,16 @@ class KeyvRedis<Value = any> extends EventEmitter {
 	async delete(key: string): DeleteOutput {
 		key = this._getKeyName(key);
 		let items = 0;
-		const del = async (redis: any) => redis.del(key);
+		const unlink = async (redis: any) => redis.unlink(key);
 
 		if (this.opts.useRedisSets) {
 			const trx = this.redis.multi();
-			await del(trx);
+			await unlink(trx);
 			await trx.srem(this._getNamespace(), key);
 			const r = await trx.exec();
 			items = r[0][1];
 		} else {
-			items = await del(this.redis);
+			items = await unlink(this.redis);
 		}
 
 		return items > 0;
@@ -122,14 +122,14 @@ class KeyvRedis<Value = any> extends EventEmitter {
 			const keys: string[] = await this.redis.smembers(this._getNamespace());
 			if (keys.length > 0) {
 				await Promise.all([
-					this.redis.del([...keys]),
+					this.redis.unlink([...keys]),
 					this.redis.srem(this._getNamespace(), [...keys]),
 				]);
 			}
 		} else {
 			const pattern = 'sets:*';
 			const keys: string[] = await this.redis.keys(pattern);
-			await this.redis.del(keys);
+			await this.redis.unlink(keys);
 		}
 	}
 


### PR DESCRIPTION
In @keyv/redis, modified the delete() and clear() functions to use UNLINK instead of DEL to improve performance.

DEL is blocking and can take longer the larger the key size, whereas UNLINK is non-blocking and perform the operation in O(1) for each key removed regardless of its size.

**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](https://github.com/jaredwray/keyv/blob/main/CONTRIBUTING.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** feature