### PR TITLE
namespace with : causing problem with iterator

### DIFF
--- a/packages/test-suite/src/iterator.ts
+++ b/packages/test-suite/src/iterator.ts
@@ -102,6 +102,35 @@ const keyvIteratorTests = (test: TestFn, Keyv: typeof KeyvModule, store: KeyvSto
 			t.is(entry.value, undefined);
 		},
 	);
+
+	test.serial(
+		'iterator() handles : in keys X',
+		async t => {
+			const keyvStore = store();
+
+			const keyv1 = new Keyv({store: keyvStore, namespace: 'keyv1:testv1'});
+			const map1 = new Map(
+				Array.from({length: 5})
+					.fill(0)
+					.map((_x, i) => [String(i) + ":" +	String(i), String(i + 10)]),
+			);
+			const toResolve = [];
+			for (const [key, value] of map1) {
+				toResolve.push(keyv1.set(key, value));
+			}
+
+			await Promise.all(toResolve);
+
+			t.plan(map1.size);
+			for await (const [key, value] of keyv1.iterator()) {
+			 	console.log("key", key, "value", value);
+				const doesKeyExist = map1.has(key);
+				const isValueSame = map1.get(key) === value;
+				t.true(doesKeyExist && isValueSame);
+			}
+		},
+	);
+
 };
 
 export default keyvIteratorTests;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] Followed the [Contributing](https://github.com/jaredwray/keyv/blob/main/CONTRIBUTING.md) guidelines.
- [X] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
- [X] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This adds a failing test that shows how ':' in the namespace causes the Redis iterator to fail.

There is some dumping to the console to see the issue (this is from running the test in the @keyv/redis package):
```
key testv1:3:3 value 13
  ✘ [fail]: test › iterator() handles : in keys X
key testv1:2:2 value 12
key testv1:4:4 value 14
key testv1:1:1 value 11
key testv1:0:0 value 10
```

This is in response to the issue https://github.com/jaredwray/keyv/issues/924  