### PR TITLE
fix(redis): do not error calling clear with empty keys and `useRedisSets` false

### DIFF
--- a/packages/redis/src/index.ts
+++ b/packages/redis/src/index.ts
@@ -122,7 +122,9 @@ class KeyvRedis extends EventEmitter implements KeyvStoreAdapter {
 		} else {
 			const pattern = `sets:${this._getNamespace()}:*`;
 			const keys: string[] = await this.redis.keys(pattern);
-			await this.redis.unlink(keys);
+			if (keys.length > 0) {
+				await this.redis.unlink(keys);
+			}
 		}
 	}
 

--- a/packages/redis/test/test.ts
+++ b/packages/redis/test/test.ts
@@ -83,6 +83,12 @@ test.serial('close tls connection successfully', async t => {
 	}
 });
 
+test.serial('clear method with empty keys should not error', async t => {
+	const keyv = new KeyvRedis(redisURI);
+
+	await t.notThrowsAsync(keyv.clear());
+});
+
 test.serial('.clear cleaned namespace', async t => {
 	// Setup
 	const keyv = new Keyv(redisURI, {
@@ -160,6 +166,13 @@ test.serial('clear method when useRedisSets is false', async t => {
 	const value2 = await keyv.get('demo2');
 	t.is(value, undefined);
 	t.is(value2, undefined);
+});
+
+test.serial('clear method when useRedisSets is false and empty keys should not error', async t => {
+	const options = {useRedisSets: false};
+	const keyv = new KeyvRedis(options);
+
+	await t.notThrowsAsync(keyv.clear());
 });
 
 test.serial('when passing in ioredis set the options.useRedisSets', t => {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](https://github.com/jaredwray/keyv/blob/main/CONTRIBUTING.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR fixes a bug in `@keyv/redis`where if `useRedisSets` is false and clear is called when no keys exist an error is thrown.

#### NOTES
- The error thrown was
```txt
ReplyError {
    command: {
      args: [],
      name: 'unlink',
    },
    message: 'ERR wrong number of arguments for \'unlink\' command',
  }
```
- I added tests for `useRedisSets` true/false so this should not regress in the future for either case.