### PR TITLE
feat: remove deprecated json-buffer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,9 @@
     "packages/*"
   ],
   "scripts": {
+    "build:keyv:serialize": "cd packages/serialize && yarn build",
     "build:keyv": "cd packages/keyv && yarn build",
-    "build": "yarn build:keyv && yarn workspaces run build",
+    "build": "yarn build:keyv:serialize && yarn build:keyv && yarn workspaces run build",
     "test": " yarn build && c8 --reporter=lcov yarn workspaces run test:ci",
     "test:services:start": "docker-compose -f ./docker-compose.yaml up -d",
     "test:services:stop": "docker-compose -f ./docker-compose.yaml down -v",

--- a/packages/compress-brotli/package.json
+++ b/packages/compress-brotli/package.json
@@ -52,13 +52,12 @@
 	},
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
-		"compress-brotli": "^1.3.12"
+		"compress-brotli": "^1.3.12",
+		"@keyv/serialize": "*"
 	},
 	"devDependencies": {
 		"@keyv/test-suite": "*",
 		"c8": "^9.1.0",
-		"json-buffer": "^3.0.1",
-		"keyv": "*",
 		"requirable": "^1.0.5",
 		"tsd": "^0.31.0",
 		"webpack": "^5.91.0",

--- a/packages/compress-brotli/package.json
+++ b/packages/compress-brotli/package.json
@@ -53,6 +53,7 @@
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
 		"compress-brotli": "^1.3.12",
+		"keyv": "*",
 		"@keyv/serialize": "*"
 	},
 	"devDependencies": {

--- a/packages/compress-brotli/src/index.ts
+++ b/packages/compress-brotli/src/index.ts
@@ -1,5 +1,6 @@
 import type {BrotliOptions, InputType} from 'node:zlib';
 import compressBrotli from 'compress-brotli';
+import {defaultDeserialize, defaultSerialize} from '@keyv/serialize';
 import type {
 	Brotli, CompressResult, Options, SerializeResult, Serialize,
 } from './types';
@@ -19,9 +20,7 @@ class KeyvBrotli {
 	}
 
 	async serialize({value, expires}: Serialize): Promise<SerializeResult> {
-		const compressValue = await this.compress(value);
-		// @ts-expect-error - `expires` is not part of the `SerializeResult` type
-		return this.brotli.serialize({value: compressValue, expires});
+		return defaultSerialize({value: await this.compress(value), expires});
 	}
 
 	async deserialize(data: CompressResult): Promise<Serialize> {
@@ -30,7 +29,7 @@ class KeyvBrotli {
 			return data;
 		}
 
-		const {value, expires} = this.brotli.deserialize(data) as Serialize;
+		const {value, expires}: Serialize = defaultDeserialize(data);
 		return {value: await this.decompress(value), expires};
 	}
 }

--- a/packages/compress-brotli/src/types.ts
+++ b/packages/compress-brotli/src/types.ts
@@ -1,11 +1,10 @@
 import type {BrotliOptions, CompressCallback, InputType} from 'node:zlib';
-import type {parse as JSONBparse, stringify as JSONBstringify} from 'json-buffer';
 
 export type CompressResult = Promise<Parameters<CompressCallback>[1]>;
-export type DecompressResult = Promise<ReturnType<typeof JSONBparse>>;
+export type DecompressResult = Promise<any>;
 
-export type SerializeResult = ReturnType<typeof JSONBstringify>;
-export type DeserializeResult = ReturnType<typeof JSONBparse>;
+export type SerializeResult = string;
+export type DeserializeResult = any;
 
 type BrotliSerialize<T> = (source: InputType) => T;
 type BrotliDeserialize<T> = (source: CompressResult) => T;

--- a/packages/compress-brotli/test/test.ts
+++ b/packages/compress-brotli/test/test.ts
@@ -1,7 +1,6 @@
 import {constants as zlibConstants} from 'node:zlib';
 import v8 from 'node:v8';
 import test from 'ava';
-import json from 'json-buffer';
 import {keyvCompresstionTests} from '@keyv/test-suite';
 import KeyvBrotli from '../src/index';
 import type {DeserializeResult} from '../src/types';
@@ -104,23 +103,3 @@ test('decompression using number array with v8', async t => {
 	t.deepEqual(decompressed, {help: [1, 2, 4]});
 });
 
-test('decompression using number array with json-buffer', async t => {
-	const options = {
-		serialize: json.stringify,
-		deserialize: json.parse,
-	};
-
-	const keyv = new KeyvBrotli(options);
-	const compressed = await keyv.compress({help: [1, 2, 4]});
-	const decompressed = await keyv.decompress(compressed);
-	t.deepEqual(decompressed, {help: [1, 2, 4]});
-});
-
-test('deserialize with an empty value', async t => {
-	const keyv = new KeyvBrotli();
-	// @ts-expect-error - Testing empty value
-	const deserialized = await keyv.deserialize('');
-
-	// @ts-expect-error - empty value
-	t.is(deserialized, '');
-});

--- a/packages/compress-brotli/test/types.ts
+++ b/packages/compress-brotli/test/types.ts
@@ -2,7 +2,6 @@ import zlib from 'node:zlib';
 import v8 from 'node:v8';
 import test from 'ava';
 import Keyv, {type KeyvStoreAdapter} from 'keyv';
-import json from 'json-buffer';
 import KeyvBrotli from '../src/index';
 
 type MyType = {
@@ -81,18 +80,3 @@ test('using number array with v8', async t => {
 	t.deepEqual(await keyv.get('testkey'), {b: [1, 2, 3]});
 });
 
-test('decompression using number array with json-buffer', async t => {
-	const options = {
-		serialize: json.stringify,
-		deserialize: json.parse,
-	};
-
-	const map = new Map() as unknown as KeyvStoreAdapter;
-
-	const keyv = new Keyv({
-		store: map,
-		compression: new KeyvBrotli(options),
-	});
-	t.true(await keyv.set('testkey', {b: [1, 2, 3]}));
-	t.deepEqual(await keyv.get('testkey'), {b: [1, 2, 3]});
-});

--- a/packages/compress-gzip/src/index.ts
+++ b/packages/compress-gzip/src/index.ts
@@ -1,5 +1,5 @@
 import pako from 'pako';
-import JSONB from 'json-buffer';
+import {defaultSerialize, defaultDeserialize} from '@keyv/serialize';
 import type {Options, Serialize} from './types';
 
 class KeyvGzip {
@@ -24,12 +24,15 @@ class KeyvGzip {
 	}
 
 	async serialize({value, expires}: Serialize) {
-		return JSONB.stringify({value: await this.compress(value), expires});
+		return defaultSerialize({value: await this.compress(value), expires});
 	}
 
 	async deserialize(data: string) {
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-		const {value, expires}: Serialize = JSONB.parse(data);
+		if (!data) {
+			return data;
+		}
+
+		const {value, expires}: Serialize = defaultDeserialize(data);
 		return {value: await this.decompress(value as pako.Data), expires};
 	}
 }

--- a/packages/keyv/README.md
+++ b/packages/keyv/README.md
@@ -151,7 +151,7 @@ In `PRE_DELETE` and `POST_DELETE` hooks, the value could be a single item or an 
 
 ### Custom Serializers
 
-Keyv uses [`json-buffer`](https://github.com/dominictarr/json-buffer) for data serialization to ensure consistency across different backends.
+Keyv uses [`buffer`](https://github.com/feross/buffer) for data serialization to ensure consistency across different backends.
 
 You can optionally provide your own serialization functions to support extra data types or to serialize to something other than JSON.
 

--- a/packages/keyv/package.json
+++ b/packages/keyv/package.json
@@ -52,7 +52,7 @@
 	},
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
-		"json-buffer": "3.0.1"
+		"@keyv/serialize": "*"
 	},
 	"devDependencies": {
 		"@keyv/test-suite": "*",

--- a/packages/keyv/src/index.ts
+++ b/packages/keyv/src/index.ts
@@ -1,4 +1,4 @@
-import JSONB from 'json-buffer';
+import {defaultSerialize, defaultDeserialize} from '@keyv/serialize';
 import HooksManager from './hooks-manager';
 import EventManager from './event-manager';
 import StatsManager from './stats-manager';
@@ -129,8 +129,8 @@ class Keyv extends EventManager {
 		// @ts-expect-error - store is being added in the next step
 		this.opts = {
 			namespace: 'keyv',
-			serialize: JSONB.stringify,
-			deserialize: JSONB.parse,
+			serialize: defaultSerialize,
+			deserialize: defaultDeserialize,
 			emitErrors: true,
 			...options,
 		};

--- a/packages/keyv/test/test.ts
+++ b/packages/keyv/test/test.ts
@@ -112,7 +112,7 @@ test.serial('.get(key, {raw: true}) returns the raw object instead of the value'
 	t.is((rawObject!).value, 'bar');
 });
 
-test.serial('Keyv uses custom serializer when provided instead of json-buffer', async t => {
+test.serial('Keyv uses custom serializer when provided instead of default', async t => {
 	t.plan(3);
 	const store = new Map();
 	const serialize = (data: Record<string, unknown>) => {

--- a/packages/memcache/package.json
+++ b/packages/memcache/package.json
@@ -68,7 +68,8 @@
 	},
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
-		"json-buffer": "^3.0.1",
+		"buffer": "^6.0.1",
+		"@keyv/serialize": "*",
 		"memjs": "^1.3.2"
 	},
 	"devDependencies": {

--- a/packages/memcache/src/index.ts
+++ b/packages/memcache/src/index.ts
@@ -1,8 +1,8 @@
 import EventEmitter from 'node:events';
-import type {Buffer} from 'node:buffer';
+import {Buffer} from 'buffer';
 import memcache from 'memjs';
-import JSONB from 'json-buffer';
 import {KeyvStoreAdapter, StoredData} from 'keyv';
+import {defaultDeserialize} from '@keyv/serialize';
 
 type KeyvMemcacheOptions = {
 	url?: string;
@@ -56,8 +56,8 @@ class KeyvMemcache extends EventEmitter implements KeyvStoreAdapter {
 							expires: 0,
 						};
 					} else {
-						// eslint-disable-next-line @typescript-eslint/no-unsafe-call
-						value_ = (this.opts.deserialize ? this.opts.deserialize(value as unknown as string) : JSONB.parse(value as unknown as string)) as StoredData<Value>;
+						// eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
+						value_ = (this.opts.deserialize ? this.opts.deserialize(value) : defaultDeserialize(value));
 					}
 
 					resolve(value_);

--- a/packages/serialize/README.md
+++ b/packages/serialize/README.md
@@ -1,0 +1,13 @@
+# @keyv/serialize [<img width="100" align="right" src="https://jaredwray.com/images/keyv.svg" alt="keyv">](https://github.com/jaredwra/keyv)
+
+> Serialization functionality for [Keyv](https://github.com/jaredwray/keyv)
+
+
+[![build](https://github.com/jaredwray/keyv/actions/workflows/tests.yaml/badge.svg)](https://github.com/jaredwray/keyv/actions/workflows/tests.yaml)
+[![codecov](https://codecov.io/gh/jaredwray/keyv/branch/main/graph/badge.svg?token=bRzR3RyOXZ)](https://codecov.io/gh/jaredwray/keyv)
+[![GitHub license](https://img.shields.io/github/license/jaredwray/keyv)](https://github.com/jaredwray/keyv/blob/master/LICENSE)
+[![npm](https://img.shields.io/npm/dm/@keyv/memcache)](https://npmjs.com/package/@keyv/memcache)
+
+## License
+
+MIT © Jared Wray

--- a/packages/serialize/package.json
+++ b/packages/serialize/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@keyv/compress-gzip",
-  "version": "1.2.4",
-  "description": "gzip compression for keyv",
+  "name": "@keyv/serialize",
+  "version": "1.0.0",
+  "description": "Serialization for keyv",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
@@ -9,10 +9,22 @@
     "prepare": "yarn build",
     "test": "xo --fix && c8 ava --serial",
     "test:ci": "xo && ava --serial",
-    "clean": "rm -rf node_modules && rm -rf .nyc_output && rm -rf ./dist && rm -rf coverage.lcov && rm -rf ./test/testdb.sqlite"
+    "clean": "rm -rf node_modules && rm -rf ./coverage"
   },
   "xo": {
     "rules": {
+      "unicorn/prefer-module": 0,
+      "unicorn/prefer-event-target": 0,
+      "unicorn/no-array-reduce": 0,
+      "n/prefer-global/process": 0,
+      "node/prefer-global/process": 0,
+      "unicorn/prefer-object-from-entries": 0,
+      "unicorn/prefer-node-protocol": 0,
+      "@typescript-eslint/consistent-type-imports": 0,
+      "@typescript-eslint/consistent-type-definitions": 0,
+      "@typescript-eslint/no-empty-function": 0,
+      "import/extensions": 0,
+      "no-promise-executor-return": 0,
       "ava/no-ignored-test-files": [
         "error",
         {
@@ -21,17 +33,16 @@
             "ts"
           ]
         }
-      ],
-      "import/extensions": 0,
-      "@typescript-eslint/prefer-nullish-coalescing": 0,
-      "@typescript-eslint/no-unsafe-argument": 0
+      ]
     }
   },
   "ava": {
     "require": [
+      "requirable",
       "ts-node/register"
     ],
     "extensions": [
+      "js",
       "ts"
     ]
   },
@@ -40,42 +51,30 @@
     "url": "git+https://github.com/jaredwray/keyv.git"
   },
   "keywords": [
-    "compress",
-    "gzip",
     "keyv",
-    "storage",
-    "adapter",
+    "serialize",
     "key",
     "value",
-    "store",
-    "cache",
-    "ttl"
+    "store"
   ],
-  "author": "Jared Wray <me@jaredwray.com> (http://jaredwray.com)",
+  "author": "Jared Wray <me@jaredwray.com> (https://jaredwray.com)",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/jaredwray/keyv/issues"
   },
   "homepage": "https://github.com/jaredwray/keyv",
   "dependencies": {
-    "@types/pako": "^2.0.3",
-    "pako": "^2.1.0",
-    "@keyv/serialize": "*"
+    "buffer": "^6.0.1"
   },
   "devDependencies": {
-    "@ava/typescript": "^4.1.0",
     "@keyv/test-suite": "*",
-    "@typescript-eslint/parser": "^7.4.0",
-    "eslint": "^8.57.0",
-    "requirable": "^1.0.5",
+    "keyv": "*",
+    "ts-node": "^10.9.2",
     "tsd": "^0.31.0",
-    "xo": "^0.58.0"
+    "typescript": "^5.4.3"
   },
   "tsd": {
     "directory": "test"
-  },
-  "engines": {
-    "node": ">= 12"
   },
   "files": [
     "dist"

--- a/packages/serialize/src/index.ts
+++ b/packages/serialize/src/index.ts
@@ -1,0 +1,67 @@
+import {Buffer} from 'buffer';
+
+// Improved version of the deprecated `json-buffer` (https://github.com/dominictarr/json-buffer) package.
+// These default functionalities can be improved separately from the dependant packages.
+export const defaultSerialize = (data: any): string => {
+	if (data === undefined || data === null) {
+		return 'null';
+	}
+
+	if (typeof data === 'string') {
+		return JSON.stringify(data.startsWith(':') ? ':' + data : data);
+	}
+
+	if (Buffer.isBuffer(data)) {
+		return JSON.stringify(':base64:' + data.toString('base64'));
+	}
+
+	if (data?.toJSON) {
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
+		data = data.toJSON();
+	}
+
+	if (typeof data === 'object') {
+		let s = '';
+		const array = Array.isArray(data);
+		s = array ? '[' : '{';
+		let first = true;
+
+		// eslint-disable-next-line guard-for-in
+		for (const k in data) {
+			const ignore = typeof data[k] === 'function' || (!array && data[k] === undefined);
+			if (!Object.hasOwnProperty.call(data, k) || ignore) {
+				continue;
+			}
+
+			if (!first) {
+				s += ',';
+			}
+
+			first = false;
+			if (array) {
+				s += defaultSerialize(data[k]);
+			} else if (data[k] !== undefined) {
+				s += defaultSerialize(k) + ':' + defaultSerialize(data[k]);
+			}
+		}
+
+		s += array ? ']' : '}';
+		return s;
+	}
+
+	return JSON.stringify(data);
+};
+
+export const defaultDeserialize = <Value>(data: any) => JSON.parse(data as unknown as string, (
+	_, value) => {
+	if (typeof value === 'string') {
+		if (value.startsWith(':base64:')) {
+			return Buffer.from(value.slice(8), 'base64');
+		}
+
+		return value.startsWith(':') ? value.slice(1) : value;
+	}
+
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+	return value;
+}) as Value;

--- a/packages/serialize/test/test.ts
+++ b/packages/serialize/test/test.ts
@@ -1,0 +1,26 @@
+import test from 'ava';
+import {defaultDeserialize, defaultSerialize} from '../src';
+
+test('serialization and deserialization of string value', t => {
+	const serialized = defaultSerialize({value: 'foo'});
+	const deserialized = defaultDeserialize<{value: string}>(serialized);
+	t.is(deserialized.value, 'foo');
+});
+
+test('serialization and deserialization of number value', t => {
+	const serialized = defaultSerialize({value: 5});
+	const deserialized = defaultDeserialize<{value: number}>(serialized);
+	t.is(deserialized.value, 5);
+});
+
+test('serialization and deserialization of boolean value', t => {
+	const serialized = defaultSerialize({value: true});
+	const deserialized = defaultDeserialize<{value: boolean}>(serialized);
+	t.is(deserialized.value, true);
+});
+
+test('serialization and deserialization of object value', t => {
+	const serialized = defaultSerialize({value: {foo: 'bar', bar: 5, baz: true, def: undefined, nul: null}});
+	const deserialized = defaultDeserialize<{value: {foo: string; bar: number; baz: boolean; def?: string; nul: string | undefined}}>(serialized);
+	t.deepEqual(deserialized.value, {foo: 'bar', bar: 5, baz: true, nul: null});
+});

--- a/packages/serialize/tsconfig.dist.json
+++ b/packages/serialize/tsconfig.dist.json
@@ -1,0 +1,6 @@
+{
+	"extends": "./tsconfig.json",
+	"include": [
+		"src/**/*"
+	]
+}

--- a/packages/serialize/tsconfig.json
+++ b/packages/serialize/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    /* Language and Environment */
+    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+
+    /* Modules */
+    "module": "commonjs",                                /* Specify what module code is generated. */
+    "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
+    "baseUrl": "./src",                                  /* Specify the base directory to resolve non-relative module names. */
+
+    /* Emit */
+    "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+    "outDir": "./dist",                                   /* Specify an output folder for all emitted files. */
+
+    /* Interop Constraints */
+    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
+    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+
+    /* Type Checking */
+    "strict": true,                                      /* Enable all strict type-checking options. */
+
+    /* Completeness */
+    "skipLibCheck": true,                     /* Skip type checking all .d.ts files. */
+    "lib": [
+      "es2016"
+    ]
+  }
+}

--- a/packages/test-suite/package.json
+++ b/packages/test-suite/package.json
@@ -54,7 +54,6 @@
 	"devDependencies": {
 		"@keyv/compress-brotli": "*",
 		"@types/json-bigint": "^1.0.4",
-		"@types/json-buffer": "^3.0.2",
 		"keyv": "*"
 	},
 	"ava": {


### PR DESCRIPTION
closes #1029

**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](https://github.com/jaredwray/keyv/blob/main/CONTRIBUTING.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
- [x] Docs have been added / updated (for bug fixes / features)

Removes the deprecated `json-buffer`. The new package `@keyv/serialize` is now independent and can be refactored later easily to improve the default serialization functionality.
