### PR TITLE
#1084 Implement disconnect for mongodb adapter to support a graceful shutdown.

### DIFF
--- a/packages/mongo/src/types.ts
+++ b/packages/mongo/src/types.ts
@@ -1,4 +1,5 @@
 import {
+	type MongoClient,
 	type Collection, type Db, type GridFSBucket, type ReadPreference,
 } from 'mongodb';
 
@@ -22,6 +23,7 @@ export type KeyvMongoConnect = {
 	bucket?: GridFSBucket;
 	store: Collection;
 	db?: Db;
+	mongoClient: MongoClient;
 };
 
 export type PifyFunction = (...arguments_: any[]) => any;

--- a/packages/mongo/test/test.ts
+++ b/packages/mongo/test/test.ts
@@ -15,6 +15,7 @@ test.afterAll(async () => {
 	await keyv.clear();
 	keyv = new KeyvMongo({collection: 'foo', useGridFS: true, ...options});
 	await keyv.clear();
+	await keyv.disconnect();
 });
 
 test.beforeEach(async () => {
@@ -204,4 +205,37 @@ test.it('iterator with namespace', async t => {
 	t.expect(entry.value[1]).toBe('bar2');
 	entry = await iterator.next();
 	t.expect(entry.value).toBeUndefined();
+});
+
+test.it('Close connection successfully on GridFS', async t => {
+	const keyv = new KeyvMongo({useGridFS: true, ...options});
+	t.expect(await keyv.get('foo')).toBeUndefined();
+	await keyv.disconnect();
+	try {
+		await keyv.get('foo');
+		t.expect.fail();
+	} catch {
+		t.expect(true).toBeTruthy();
+	}
+});
+
+test.it('Close connection successfully', async t => {
+	const keyv = new KeyvMongo({namespace: 'key1', ...options});
+	t.expect(await keyv.get('foo')).toBeUndefined();
+	await keyv.disconnect();
+	try {
+		await keyv.get('foo');
+		t.expect.fail();
+	} catch {
+		t.expect(true).toBeTruthy();
+	}
+});
+
+test.it('Close connection should fail', async t => {
+	const keyv = new KeyvMongo({namespace: 'key1', ...options});
+	try {
+		await keyv.disconnect();
+	} catch {
+		t.expect(true).toBeTruthy();
+	}
 });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](https://github.com/jaredwray/keyv/blob/main/CONTRIBUTING.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix.  The Mongodb adapter failed to shutdown gracefully leaving the nodejs process in a hung state (open sockets).  The disconnect method was implement to allow the client api to call it in a "finally" clause or dispose method.