### PR TITLE
fix: preDelete hook not called when a single key is deleted

### DIFF
--- a/packages/keyv/src/index.ts
+++ b/packages/keyv/src/index.ts
@@ -354,13 +354,14 @@ export class Keyv<GenericValue = any> extends EventManager {
 
 			const results = await Promise.allSettled(promises);
 			const returnResult = results.every(x => (x as PromiseFulfilledResult<any>).value === true);
-			this.hooks.trigger(KeyvHooks.POST_DELETE, returnResult);
+			this.hooks.trigger(KeyvHooks.POST_DELETE, {key: keyPrefixed, value:returnResult});
 			return returnResult;
 		}
 
 		const keyPrefixed = this._getKeyPrefix(key);
-		const result = store.delete(keyPrefixed);
-		this.hooks.trigger(KeyvHooks.POST_DELETE, result);
+		this.hooks.trigger(KeyvHooks.PRE_DELETE, {key: keyPrefixed});
+		const result = await store.delete(keyPrefixed);
+		this.hooks.trigger(KeyvHooks.POST_DELETE, {key: keyPrefixed, value:result});
 		this.stats.delete();
 		return result;
 	}

--- a/packages/keyv/src/index.ts
+++ b/packages/keyv/src/index.ts
@@ -354,14 +354,14 @@ export class Keyv<GenericValue = any> extends EventManager {
 
 			const results = await Promise.allSettled(promises);
 			const returnResult = results.every(x => (x as PromiseFulfilledResult<any>).value === true);
-			this.hooks.trigger(KeyvHooks.POST_DELETE, {key: keyPrefixed, value:returnResult});
+			this.hooks.trigger(KeyvHooks.POST_DELETE, {key: keyPrefixed, value: returnResult});
 			return returnResult;
 		}
 
 		const keyPrefixed = this._getKeyPrefix(key);
 		this.hooks.trigger(KeyvHooks.PRE_DELETE, {key: keyPrefixed});
 		const result = await store.delete(keyPrefixed);
-		this.hooks.trigger(KeyvHooks.POST_DELETE, {key: keyPrefixed, value:result});
+		this.hooks.trigger(KeyvHooks.POST_DELETE, {key: keyPrefixed, value: result});
 		this.stats.delete();
 		return result;
 	}

--- a/packages/keyv/test/keyv-hooks.test.ts
+++ b/packages/keyv/test/keyv-hooks.test.ts
@@ -92,7 +92,7 @@ test.it('POST_GET_MANY with getMany function', async () => {
 test.it('PRE_DELETE hook', async () => {
 	const keyv = new Keyv();
 	keyv.hooks.addHandler(KeyvHooks.PRE_DELETE, data => {
-		test.expect(data.key).toBe('foo');
+		test.expect(data.key).toBe('keyv:foo');
 	});
 	test.expect(keyv.hooks.handlers.size).toBe(1);
 	await keyv.set('foo', 'bar');


### PR DESCRIPTION
I was using the package and noticed that preDelete is not called, and postDelete doesn't return the keys that where deleted.
I just added proper calling of the hooks
