### PR TITLE
feat: add noNamespaceAffectsAll option

### DIFF
--- a/packages/redis/README.md
+++ b/packages/redis/README.md
@@ -113,7 +113,7 @@ NOTE: If you plan to do many clears or deletes, it is recommended to read the [P
 # Performance Considerations
 
 With namespaces being prefix based it is critical to understand some of the performance considerations we have made:
-* `clear()` - We use the `SCAN` command to iterate over keys. This is a non-blocking command that is more efficient than `KEYS`. In addition we are using `UNLINK` by default instead of `DEL`. Even with that if you are iterating over a large dataset it can still be slow. It is highly recommended to use the `namespace` option to limit the keys that are being cleared and if possible to not use the `clear()` method in high performance environments.
+* `clear()` - We use the `SCAN` command to iterate over keys. This is a non-blocking command that is more efficient than `KEYS`. In addition we are using `UNLINK` by default instead of `DEL`. Even with that if you are iterating over a large dataset it can still be slow. It is highly recommended to use the `namespace` option to limit the keys that are being cleared and if possible to not use the `clear()` method in high performance environments. If you don't set namespaces, you can enable `noNamespaceAffectsAll` to clear all keys using the `FLUSHDB` command which is faster and can be used in production environments.
 
 * `delete()` - By default we are now using `UNLINK` instead of `DEL` for deleting keys. This is a non-blocking command that is more efficient than `DEL`. If you are deleting a large number of keys it is recommended to use the `deleteMany()` method instead of `delete()`.
 
@@ -217,6 +217,7 @@ const keyv = new Keyv({ store: new KeyvRedis(tlsOptions) });
 * **keyPrefixSeparator** - The separator to use between the namespace and key.
 * **clearBatchSize** - The number of keys to delete in a single batch.
 * **useUnlink** - Use the `UNLINK` command for deleting keys isntead of `DEL`.
+* **noNamespaceAffectsAll**: Whether to allow clearing all keys when no namespace is set (default is `false`).
 * **set** - Set a key.
 * **setMany** - Set multiple keys.
 * **get** - Get a key.
@@ -225,9 +226,9 @@ const keyv = new Keyv({ store: new KeyvRedis(tlsOptions) });
 * **hasMany** - Check if multiple keys exist.
 * **delete** - Delete a key.
 * **deleteMany** - Delete multiple keys.
-* **clear** - Clear all keys in the namespace. If the namespace is not set it will clear all keys that are not prefixed with a namespace.
+* **clear** - Clear all keys in the namespace. If the namespace is not set it will clear all keys that are not prefixed with a namespace unless `noNamespaceAffectsAll` is set to `true`.
 * **disconnect** - Disconnect from the Redis server.
-* **iterator** - Create a new iterator for the keys. If the namespace is not set it will iterate over all keys that are not prefixed with a namespace.
+* **iterator** - Create a new iterator for the keys. If the namespace is not set it will iterate over all keys that are not prefixed with a namespace unless `noNamespaceAffectsAll` is set to `true`.
 
 # Migrating from v3 to v4
 

--- a/packages/redis/src/index.ts
+++ b/packages/redis/src/index.ts
@@ -196,7 +196,7 @@ export default class KeyvRedis extends EventEmitter implements KeyvStoreAdapter 
 		this._useUnlink = value;
 	}
 
-	/**
+/**
  * Get if no namespace affects all keys.
  * Whether to allow clearing all keys when no namespace is set.
  * If set to true and no namespace is set, iterate() will return all keys.

--- a/packages/redis/src/index.ts
+++ b/packages/redis/src/index.ts
@@ -518,7 +518,7 @@ export default class KeyvRedis extends EventEmitter implements KeyvStoreAdapter 
 	}
 
 	private async clearNamespaceCluster(namespace?: string): Promise<void> {
-			throw new Error('Clearing all keys in a cluster is not supported.');
+		throw new Error('Clearing all keys in a cluster is not supported.');
 	}
 
 	private isClientCluster(client: RedisClientConnectionType): boolean {

--- a/packages/redis/src/index.ts
+++ b/packages/redis/src/index.ts
@@ -196,12 +196,12 @@ export default class KeyvRedis extends EventEmitter implements KeyvStoreAdapter 
 		this._useUnlink = value;
 	}
 
-/**
- * Get if no namespace affects all keys.
- * Whether to allow clearing all keys when no namespace is set.
- * If set to true and no namespace is set, iterate() will return all keys.
- * @default false
- */
+	/**
+	 * Get if no namespace affects all keys.
+	 * Whether to allow clearing all keys when no namespace is set.
+	 * If set to true and no namespace is set, iterate() will return all keys.
+	 * @default false
+	 */
 	public get noNamespaceAffectsAll(): boolean {
 		return this._noNamespaceAffectsAll;
 	}

--- a/packages/redis/src/index.ts
+++ b/packages/redis/src/index.ts
@@ -26,6 +26,12 @@ export type KeyvRedisOptions = {
 	 */
 	useUnlink?: boolean;
 
+	/**
+   * Whether to allow clearing all keys when no namespace is set.
+   * If set to true and no namespace is set, iterate() will return all keys.
+   * Defaults to `false`.
+   */
+	noNamespaceAffectsAll?: boolean;
 };
 
 export type KeyvRedisPropertyOptions = KeyvRedisOptions & {
@@ -63,6 +69,7 @@ export default class KeyvRedis extends EventEmitter implements KeyvStoreAdapter 
 	private _keyPrefixSeparator = '::';
 	private _clearBatchSize = 1000;
 	private _useUnlink = true;
+	private _noNamespaceAffectsAll = false;
 
 	/**
 	 * KeyvRedis constructor.
@@ -114,6 +121,7 @@ export default class KeyvRedis extends EventEmitter implements KeyvStoreAdapter 
 			namespace: this._namespace,
 			keyPrefixSeparator: this._keyPrefixSeparator,
 			clearBatchSize: this._clearBatchSize,
+			noNamespaceAffectsAll: this._noNamespaceAffectsAll,
 			dialect: 'redis',
 			url,
 		};
@@ -186,6 +194,23 @@ export default class KeyvRedis extends EventEmitter implements KeyvStoreAdapter 
 	 */
 	public set useUnlink(value: boolean) {
 		this._useUnlink = value;
+	}
+
+	/**
+ * Get if no namespace affects all keys.
+ * Whether to allow clearing all keys when no namespace is set.
+ * If set to true and no namespace is set, iterate() will return all keys.
+ * @default false
+ */
+	public get noNamespaceAffectsAll(): boolean {
+		return this._noNamespaceAffectsAll;
+	}
+
+	/**
+	 * Set if not namespace affects all keys.
+	 */
+	public set noNamespaceAffectsAll(value: boolean) {
+		this._noNamespaceAffectsAll = value;
 	}
 
 	/**
@@ -419,7 +444,7 @@ export default class KeyvRedis extends EventEmitter implements KeyvStoreAdapter 
 			cursor = result.cursor.toString();
 			let {keys} = result;
 
-			if (!namespace) {
+			if (!namespace && !this._noNamespaceAffectsAll) {
 				keys = keys.filter(key => !key.includes(this._keyPrefixSeparator));
 			}
 
@@ -448,6 +473,12 @@ export default class KeyvRedis extends EventEmitter implements KeyvStoreAdapter 
 
 	private async clearNamespace(namespace?: string): Promise<void> {
 		try {
+			if (!namespace && this._noNamespaceAffectsAll) {
+				const client = await this.getClient() as RedisClientType;
+				await client.flushDb();
+				return;
+			}
+
 			let cursor = '0';
 			const batchSize = this._clearBatchSize;
 			const match = namespace ? `${namespace}${this._keyPrefixSeparator}*` : '*';
@@ -479,6 +510,7 @@ export default class KeyvRedis extends EventEmitter implements KeyvStoreAdapter 
 					}
 				}
 			} while (cursor !== '0');
+
 		/* c8 ignore next 3 */
 		} catch (error) {
 			this.emit('error', error);
@@ -486,7 +518,7 @@ export default class KeyvRedis extends EventEmitter implements KeyvStoreAdapter 
 	}
 
 	private async clearNamespaceCluster(namespace?: string): Promise<void> {
-		throw new Error('Clearing all keys in a cluster is not supported.');
+			throw new Error('Clearing all keys in a cluster is not supported.');
 	}
 
 	private isClientCluster(client: RedisClientConnectionType): boolean {
@@ -516,6 +548,10 @@ export default class KeyvRedis extends EventEmitter implements KeyvStoreAdapter 
 
 		if (options.useUnlink !== undefined) {
 			this._useUnlink = options.useUnlink;
+		}
+
+		if (options.noNamespaceAffectsAll !== undefined) {
+			this._noNamespaceAffectsAll = options.noNamespaceAffectsAll;
 		}
 	}
 

--- a/packages/redis/src/index.ts
+++ b/packages/redis/src/index.ts
@@ -27,10 +27,10 @@ export type KeyvRedisOptions = {
 	useUnlink?: boolean;
 
 	/**
-   * Whether to allow clearing all keys when no namespace is set.
-   * If set to true and no namespace is set, iterate() will return all keys.
-   * Defaults to `false`.
-   */
+	 * Whether to allow clearing all keys when no namespace is set.
+	 * If set to true and no namespace is set, iterate() will return all keys.
+	 * Defaults to `false`.
+	 */
 	noNamespaceAffectsAll?: boolean;
 };
 

--- a/packages/redis/test/cluster.ts
+++ b/packages/redis/test/cluster.ts
@@ -31,7 +31,7 @@ describe('KeyvRedis Cluster', () => {
 		expect(keyvRedis.isCluster()).toBe(true);
 	});
 
-	test('shoudl be able to set the redis cluster client', async () => {
+	test('should be able to set the redis cluster client', async () => {
 		const cluster = createCluster(defaultClusterOptions);
 
 		const keyvRedis = new KeyvRedis();
@@ -61,7 +61,7 @@ describe('KeyvRedis Cluster', () => {
 		await keyvRedis.delete('test-cl1');
 	});
 
-	test('should thrown an error on clear', async () => {
+	test('should throw an error on clear', async () => {
 		const cluster = createCluster(defaultClusterOptions);
 
 		const keyvRedis = new KeyvRedis(cluster);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](https://github.com/jaredwray/keyv/blob/main/CONTRIBUTING.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?**
This PR is a follow-up on issue #1222 which I reported earlier. It adds an option to the adapter's API called `noNamespacesAffectsAll` and if is set to `true` and `namespace` is undefined:
- `clear` method will use `FLUSHDB` command
- `iterator` method will return all keys regardless of having a namespace prefix

The behavior of these methods will remain the same in cluster mode.
This option has a default value of `false` for backward compatibility so this PR does not introduce a breaching change.
 
