### PR TITLE
redis: clear and iterator methods support Clusters

### DIFF
--- a/packages/redis/README.md
+++ b/packages/redis/README.md
@@ -117,7 +117,7 @@ With namespaces being prefix based it is critical to understand some of the perf
 
 * `delete()` - By default we are now using `UNLINK` instead of `DEL` for deleting keys. This is a non-blocking command that is more efficient than `DEL`. If you are deleting a large number of keys it is recommended to use the `deleteMany()` method instead of `delete()`.
 
-* `clearBatchSize` - The `clearBatchSize` option is set to `1000` by default. This is because Redis has a limit of 1000 keys that can be deleted in a single batch. 
+* `clearBatchSize` - The `clearBatchSize` option is set to `1000` by default. This is because Redis has a limit of 1000 keys that can be deleted in a single batch. If no namespace is defined and noNamespaceAffectsAll is set to `true` this option will be ignored and the `FLUSHDB` command will be used instead.
 
 * `useUnlink` - This option is set to `true` by default. This is because `UNLINK` is a non-blocking command that is more efficient than `DEL`. If you are not using `UNLINK` and are doing a lot of deletes it is recommended to set this option to `true`.
 
@@ -182,8 +182,6 @@ const cluster = createCluster({
 
 const keyv = new Keyv({ store: new KeyvRedis(cluster) });
 ```
-
-There are some features that are not supported in clustering such as `clear()` and `iterator()`. This is because the `SCAN` command is not supported in clustering. If you need to clear or delete keys you can use the `deleteMany()` method.
 
 You can learn more about the `createCluster` function in the [documentation](https://github.com/redis/node-redis/blob/master/docs/clustering.md) at https://github.com/redis/node-redis/tree/master/docs. 
 

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -41,6 +41,7 @@
 	},
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
+		"cluster-key-slot": "^1.1.2",
 		"keyv": "workspace:^",
 		"redis": "^4.7.0"
 	},

--- a/packages/redis/src/index.ts
+++ b/packages/redis/src/index.ts
@@ -513,7 +513,7 @@ export default class KeyvRedis extends EventEmitter implements KeyvStoreAdapter 
 	}
 
 	/**
-	 * Clear all keys in the store with a specific namespace. If the instance is a cluster, it will clear all keys
+	 * Get many keys. If the instance is a cluster, it will do multiple MGET calls
 	 * by separating the keys by slot to solve the CROSS-SLOT error.
 	 */
 	private async mGetWithClusterSupport<T = any>(keys: string[]): Promise<Array<T | undefined>> {

--- a/packages/redis/src/index.ts
+++ b/packages/redis/src/index.ts
@@ -515,7 +515,7 @@ export default class KeyvRedis extends EventEmitter implements KeyvStoreAdapter 
 
 	/**
 	 * Get many keys. If the instance is a cluster, it will do multiple MGET calls
-	 * by separating the keys by slot to solve the CROSS-SLOT error.
+	 * by separating the keys by slot to solve the CROSS-SLOT restriction.
 	 */
 	private async mGetWithClusterSupport<T = any>(keys: string[]): Promise<Array<T | undefined>> {
 		const slotMap = this.getSlotMap(keys);
@@ -535,7 +535,7 @@ export default class KeyvRedis extends EventEmitter implements KeyvStoreAdapter 
 
 	/**
 	 * Clear all keys in the store with a specific namespace. If the instance is a cluster, it will clear all keys
-	 * by separating the keys by slot to solve the CROSS-SLOT error.
+	 * by separating the keys by slot to solve the CROSS-SLOT restriction.
 	 */
 	private async clearWithClusterSupport(keys: string[]): Promise<void> {
 		if (keys.length > 0) {

--- a/packages/redis/src/index.ts
+++ b/packages/redis/src/index.ts
@@ -435,6 +435,7 @@ export default class KeyvRedis extends EventEmitter implements KeyvStoreAdapter 
 	 * @returns {AsyncGenerator<[string, T | undefined], void, unknown>} - async iterator with key value pairs
 	 */
 	public async * iterator<Value>(namespace?: string): AsyncGenerator<[string, Value | undefined], void, unknown> {
+		// When instance is not a cluster, it will only have one client
 		const clients = await this.getMasterNodes();
 
 		for (const client of clients) {

--- a/packages/redis/src/index.ts
+++ b/packages/redis/src/index.ts
@@ -321,7 +321,7 @@ export default class KeyvRedis extends EventEmitter implements KeyvStoreAdapter 
 		}
 
 		keys = keys.map(key => this.createKeyPrefix(key, this._namespace));
-		const values = await this.mGetWithClusterSupport<T>(keys);
+		const values = await this.mget<T>(keys);
 
 		return values;
 	}
@@ -453,7 +453,7 @@ export default class KeyvRedis extends EventEmitter implements KeyvStoreAdapter 
 
 				if (keys.length > 0) {
 					// eslint-disable-next-line no-await-in-loop
-					const values = await this.mGetWithClusterSupport<Value>(keys);
+					const values = await this.mget<Value>(keys);
 					for (const i of keys.keys()) {
 						const key = this.getKeyWithoutPrefix(keys[i], namespace);
 						const value = values[i];
@@ -517,7 +517,7 @@ export default class KeyvRedis extends EventEmitter implements KeyvStoreAdapter 
 	 * Get many keys. If the instance is a cluster, it will do multiple MGET calls
 	 * by separating the keys by slot to solve the CROSS-SLOT restriction.
 	 */
-	private async mGetWithClusterSupport<T = any>(keys: string[]): Promise<Array<T | undefined>> {
+	private async mget<T = any>(keys: string[]): Promise<Array<T | undefined>> {
 		const slotMap = this.getSlotMap(keys);
 
 		const valueMap = new Map<string, string | undefined>();

--- a/packages/redis/test/cluster.ts
+++ b/packages/redis/test/cluster.ts
@@ -1,4 +1,6 @@
-import {describe, test, expect} from 'vitest';
+import {
+	describe, test, expect, beforeEach,
+} from 'vitest';
 import KeyvRedis, {createCluster} from '../src/index.js';
 
 const defaultClusterOptions = {
@@ -17,6 +19,14 @@ const defaultClusterOptions = {
 };
 
 describe('KeyvRedis Cluster', () => {
+	beforeEach(async () => {
+		const cluster = createCluster(defaultClusterOptions);
+		const keyvRedis = new KeyvRedis(cluster);
+		keyvRedis.noNamespaceAffectsAll = true;
+		await keyvRedis.clear();
+		await keyvRedis.disconnect();
+	});
+
 	test('should be able to connect to a cluster', async () => {
 		const cluster = createCluster(defaultClusterOptions);
 
@@ -24,6 +34,8 @@ describe('KeyvRedis Cluster', () => {
 
 		expect(keyvRedis).toBeDefined();
 		expect(keyvRedis.client).toEqual(cluster);
+
+		await keyvRedis.disconnect();
 	});
 
 	test('should be able to send in cluster options', async () => {
@@ -40,6 +52,8 @@ describe('KeyvRedis Cluster', () => {
 		keyvRedis.client = cluster;
 		expect(keyvRedis.client).toEqual(cluster);
 		expect(keyvRedis.isCluster()).toBe(true);
+
+		await keyvRedis.disconnect();
 	});
 
 	test('should be able to set a value', async () => {
@@ -59,42 +73,249 @@ describe('KeyvRedis Cluster', () => {
 		expect(result).toBe('test');
 
 		await keyvRedis.delete('test-cl1');
+
+		await keyvRedis.disconnect();
 	});
 
-	test('should throw an error on clear', async () => {
-		const cluster = createCluster(defaultClusterOptions);
+	describe('KeyvRedis clear method', () => {
+		test('should not throw an error on clear', async () => {
+			const cluster = createCluster(defaultClusterOptions);
 
-		const keyvRedis = new KeyvRedis(cluster);
+			const keyvRedis = new KeyvRedis(cluster);
 
-		let errorThrown = false;
-		try {
+			let errorThrown = false;
+			try {
+				await keyvRedis.clear();
+			} catch (error) {
+				console.log(error);
+				expect(error).toBeDefined();
+				errorThrown = true;
+			}
+
+			expect(errorThrown).toBe(false);
+
+			await keyvRedis.disconnect();
+		});
+
+		test('should do nothing if no keys on clear', async () => {
+			const cluster = createCluster(defaultClusterOptions);
+			const keyvRedis = new KeyvRedis(cluster);
+
 			await keyvRedis.clear();
-		} catch (error) {
-			expect(error).toBeDefined();
-			errorThrown = true;
-		}
+			keyvRedis.namespace = 'ns1';
+			await keyvRedis.clear();
+			await keyvRedis.disconnect();
+		});
 
-		expect(errorThrown).toBe(true);
+		test('should clear with no namespace', async () => {
+			const cluster = createCluster(defaultClusterOptions);
+			const keyvRedis = new KeyvRedis(cluster);
+			await keyvRedis.set('foo90', 'bar');
+			await keyvRedis.set('foo902', 'bar2');
+			await keyvRedis.set('foo903', 'bar3');
+			await keyvRedis.clear();
+			const value = await keyvRedis.get('foo90');
+			expect(value).toBeUndefined();
+			await keyvRedis.disconnect();
+		});
+
+		test('should clear with no namespace and useUnlink to false', async () => {
+			const cluster = createCluster(defaultClusterOptions);
+			const keyvRedis = new KeyvRedis(cluster);
+			keyvRedis.useUnlink = false;
+			await keyvRedis.set('foo90', 'bar');
+			await keyvRedis.set('foo902', 'bar2');
+			await keyvRedis.set('foo903', 'bar3');
+			await keyvRedis.clear();
+			const value = await keyvRedis.get('foo90');
+			expect(value).toBeUndefined();
+			await keyvRedis.disconnect();
+		});
+
+		test('should clear with no namespace but not the namespace ones', async () => {
+			const cluster = createCluster(defaultClusterOptions);
+			const keyvRedis = new KeyvRedis(cluster);
+			keyvRedis.namespace = 'ns1';
+			await keyvRedis.set('foo91', 'bar');
+			keyvRedis.namespace = undefined;
+			await keyvRedis.set('foo912', 'bar2');
+			await keyvRedis.set('foo913', 'bar3');
+			await keyvRedis.clear();
+			keyvRedis.namespace = 'ns1';
+			const value = await keyvRedis.get('foo91');
+			expect(value).toBe('bar');
+			await keyvRedis.disconnect();
+		});
+
+		test('should not clear all with no namespace if noNamespaceAffectsAll is false', async () => {
+			const cluster = createCluster(defaultClusterOptions);
+			const keyvRedis = new KeyvRedis(cluster);
+			keyvRedis.noNamespaceAffectsAll = false;
+
+			keyvRedis.namespace = 'ns1';
+			await keyvRedis.set('foo91', 'bar');
+			keyvRedis.namespace = undefined;
+			await keyvRedis.set('foo912', 'bar2');
+			await keyvRedis.set('foo913', 'bar3');
+			await keyvRedis.clear();
+			keyvRedis.namespace = 'ns1';
+			const value = await keyvRedis.get('foo91');
+			expect(value).toBeDefined();
+		});
+
+		test('should clear all with no namespace if noNamespaceAffectsAll is true', async () => {
+			const cluster = createCluster(defaultClusterOptions);
+			const keyvRedis = new KeyvRedis(cluster);
+			keyvRedis.noNamespaceAffectsAll = true;
+
+			keyvRedis.namespace = 'ns1';
+			await keyvRedis.set('foo91', 'bar');
+			keyvRedis.namespace = undefined;
+			await keyvRedis.set('foo912', 'bar2');
+			await keyvRedis.set('foo913', 'bar3');
+			await keyvRedis.clear();
+			keyvRedis.namespace = 'ns1';
+			const value = await keyvRedis.get('foo91');
+			expect(value).toBeUndefined();
+		});
+
+		test('should clear namespace but not other ones', async () => {
+			const cluster = createCluster(defaultClusterOptions);
+			const keyvRedis = new KeyvRedis(cluster);
+			keyvRedis.namespace = 'ns1';
+			await keyvRedis.set('foo921', 'bar');
+			keyvRedis.namespace = 'ns2';
+			await keyvRedis.set('foo922', 'bar2');
+			await keyvRedis.clear();
+			keyvRedis.namespace = 'ns1';
+			const value = await keyvRedis.get('foo921');
+			expect(value).toBe('bar');
+			await keyvRedis.disconnect();
+		});
 	});
 
-	test('should throw an error on iterator', async () => {
-		const cluster = createCluster(defaultClusterOptions);
+	describe('KeyvRedis Iterators', () => {
+		test('should no throw an error on iterator', async () => {
+			const cluster = createCluster(defaultClusterOptions);
+			const keyvRedis = new KeyvRedis(cluster);
 
-		const keyvRedis = new KeyvRedis(cluster);
+			let errorThrown = false;
+			try {
+				const keys = [];
+				const values = [];
+				for await (const [key, value] of keyvRedis.iterator('foo')) {
+					keys.push(key);
+					values.push(value);
+				}
+			} catch (error) {
+				console.log(error);
+				expect(error).toBeDefined();
+				errorThrown = true;
+			}
 
-		let errorThrown = false;
-		try {
+			expect(errorThrown).toBe(false);
+		});
+
+		test('should be able to iterate over keys', async () => {
+			const cluster = createCluster(defaultClusterOptions);
+			const keyvRedis = new KeyvRedis(cluster);
+			await keyvRedis.set('foo95', 'bar');
+			await keyvRedis.set('foo952', 'bar2');
+			await keyvRedis.set('foo953', 'bar3');
+			const keys = [];
+			for await (const [key] of keyvRedis.iterator()) {
+				keys.push(key);
+			}
+
+			expect(keys).toContain('foo95');
+			expect(keys).toContain('foo952');
+			expect(keys).toContain('foo953');
+			await keyvRedis.disconnect();
+		});
+
+		test('should be able to iterate over keys by namespace', async () => {
+			const cluster = createCluster(defaultClusterOptions);
+			const keyvRedis = new KeyvRedis(cluster);
+			const namespace = 'ns1';
+			await keyvRedis.set('foo96', 'bar');
+			await keyvRedis.set('foo962', 'bar2');
+			await keyvRedis.set('foo963', 'bar3');
+			keyvRedis.namespace = namespace;
+			await keyvRedis.set('foo961', 'bar');
+			await keyvRedis.set('foo9612', 'bar2');
+			await keyvRedis.set('foo9613', 'bar3');
 			const keys = [];
 			const values = [];
-			for await (const [key, value] of keyvRedis.iterator('foo')) {
+			for await (const [key, value] of keyvRedis.iterator(namespace)) {
 				keys.push(key);
 				values.push(value);
 			}
-		} catch (error) {
-			expect(error).toBeDefined();
-			errorThrown = true;
-		}
 
-		expect(errorThrown).toBe(true);
+			expect(keys).toContain('foo961');
+			expect(keys).toContain('foo9612');
+			expect(keys).toContain('foo9613');
+			expect(values).toContain('bar');
+			expect(values).toContain('bar2');
+			expect(values).toContain('bar3');
+
+			await keyvRedis.disconnect();
+		});
+
+		test('should be able to iterate over all keys if namespace is undefined and noNamespaceAffectsAll is true', async () => {
+			const cluster = createCluster(defaultClusterOptions);
+			const keyvRedis = new KeyvRedis(cluster);
+			keyvRedis.noNamespaceAffectsAll = true;
+
+			keyvRedis.namespace = 'ns1';
+			await keyvRedis.set('foo1', 'bar1');
+			keyvRedis.namespace = 'ns2';
+			await keyvRedis.set('foo2', 'bar2');
+			keyvRedis.namespace = undefined;
+			await keyvRedis.set('foo3', 'bar3');
+
+			const keys = [];
+			const values = [];
+			for await (const [key, value] of keyvRedis.iterator()) {
+				keys.push(key);
+				values.push(value);
+			}
+
+			expect(keys).toContain('ns1::foo1');
+			expect(keys).toContain('ns2::foo2');
+			expect(keys).toContain('foo3');
+			expect(values).toContain('bar1');
+			expect(values).toContain('bar2');
+			expect(values).toContain('bar3');
+		});
+
+		test('should only iterate over keys with no namespace if name is undefined set and noNamespaceAffectsAll is false', async () => {
+			const cluster = createCluster(defaultClusterOptions);
+			const keyvRedis = new KeyvRedis(cluster);
+			keyvRedis.noNamespaceAffectsAll = false;
+
+			keyvRedis.namespace = 'ns1';
+			await keyvRedis.set('foo1', 'bar1');
+			keyvRedis.namespace = 'ns2';
+			await keyvRedis.set('foo2', 'bar2');
+			keyvRedis.namespace = undefined;
+			await keyvRedis.set('foo3', 'bar3');
+
+			const keys = [];
+			const values = [];
+			for await (const [key, value] of keyvRedis.iterator()) {
+				keys.push(key);
+				values.push(value);
+			}
+
+			expect(keys).toContain('foo3');
+			expect(values).toContain('bar3');
+
+			expect(keys).not.toContain('foo1');
+			expect(keys).not.toContain('ns1::foo1');
+			expect(keys).not.toContain('ns2::foo2');
+			expect(keys).not.toContain('foo2');
+			expect(values).not.toContain('bar1');
+			expect(values).not.toContain('bar2');
+		});
 	});
 });

--- a/packages/redis/test/test.ts
+++ b/packages/redis/test/test.ts
@@ -208,6 +208,13 @@ describe('KeyvRedis Methods', () => {
 		await keyvRedis.disconnect();
 	});
 
+	test('should be able to call getMany with an empty array', async () => {
+		const keyvRedis = new KeyvRedis();
+		const values = await keyvRedis.getMany([]);
+		expect(values).toEqual([]);
+		await keyvRedis.disconnect();
+	});
+
 	test('should be able to delete many with namespace', async () => {
 		const keyvRedis = new KeyvRedis();
 		await keyvRedis.setMany([{key: 'foo-dm1', value: 'bar'}, {key: 'foo-dm2', value: 'bar2'}, {key: 'foo-dm3', value: 'bar3', ttl: 5}]);

--- a/packages/redis/test/test.ts
+++ b/packages/redis/test/test.ts
@@ -377,7 +377,7 @@ describe('KeyvRedis Iterators', () => {
 		await keyvRedis.set('foo952', 'bar2');
 		await keyvRedis.set('foo953', 'bar3');
 		const keys = [];
-		for await (const [key, value] of keyvRedis.iterator()) {
+		for await (const [key] of keyvRedis.iterator()) {
 			keys.push(key);
 		}
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](https://github.com/jaredwray/keyv/blob/main/CONTRIBUTING.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?**
This PR introduces these non-braking features and improvements:
- `iterator` method works on clusters
- `clear` method works on clusters
- `setMany` method uses `MGET` operation instead of transactions which improves its performance 