### PR TITLE
redis - fix: if you pass in nothing to createKeyv it defaults to redi…

### DIFF
--- a/packages/redis/src/index.ts
+++ b/packages/redis/src/index.ts
@@ -631,11 +631,12 @@ export default class KeyvRedis<T> extends EventEmitter implements KeyvStoreAdapt
 
 /**
  * Will create a Keyv instance with the Redis adapter. This will also set the namespace and useKeyPrefix to false.
- * @param connect
- * @param options
+ * @param connect - How to connect to the Redis server. If string pass in the url, if object pass in the options, if RedisClient pass in the client. If nothing is passed in, it will default to 'redis://localhost:6379'.
+ * @param {KeyvRedisOptions} options - Options for the adapter such as namespace, keyPrefixSeparator, and clearBatchSize.
  * @returns {Keyv} - Keyv instance with the Redis adapter
  */
 export function createKeyv(connect?: string | RedisClientOptions | RedisClientType, options?: KeyvRedisOptions): Keyv {
+	connect ??= 'redis://localhost:6379';
 	const adapter = new KeyvRedis(connect, options);
 	const keyv = new Keyv({store: adapter, namespace: options?.namespace, useKeyPrefix: false});
 	return keyv;

--- a/packages/redis/test/test.ts
+++ b/packages/redis/test/test.ts
@@ -475,4 +475,10 @@ describe('KeyvRedis Iterators', () => {
 		expect(values).not.toContain('bar1');
 		expect(values).not.toContain('bar2');
 	});
+
+	test('should be able to pass undefined on connect to get localhost', async () => {
+		const keyv = createKeyv();
+		const keyvRedis = keyv.store as KeyvRedis<string>;
+		expect((keyvRedis.client as RedisClientType).options?.url).toBe('redis://localhost:6379');
+	});
 });


### PR DESCRIPTION
…s localhost

**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](https://github.com/jaredwray/keyv/blob/main/CONTRIBUTING.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
redis - fix: if you pass in nothing to createKeyv it defaults to redis localhost