### PR TITLE
compress-brotli - fix: moving Keyv to a peer dependency

### DIFF
--- a/packages/compress-brotli/package.json
+++ b/packages/compress-brotli/package.json
@@ -48,7 +48,9 @@
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
 		"@keyv/serialize": "workspace:^",
-		"compress-brotli": "^1.3.12",
+		"compress-brotli": "^1.3.12"
+	},
+	"peerDependencies": {
 		"keyv": "workspace:^"
 	},
 	"devDependencies": {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](https://github.com/jaredwray/keyv/blob/main/CONTRIBUTING.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
compress-brotli - fix: moving Keyv to a peer dependency