### PR TITLE
redis - fixed `@keyv/valkey` name in readme

### DIFF
--- a/packages/redis/README.md
+++ b/packages/redis/README.md
@@ -294,7 +294,7 @@ Here are some of the events you can listen to: https://www.npmjs.com/package/red
 # Migrating from v3 to v4
 
 Overall the API is the same as v3 with additional options and performance improvements. Here are the main changes:
-* The `ioredis` library has been removed in favor of the `redis` aka `node-redis` library. If you want to use ioredis you can use `@keyv/keyval`
+* The `ioredis` library has been removed in favor of the `redis` aka `node-redis` library. If you want to use ioredis you can use `@keyv/valkey`
 * The `useUnlink` option has been added to use `UNLINK` instead of `DEL` and set to true by default.
 * The `clearBatchSize` option has been added to set the number of keys to delete in a single batch.
 * The `clear()` and `delete()` methods now use `UNLINK` instead of `DEL`. If you want to use `DEL` you can set the `useUnlink` option to `false`.


### PR DESCRIPTION
@keyv/keyval -> @keyv/valkey

**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](https://github.com/jaredwray/keyv/blob/main/CONTRIBUTING.md) guidelines.
- [ ] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

- fix docs
