### PR TITLE
keyv - fix: serialize entries in setMany

### DIFF
--- a/packages/keyv/src/index.ts
+++ b/packages/keyv/src/index.ts
@@ -619,13 +619,15 @@ export class Keyv<GenericValue = any> extends EventManager {
 		try {
 			// If the store has a setMany method then use it
 			if (this._store.setMany !== undefined) {
-				const serializedEntries = await Promise.all(entries.map(async ({ key, value, ttl }) => {
+				const serializedEntries = await Promise.all(entries.map(async ({key, value, ttl}) => {
 					if (ttl === undefined) {
 						ttl = this._ttl;
 					}
+
 					if (ttl === 0) {
 						ttl = undefined;
 					}
+
 					const expires = (typeof ttl === 'number') ? (Date.now() + ttl) : null;
 
 					if (typeof value === 'symbol') {
@@ -633,9 +635,9 @@ export class Keyv<GenericValue = any> extends EventManager {
 						throw new Error('symbol cannot be serialized');
 					}
 
-					const formattedValue = { value, expires };
+					const formattedValue = {value, expires};
 					const serializedValue = await this.serializeData(formattedValue);
-					return { key, value: serializedValue, ttl };
+					return {key, value: serializedValue, ttl};
 				}));
 				results = await this._store.setMany(serializedEntries);
 				return results;

--- a/packages/keyv/src/index.ts
+++ b/packages/keyv/src/index.ts
@@ -619,7 +619,25 @@ export class Keyv<GenericValue = any> extends EventManager {
 		try {
 			// If the store has a setMany method then use it
 			if (this._store.setMany !== undefined) {
-				results = await this._store.setMany(entries);
+				const serializedEntries = await Promise.all(entries.map(async ({ key, value, ttl }) => {
+					if (ttl === undefined) {
+						ttl = this._ttl;
+					}
+					if (ttl === 0) {
+						ttl = undefined;
+					}
+					const expires = (typeof ttl === 'number') ? (Date.now() + ttl) : null;
+
+					if (typeof value === 'symbol') {
+						this.emit('error', 'symbol cannot be serialized');
+						throw new Error('symbol cannot be serialized');
+					}
+
+					const formattedValue = { value, expires };
+					const serializedValue = await this.serializeData(formattedValue);
+					return { key, value: serializedValue, ttl };
+				}));
+				results = await this._store.setMany(serializedEntries);
 				return results;
 			}
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](https://github.com/jaredwray/keyv/blob/main/CONTRIBUTING.md) guidelines.
- [ ] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

Currently `setMany` does not serialize the entries currently which causes errors with `@keyv/redis`. I replicated the serialization/ttl fallback logic from `set` for this. I'm currently using this in my application as a patch to get it working.