### PR TITLE
feat(dynamo): add automatic table creation and ttl configuration

### DIFF
--- a/packages/dynamo/test/test.ts
+++ b/packages/dynamo/test/test.ts
@@ -21,6 +21,15 @@ test.beforeEach(async () => {
   await keyv.clear();
 });
 
+test.it('should ensure table creation', async t => {
+  const store = new KeyvDynamo({endpoint: dynamoURL, tableName: 'newTable'});
+  await store.set('test:key1', 'value1');
+  await t.expect(store.get('test:key1')).resolves.toBe('value1');
+
+  await store.set('test:key2', 'value2');
+  await t.expect(store.get('test:key2')).resolves.toBe('value2');
+});
+
 test.it('should be able to create a keyv instance', t => {
   const keyv = new Keyv<string>({store: keyvDynamodb});
   t.expect(keyv.store.opts.endpoint).toEqual(dynamoURL);
@@ -48,8 +57,8 @@ test.it('.clear() an empty store should not fail', async t => {
   await store.clear();
 });
 
-test.it('should emit error if there is no table previously created', async t => {
-  const store = new KeyvDynamo({endpoint: dynamoURL, tableName: 'invalid_table'});
+test.it('should emit unknown error (invalid table name', async t => {
+  const store = new KeyvDynamo({endpoint: dynamoURL, tableName: 'invalid_table%&#@'});
 
   const expectedError = new Promise((_resolve, reject) => {
     store.on('error', reject);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](https://github.com/jaredwray/keyv/blob/main/CONTRIBUTING.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Implements automatic DynamoDB table creation if the table doesn't exist.

## Changes
- **Automatic table creation**: Checks if table exists, creates it if missing
- **TTL configuration**: Automatically configures Time-To-Live on `expiresAt` attribute  
- **Table readiness**: All operations wait for table initialization
- **Error handling**: Proper handling of AWS exceptions

## Implementation
Uses `DescribeTableCommand` → `CreateTableCommand` → `UpdateTimeToLiveCommand` pattern with `PAY_PER_REQUEST` billing mode.

## Usage
```javascript
// Will automatically create 'my-cache' table if it doesn't exist
const store = new KeyvDynamo({ tableName: 'my-cache' });

// Or use default 'keyv' table name
const store = new KeyvDynamo();
```