### PR TITLE
fix redis docs

### DIFF
--- a/packages/redis/README.md
+++ b/packages/redis/README.md
@@ -170,13 +170,13 @@ You can pass these options when creating a new `KeyvRedis` instance:
 import Keyv from 'keyv';
 import KeyvRedis from '@keyv/redis';
 
-const keyvRedis = new KeyvRedis({
+const keyvRedis = new KeyvRedis('redis://user:pass@localhost:6379', {
   namespace: 'my-namespace',
   keyPrefixSeparator: ':',
   clearBatchSize: 1000,
   useUnlink: true,
   noNamespaceAffectsAll: false,
-  connectTimeout: 200
+  connectionTimeout: 200
 });
 
 const keyv = new Keyv({ store: keyvRedis });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](https://github.com/jaredwray/keyv/blob/main/CONTRIBUTING.md) guidelines.
- [ ] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
the KeyvRedis documentation had an invalid example on how to use `new KeyvRedis` - the `connectTimeout` field should be `connectionTimeout`, and the ctor expects a url (or client), before the KeyvRedisOptions instance