### PR TITLE
postgres - chore: connect method as public

### DIFF
--- a/packages/postgres/src/index.ts
+++ b/packages/postgres/src/index.ts
@@ -161,7 +161,7 @@ export class KeyvPostgres extends EventEmitter implements KeyvStoreAdapter {
 		return rows[0].exists;
 	}
 
-	protected async connect() {
+	async connect() {
 		const conn = pool(this.opts!.uri!, this.opts);
 		// biome-ignore lint/suspicious/noExplicitAny: type format
 		return async (sql: string, values?: any) => {


### PR DESCRIPTION
While we are waiting #1680 (if it will of course) here's small cosmetic change for ability to implement own PGlite support like

```ts
class KeyvPglite extends KeyvPostgres {
  override connect() {
    // PGlite connect
  }
  
  override disconnect() {
    // PGlite disconnect
  }
}
```

The rest should works out of the box