### PR TITLE
Keyv - fix: Remove 'type' field from keyv package.json

### DIFF
--- a/packages/keyv/package.json
+++ b/packages/keyv/package.json
@@ -2,7 +2,6 @@
 	"name": "keyv",
 	"version": "5.5.4",
 	"description": "Simple key-value storage with support for multiple backends",
-	"type": "module",
 	"main": "dist/index.cjs",
 	"module": "dist/index.js",
 	"types": "dist/index.d.ts",


### PR DESCRIPTION
Wrong 'type' field will confuse Node.js, when it wants to import ESM, it gets CJS instead and throw errors.

**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](https://github.com/jaredwray/keyv/blob/main/CONTRIBUTING.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** Bug fix
