### PR TITLE
keyv - fix: prevent duplicate namespace prefixing and add iterator test for delete stats

### DIFF
--- a/packages/keyv/src/index.ts
+++ b/packages/keyv/src/index.ts
@@ -533,6 +533,11 @@ export class Keyv<GenericValue = any> extends EventManager {
 			return key;
 		}
 
+		// If the key is already prefixed, return it
+		if (key.startsWith(this._namespace)) {
+			return key;
+		}
+
 		return `${this._namespace}:${key}`;
 	}
 


### PR DESCRIPTION
This solves bug described in https://github.com/jaredwray/keyv/issues/1771

**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
keyv - fix: prevent duplicate namespace prefixing and add iterator test for delete stats