### PR TITLE
redis - fix: move client initialization to constructor to prevent connection on module load (#1805)

### DIFF
--- a/packages/redis/src/index.ts
+++ b/packages/redis/src/index.ts
@@ -46,8 +46,7 @@ export default class KeyvRedis<T>
 	extends Hookified
 	implements KeyvStoreAdapter
 {
-	private _client: RedisClientConnectionType =
-		createClient() as RedisConnectionClientType;
+	private _client!: RedisClientConnectionType;
 	private _namespace: string | undefined;
 	private _keyPrefixSeparator = "::";
 	private _clearBatchSize = 1000;
@@ -105,6 +104,9 @@ export default class KeyvRedis<T>
 					this._client = createCluster(connect as RedisClusterOptions);
 				}
 			}
+		} else {
+			// No connect provided, create the default client here instead of at class field initialization
+			this._client = createClient({ socket }) as RedisConnectionClientType;
 		}
 
 		this.setOptions(options);


### PR DESCRIPTION
The class field initializer `_client = createClient()` was executing at module load time,
causing Redis connection attempts before any KeyvRedis instance was created. This caused
issues with:
- Startup hangs when localhost:6379 is unavailable
- OpenTelemetry instrumentation missing initialization
- Serverless cold start delays
- Testing complications with mock Redis

Moved client initialization from class field to constructor so connections only occur
when explicitly instantiating KeyvRedis or calling createKeyv().