### PR TITLE
docs: improve createKeyvNonBlocking documentation and add JSDoc

### DIFF
--- a/packages/redis/src/create.ts
+++ b/packages/redis/src/create.ts
@@ -53,6 +53,25 @@ export function createKeyv(
 	return keyv;
 }
 
+/**
+ * Creates a Keyv instance with the Redis adapter configured for non-blocking, best-effort usage.
+ * This is intended for scenarios where Redis is used as a secondary (L2) cache and failures
+ * should be silently ignored rather than propagated to the caller.
+ *
+ * Specifically, this function:
+ * - Disables `throwOnConnectError` on the Redis adapter (connection failures are swallowed)
+ * - Disables `throwOnErrors` on both the adapter and the Keyv instance (operation errors are swallowed)
+ * - Disables the Redis offline queue (commands are rejected immediately when disconnected instead of being queued)
+ * - Disables the Redis reconnect strategy (no automatic reconnection attempts)
+ *
+ * **Important:** "Non-blocking" here refers to error suppression and fail-fast behavior, not
+ * asynchronous fire-and-forget semantics. All operations (`get`, `set`, `delete`, etc.) still
+ * return promises that resolve/reject normally — they simply won't throw when Redis is unavailable.
+ *
+ * @param connect - How to connect to the Redis server. If string pass in the url, if object pass in the options, if RedisClient pass in the client. If nothing is passed in, it will default to 'redis://localhost:6379'.
+ * @param {KeyvRedisOptions} options - Options for the adapter such as namespace, keyPrefixSeparator, and clearBatchSize.
+ * @returns {Keyv} - Keyv instance with error suppression and fail-fast Redis configuration
+ */
 export function createKeyvNonBlocking(
 	connect?: string | RedisClientOptions | RedisClientType,
 	options?: KeyvRedisOptions,


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Documentation update and code documentation improvement.

**Description**

This PR improves the documentation and code comments for the `createKeyvNonBlocking` function to clarify its purpose, behavior, and use cases.

**Changes made:**

1. **README.md updates:**
   - Restructured the `createKeyvNonBlocking` section with clearer formatting using bullet points
   - Added explicit explanation of what "non-blocking" means in this context (error suppression and fail-fast behavior, not fire-and-forget)
   - Clarified that all operations still return promises
   - Added context about how this function complements the `nonBlocking` option in Cacheable
   - Improved readability with better organization and a note section

2. **JSDoc improvements:**
   - Added comprehensive JSDoc comment to the `createKeyvNonBlocking` function
   - Documented the specific behaviors: error suppression, offline queue disabling, and reconnect strategy disabling
   - Clarified the distinction between "non-blocking" (error handling) and "fire-and-forget" semantics
   - Added parameter and return type documentation

**Motivation**

The previous documentation was brief and could be misunderstood. Users might incorrectly assume "non-blocking" means fire-and-forget semantics or that errors are completely ignored. These improvements provide clarity on the actual behavior and appropriate use cases, particularly when using Redis as a secondary cache with libraries like Cacheable.

**Testing**

No functional changes — documentation and comments only.

https://claude.ai/code/session_016txnxR5J7WAcbyQgJVqaN3