### PR TITLE
postgres - feat: moving eventemitter to hookified

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -409,6 +409,9 @@ importers:
 
   storage/postgres:
     dependencies:
+      hookified:
+        specifier: ^1.15.0
+        version: 1.15.1
       keyv:
         specifier: workspace:^
         version: link:../../core/keyv
@@ -6298,14 +6301,6 @@ snapshots:
     optionalDependencies:
       vite: 7.3.1(@types/node@24.10.4)(terser@5.37.0)(tsx@4.21.0)
 
-  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@25.0.2)(terser@5.37.0)(tsx@4.21.0))':
-    dependencies:
-      '@vitest/spy': 4.0.18
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 7.3.1(@types/node@25.0.2)(terser@5.37.0)(tsx@4.21.0)
-
   '@vitest/pretty-format@4.0.18':
     dependencies:
       tinyrainbow: 3.0.3
@@ -9667,7 +9662,7 @@ snapshots:
   vitest@4.0.18(@types/node@25.0.2)(terser@5.37.0)(tsx@4.21.0):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.0.2)(terser@5.37.0)(tsx@4.21.0))
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@24.10.4)(terser@5.37.0)(tsx@4.21.0))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18

--- a/storage/postgres/package.json
+++ b/storage/postgres/package.json
@@ -51,6 +51,7 @@
 	},
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
+		"hookified": "^1.15.0",
 		"pg": "^8.17.1"
 	},
 	"peerDependencies": {

--- a/storage/postgres/src/index.ts
+++ b/storage/postgres/src/index.ts
@@ -1,5 +1,6 @@
 // biome-ignore-all lint/style/noNonNullAssertion: need to fix
-import EventEmitter from "node:events";
+
+import { Hookified } from "hookified";
 import Keyv, { type KeyvEntry, type KeyvStoreAdapter } from "keyv";
 import type { DatabaseError } from "pg";
 import { endPool, pool } from "./pool.js";
@@ -15,7 +16,7 @@ function escapeIdentifier(identifier: string): string {
 	return `"${identifier.replace(/"/g, '""')}"`;
 }
 
-export class KeyvPostgres extends EventEmitter implements KeyvStoreAdapter {
+export class KeyvPostgres extends Hookified implements KeyvStoreAdapter {
 	opts: KeyvPostgresOptions;
 	query: Query;
 	namespace?: string;


### PR DESCRIPTION
Replace Node.js EventEmitter with hookified to align with other storage
adapters (redis, memcache, bigmap) and enable middleware/hook capabilities.

https://claude.ai/code/session_012pLBa4JGfkZCTDgdXFuaV9