### PR TITLE
keyv - fix(v5): listener leak when using once and off

### DIFF
--- a/packages/keyv/src/event-manager.ts
+++ b/packages/keyv/src/event-manager.ts
@@ -1,5 +1,7 @@
 // biome-ignore lint/suspicious/noExplicitAny: type format
-type EventListener = (...arguments_: any[]) => void;
+type EventListener = ((...arguments_: any[]) => void) & {
+	_originalListener?: EventListener;
+};
 
 class EventManager {
 	_eventListeners: Map<string, EventListener[]>;
@@ -30,7 +32,7 @@ class EventManager {
 		if (listeners) {
 			if (listeners.length >= this._maxListeners) {
 				console.warn(
-					`MaxListenersExceededWarning: Possible event memory leak detected. ${listeners.length + 1} ${event} listeners added. Use setMaxListeners() to increase limit.`,
+					`MaxListenersExceededWarning: Possible event memory leak detected. ${listeners.length + 1} ${event} listeners added to Keyv's EventManager. Use setMaxListeners() to increase limit.`,
 				);
 			}
 
@@ -47,7 +49,9 @@ class EventManager {
 
 	public off(event: string, listener: EventListener): void {
 		const listeners = this._eventListeners.get(event) ?? [];
-		const index = listeners.indexOf(listener);
+		const index = listeners.findIndex(
+			(v) => v === listener || v._originalListener === listener,
+		);
 		if (index !== -1) {
 			listeners.splice(index, 1);
 		}
@@ -63,6 +67,7 @@ class EventManager {
 			listener(...arguments_);
 			this.off(event, onceListener);
 		};
+		onceListener._originalListener = listener;
 
 		this.on(event, onceListener);
 	}

--- a/packages/keyv/src/event-manager.ts
+++ b/packages/keyv/src/event-manager.ts
@@ -50,7 +50,7 @@ class EventManager {
 	public off(event: string, listener: EventListener): void {
 		const listeners = this._eventListeners.get(event) ?? [];
 		const index = listeners.findIndex(
-			(v) => v === listener || v._originalListener === listener,
+			(v) => v === listener || (v._originalListener === listener && listener !== undefined),
 		);
 		if (index !== -1) {
 			listeners.splice(index, 1);

--- a/packages/keyv/test/event-manager.test.ts
+++ b/packages/keyv/test/event-manager.test.ts
@@ -130,3 +130,15 @@ test.it("once method", (t) => {
 
 	t.expect(dataReceived).toBe(1);
 });
+
+test.it("remove once listener handler", (t) => {
+	const emitter = new EventManager();
+	const listener: EventListener = (data) => {
+		console.log(data);
+	};
+
+	emitter.once("test-event", listener);
+	t.expect(emitter.listeners("test-event").length).toBe(1);
+	emitter.off("test-event", listener);
+	t.expect(emitter.listeners("test-event").length).toBe(0);
+});


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

In v5, a custom `EventManager` is used, and it has a bug that can cause listeners to leak.

https://github.com/jaredwray/keyv/blob/e41ad98e0a9f5629d777a298eb2c20ae92c408af/packages/keyv/src/event-manager.ts#L60-L68

When adding a once listener, it wraps the original inside the newly created `onceListener`, and adds it into listeners. When user code tries to remove it using its original listener, it fails, because `off` cannot find the original listener that is used by user code.

This PR saves the reference of the original listener within the `onceListener` and make `off` also check for it, so it can be removed properly. The PR also changed the max listener warning message, to make it easier to trace.

Example case covered:

https://github.com/jaredwray/cacheable/blob/069f7340194f29f8ad2310cec4b922c0ad21b4f9/packages/cacheable-request/src/index.ts#L316-L325
