### PR TITLE
sqlite - fix: upgrade sqlite3 to ^6.0.1 to resolve dependency vulnerabilities

### DIFF
--- a/packages/sqlite/package.json
+++ b/packages/sqlite/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keyv/sqlite",
-	"version": "4.0.8",
+	"version": "4.1.0",
 	"description": "SQLite storage adapter for Keyv",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/sqlite/package.json
+++ b/packages/sqlite/package.json
@@ -50,7 +50,7 @@
 	},
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
-		"sqlite3": "^5.1.7"
+		"sqlite3": "^6.0.1"
 	},
 	"peerDependencies": {
 		"keyv": "workspace:^"
@@ -68,7 +68,7 @@
 		"directory": "test"
 	},
 	"engines": {
-		"node": ">= 18"
+		"node": ">= 20.17.0"
 	},
 	"files": [
 		"dist",

--- a/packages/test-suite/package.json
+++ b/packages/test-suite/package.json
@@ -56,7 +56,6 @@
 		"@vitest/coverage-v8": "^4.0.15",
 		"bignumber.js": "^9.3.1",
 		"json-bigint": "^1.0.0",
-		"sqlite3": "^5.1.7",
 		"timekeeper": "^2.3.1",
 		"vitest": "^4.0.15"
 	},


### PR DESCRIPTION
## What & why

Fixes #1940. The published `@keyv/sqlite` depended on `sqlite3@^5.1.7`, which pulled in a vulnerable dependency chain:

```
sqlite3@5.1.7 → node-gyp → make-fetch-happen → http-proxy-agent → @tootallnate/once   (GHSA-vpq2-c234-7xj6)
              → tar (node-tar ≤7.5.10)   (multiple high-severity advisories)
              → cacache
```

Per the maintainer's direction, this is a **non-breaking version bump — `sqlite3` is *not* swapped out** for another driver. It simply upgrades `sqlite3@^5.1.7 → ^6.0.1`.

`sqlite3@6.x` modernized its install model:
- `node-gyp` is now an **optional peer dependency** (`12.x`) instead of a hard dependency → the entire `node-gyp → make-fetch-happen → http-proxy-agent → @tootallnate/once` chain is gone, and real consumers don't auto-install it (it falls back to `prebuild-install` for prebuilt binaries).
- Its `tar` dependency (`^7.5.10`) resolves to a patched **`tar@7.5.16`** (> the vulnerable `≤7.5.10` range).

The `KeyvSqlite` API and behaviour are unchanged — the existing `sqlite3` callback code is a drop-in fit for `6.x`.

## Changes

- `packages/sqlite/package.json`: `sqlite3@^5.1.7 → ^6.0.1`; `engines.node` `>= 18 → >= 20.17.0` (see note below).
- `packages/test-suite/package.json`: **removed the unused `sqlite3` dependency** — it was never imported anywhere in `@keyv/test-suite`, and was the only other source of `sqlite3@5.1.7` in the workspace.

## Verification

- `pnpm audit --prod` → **No known vulnerabilities found.**
- After install, the workspace contains only `sqlite3@6.0.1` (no `5.1.7`); `@tootallnate/once`, `http-proxy-agent`, `make-fetch-happen`, and `cacache` are gone (62 packages removed). The only `node-gyp` present is the non-vulnerable `12.4.0` (advisory was `≤10.3.1`).
- `@keyv/sqlite` `test:ci`: lint clean, **57 tests pass, 100% coverage**; `tsup` CJS+ESM+DTS build succeeds.
- `@keyv/test-suite` `test:ci`: **100% coverage** (confirms the removed `sqlite3` was unused).
- `keyv` core ↔ `KeyvSqlite` integration: **59 tests pass**.

## One consequence to note

`sqlite3@6.x` requires **Node ≥20.17.0**, so `@keyv/sqlite`'s `engines.node` is raised from `>= 18` to match (otherwise the manifest would claim support it can't honor). Node 18 reached end-of-life in April 2025. If you'd prefer to keep the `>= 18` floor, the alternative is staying on `sqlite3@5.1.7` and forcing patched transitive deps via `pnpm.overrides` — happy to switch approaches if you want.

> Note: this PR targets `v5` (the line that produces today's npm `latest`, `@keyv/sqlite@4.0.8`). `main`/v6 already moved off the vulnerable chain separately.

https://claude.ai/code/session_016oFCwmsf8nRkFqY437Mcq7