### PR TITLE
mono - docs: fix broken keyv logo link in package READMEs

### DIFF
--- a/compression/compress-brotli/README.md
+++ b/compression/compress-brotli/README.md
@@ -1,4 +1,4 @@
-# @keyv/compress-brotli [<img width="100" align="right" src="https://jaredwray.com/images/keyv-symbol.svg" alt="keyv">](https://github.com/jaredwra/keyv)
+# @keyv/compress-brotli [<img width="100" align="right" src="https://jaredwray.com/images/keyv-symbol.svg" alt="keyv">](https://github.com/jaredwray/keyv)
 
 > Brotli compression for Keyv
 

--- a/compression/compress-gzip/README.md
+++ b/compression/compress-gzip/README.md
@@ -1,4 +1,4 @@
-# @keyv/compress-gzip [<img width="100" align="right" src="https://jaredwray.com/images/keyv-symbol.svg" alt="keyv">](https://github.com/jaredwra/keyv)
+# @keyv/compress-gzip [<img width="100" align="right" src="https://jaredwray.com/images/keyv-symbol.svg" alt="keyv">](https://github.com/jaredwray/keyv)
 
 > Gzip compression for Keyv
 

--- a/compression/compress-lz4/README.md
+++ b/compression/compress-lz4/README.md
@@ -1,4 +1,4 @@
-# @keyv/compress-lz4 [<img width="100" align="right" src="https://jaredwray.com/images/keyv-symbol.svg" alt="keyv">](https://github.com/jaredwra/keyv)
+# @keyv/compress-lz4 [<img width="100" align="right" src="https://jaredwray.com/images/keyv-symbol.svg" alt="keyv">](https://github.com/jaredwray/keyv)
 
 > lz4 compression for Keyv
 

--- a/core/bigmap/README.md
+++ b/core/bigmap/README.md
@@ -1,4 +1,4 @@
-# @keyv/bigmap [<img width="100" align="right" src="https://jaredwray.com/images/keyv-symbol.svg" alt="keyv">](https://github.com/jaredwra/keyv)
+# @keyv/bigmap [<img width="100" align="right" src="https://jaredwray.com/images/keyv-symbol.svg" alt="keyv">](https://github.com/jaredwray/keyv)
 
 > Bigmap for Keyv
 

--- a/core/test-suite/README.md
+++ b/core/test-suite/README.md
@@ -1,4 +1,4 @@
-# @keyv/test-suite [<img width="100" align="right" src="https://jaredwray.com/images/keyv-symbol.svg" alt="keyv">](https://github.com/jaredwra/keyv)
+# @keyv/test-suite [<img width="100" align="right" src="https://jaredwray.com/images/keyv-symbol.svg" alt="keyv">](https://github.com/jaredwray/keyv)
 
 > Test suite for Keyv API compliance
 

--- a/storage/mongo/README.md
+++ b/storage/mongo/README.md
@@ -1,4 +1,4 @@
-# @keyv/mongo [<img width="100" align="right" src="https://jaredwray.com/images/keyv-symbol.svg" alt="keyv">](https://github.com/jaredwra/keyv)
+# @keyv/mongo [<img width="100" align="right" src="https://jaredwray.com/images/keyv-symbol.svg" alt="keyv">](https://github.com/jaredwray/keyv)
 
 > MongoDB storage adapter for Keyv
 

--- a/storage/mysql/README.md
+++ b/storage/mysql/README.md
@@ -1,4 +1,4 @@
-# @keyv/mysql [<img width="100" align="right" src="https://jaredwray.com/images/keyv-symbol.svg" alt="keyv">](https://github.com/jaredwra/keyv)
+# @keyv/mysql [<img width="100" align="right" src="https://jaredwray.com/images/keyv-symbol.svg" alt="keyv">](https://github.com/jaredwray/keyv)
 
 > MySQL/MariaDB storage adapter for Keyv
 

--- a/storage/redis/README.md
+++ b/storage/redis/README.md
@@ -1,4 +1,4 @@
-# @keyv/redis [<img width="100" align="right" src="https://jaredwray.com/images/keyv-symbol.svg" alt="keyv">](https://github.com/jaredwra/keyv)
+# @keyv/redis [<img width="100" align="right" src="https://jaredwray.com/images/keyv-symbol.svg" alt="keyv">](https://github.com/jaredwray/keyv)
 
 > Redis storage adapter for Keyv
 

--- a/storage/valkey/README.md
+++ b/storage/valkey/README.md
@@ -1,4 +1,4 @@
-# @keyv/valkey [<img width="100" align="right" src="https://jaredwray.com/images/keyv-symbol.svg" alt="keyv">](https://github.com/jaredwra/keyv)
+# @keyv/valkey [<img width="100" align="right" src="https://jaredwray.com/images/keyv-symbol.svg" alt="keyv">](https://github.com/jaredwray/keyv)
 
 > Valkey storage adapter for Keyv
 


### PR DESCRIPTION
## What

The keyv logo in the header of several package READMEs linked to `https://github.com/jaredwra/keyv` — note the missing **"y"** in `jaredwray`. That URL returns a **404**. This fixes the typo to `https://github.com/jaredwray/keyv` (which returns 200) across all affected packages.

This was reported from the npm page for `@keyv/compress-brotli`, where the header logo appears broken.

## Affected files (9)

- `compression/compress-brotli/README.md`
- `compression/compress-gzip/README.md`
- `compression/compress-lz4/README.md`
- `core/bigmap/README.md`
- `core/test-suite/README.md`
- `storage/mongo/README.md`
- `storage/mysql/README.md`
- `storage/redis/README.md`
- `storage/valkey/README.md`

## Diff (representative)

```diff
-# @keyv/compress-brotli [`&lt;img ... src="https://jaredwray.com/images/keyv-symbol.svg" alt="keyv"&gt;`](https://github.com/jaredwra/keyv)
+# @keyv/compress-brotli [`&lt;img ... src="https://jaredwray.com/images/keyv-symbol.svg" alt="keyv"&gt;`](https://github.com/jaredwray/keyv)
```

## Note on the broken image *thumbnails* on npm

Separately from this link fix, the logo/`codecov`/`npm` **images** render as broken thumbnails on the npm package page. I verified every image URL in those READMEs returns **HTTP 200** with a valid `image/svg+xml` content type (logo, codecov badge, and both shields.io npm badges), so the broken display is npm's external-image proxy rather than a bad URL in the repo — not something this PR can change. The GitHub Actions build badge renders because it is served from `github.com`.

https://claude.ai/code/session_01QvPXbEJvqg8UcLhnGj8RQB

---
_Generated by [Claude Code](https://claude.ai/code/session_01QvPXbEJvqg8UcLhnGj8RQB)_