### PR TITLE
mono - chore: upgrade GitHub Actions (breaking)

### DIFF
--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -42,7 +42,7 @@ jobs:
         run: pnpm test:ci
 
       - name: Code Coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_KEY }}
           verbose: true

--- a/.github/workflows/deploy-website.yaml
+++ b/.github/workflows/deploy-website.yaml
@@ -36,10 +36,10 @@ jobs:
       run: pnpm website:build
 
     - name: Install Wrangler
-      run: pnpm add -Dw wrangler@3
+      run: pnpm add -Dw wrangler@4
 
     - name: Publish to Cloudflare Pages
-      uses: cloudflare/wrangler-action@v3
+      uses: cloudflare/wrangler-action@v4
       with:
         apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         command: pages deploy website/dist --project-name=keyv --branch=main


### PR DESCRIPTION
## Summary
Upgrades the GitHub Actions group (third dep-management PR, following #1944 and #1945). Only two of the six referenced actions were behind: both are major bumps, hence `(breaking)`.

## Versions
- `codecov/codecov-action` `v5` → `v7`
- `cloudflare/wrangler-action` `v3` → `v4`, plus the workflow's wrangler CLI pin `wrangler@3` → `wrangler@4` (script-installed tool travels with its action)

Already current via floating major tags (no change): `actions/checkout@v6` (latest v6.0.3), `actions/setup-node@v6` (v6.4.0), `pnpm/action-setup@v6` (v6.0.8), `oven-sh/setup-bun@v2` (v2.2.0). Pin style (`@vX`) preserved throughout.

## Checks
- [x] All 6 workflow YAMLs parse
- [x] `wrangler@4` (4.99.0) verified locally: `pages deploy [directory]` interface unchanged from v3
- [x] codecov-action v7 is exercised live by this PR's own CI (codecov.yaml runs on pull_request)
- [ ] `deploy-website.yaml` is release-triggered and uses secrets — not verifiable from PR CI; first real validation is the next release deploy

## Breaking notes
- **codecov-action v5 → v7**: v6 moved the action runtime to node24 (a runner-side change; ubuntu-latest supports it); v7 rotated release-signing to the `codecovsecops` account. The `token`/`verbose` inputs used here are unchanged.
- **wrangler-action v3 → v4**: defaults to wrangler CLI v4 when `wranglerVersion` is unset; inputs (`apiToken`, `command`) unchanged. The workflow's explicit `pnpm add -Dw wrangler@3` is bumped to `wrangler@4` to match — `wrangler pages deploy website/dist --project-name=keyv --branch=main` parses identically under wrangler 4.

https://claude.ai/code/session_01UbQQmCL4uni3MpdpSVyVqW

---
_Generated by [Claude Code](https://claude.ai/code/session_01UbQQmCL4uni3MpdpSVyVqW)_