### PR TITLE
test-suite - feat: allow storage TTL tests to specify milliseconds or seconds

### DIFF
--- a/core/test-suite/README.md
+++ b/core/test-suite/README.md
@@ -48,6 +48,49 @@ Set your test script in `package.json` to `vitest`.
 
 Take a look at [keyv/redis](https://github.com/jaredwray/keyv/tree/main/storage/redis) for an example of an existing storage adapter using `@keyv/test-suite`.
 
+## Storage Adapter Tests
+
+To test a storage adapter directly (without the `Keyv` wrapper), use `storageTestSuite`. It runs basic CRUD, batch, iterator, TTL, namespace, and disconnect tests against the adapter:
+
+```js
+import { it } from 'vitest';
+import { storageTestSuite } from '@keyv/test-suite';
+import KeyvStore from './';
+
+const store = () => new KeyvStore();
+storageTestSuite(it, store);
+```
+
+### Storage Test Options
+
+`storageTestSuite` (and the individual `storage*Tests` functions) accept an options object as the third argument:
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `missingValue` | `undefined \| null` | `undefined` | Value returned by `get()` for missing or expired keys |
+| `basic` | `boolean` | `true` | Enable basic CRUD tests (`set`/`get`/`delete`/`has`/`clear`) |
+| `batch` | `boolean` | `true` | Enable batch operation tests (`setMany`/`getMany`/`hasMany`/`deleteMany`) |
+| `iterator` | `boolean` | `true` | Enable iterator tests |
+| `ttl` | `boolean` | `true` | Enable TTL tests |
+| `ttlGranularity` | `'milliseconds' \| 'seconds'` | `'milliseconds'` | TTL granularity used by the TTL tests |
+| `namespace` | `boolean` | `true` | Enable namespace getter/setter test |
+| `disconnect` | `boolean` | `true` | Enable disconnect test |
+
+### TTL Granularity
+
+By default the TTL tests use sub-second TTL values (100ms TTL with a 200ms expiry wait). Storage backends such as etcd (leases) and DynamoDB only support TTLs at second-level resolution, so they can't honor sub-second TTLs. For those adapters, set `ttlGranularity: 'seconds'` and the TTL tests will use second-scale values instead (1 second TTL with a 3 second expiry wait):
+
+```js
+import { it } from 'vitest';
+import { storageTestSuite } from '@keyv/test-suite';
+import KeyvStore from './';
+
+const store = () => new KeyvStore();
+storageTestSuite(it, store, { ttlGranularity: 'seconds' });
+```
+
+Use `ttl: false` only when the adapter has no storage-level TTL support at all.
+
 ## Testing Compression Adapters
 
 If you're testing a compression adapter, you can use the `keyvCompressionTests` method instead of `keyvTestSuite`.

--- a/core/test-suite/src/storage-ttl.ts
+++ b/core/test-suite/src/storage-ttl.ts
@@ -5,9 +5,11 @@ import type { StorageFn, StorageTestOptions, TestFunction } from "./types.js";
 /**
  * Registers TTL expiration tests directly on the storage adapter: set with TTL,
  * has after expiry, and setMany with per-entry TTL. Skipped if `options.ttl` is `false`.
+ * Set `options.ttlGranularity` to "seconds" for backends that only support
+ * second-level TTLs (e.g. etcd leases, DynamoDB TTL) so second-scale values are used.
  * @param test - The test registration function (e.g. vitest `it`)
  * @param store - Factory that returns a fresh {@link KeyvStorageAdapter} instance
- * @param options - Test configuration (missingValue, toggle flags)
+ * @param options - Test configuration (missingValue, ttlGranularity, toggle flags)
  */
 const storageTtlTests = (test: TestFunction, store: StorageFn, options?: StorageTestOptions) => {
 	/* v8 ignore next 3 -- @preserve */
@@ -16,22 +18,25 @@ const storageTtlTests = (test: TestFunction, store: StorageFn, options?: Storage
 	}
 
 	const missingValue = options?.missingValue;
+	const seconds = options?.ttlGranularity === "seconds";
+	const ttl = seconds ? 1000 : 100;
+	const expiryDelay = seconds ? 3000 : 200;
 
 	test("set(key, value, ttl) expires after TTL", async (t) => {
 		const s = store();
 		const key = faker.string.alphanumeric(10);
 		const value = faker.lorem.word();
-		await s.set(key, value, 100);
+		await s.set(key, value, ttl);
 		t.expect(await s.get(key)).toBe(value);
-		await delay(200);
+		await delay(expiryDelay);
 		t.expect(await s.get(key)).toBe(missingValue);
 	});
 
 	test("has(key) returns false for expired key", async (t) => {
 		const s = store();
 		const key = faker.string.alphanumeric(10);
-		await s.set(key, faker.lorem.word(), 100);
-		await delay(200);
+		await s.set(key, faker.lorem.word(), ttl);
+		await delay(expiryDelay);
 		t.expect(await s.has(key)).toBe(false);
 	});
 
@@ -42,12 +47,12 @@ const storageTtlTests = (test: TestFunction, store: StorageFn, options?: Storage
 		const val1 = faker.lorem.word();
 		const val2 = faker.lorem.word();
 		await s.setMany([
-			{ key: key1, value: val1, ttl: 100 },
+			{ key: key1, value: val1, ttl },
 			{ key: key2, value: val2 },
 		]);
 		t.expect(await s.get(key1)).toBe(val1);
 		t.expect(await s.get(key2)).toBe(val2);
-		await delay(200);
+		await delay(expiryDelay);
 		t.expect(await s.get(key1)).toBe(missingValue);
 		t.expect(await s.get(key2)).toBe(val2);
 	});

--- a/core/test-suite/src/types.ts
+++ b/core/test-suite/src/types.ts
@@ -32,6 +32,12 @@ export type StorageTestOptions = {
 	iterator?: boolean;
 	/** Enable TTL tests. Default: true */
 	ttl?: boolean;
+	/**
+	 * TTL granularity used by the TTL tests. Use "seconds" for backends that only
+	 * support second-level TTLs (e.g. etcd leases, DynamoDB TTL), which makes the
+	 * tests use second-scale TTL values and waits. Default: "milliseconds"
+	 */
+	ttlGranularity?: "milliseconds" | "seconds";
 	/** Enable namespace getter/setter test. Default: true */
 	namespace?: boolean;
 	/** Enable disconnect test. Default: true */

--- a/core/test-suite/test/unit.ts
+++ b/core/test-suite/test/unit.ts
@@ -9,6 +9,7 @@ import {
 	keyvTestSuite,
 	serializationTestSuite,
 	storageTestSuite,
+	storageTtlTests,
 } from "../src/index.js";
 
 const storeExtended = () => {
@@ -24,6 +25,9 @@ compressionTestSuite(it, new KeyvLz4TestAdapter());
 // Storage-level tests using KeyvMemoryAdapter
 const memoryStore = () => new KeyvMemoryAdapter(new Map());
 storageTestSuite(it, memoryStore);
+
+// TTL tests at second granularity (used by stores like etcd and DynamoDB)
+storageTtlTests(it, memoryStore, { ttlGranularity: "seconds" });
 
 // Serialization tests using built-in JSON serializer
 serializationTestSuite(it, new KeyvJsonSerializer());

--- a/storage/dynamo/test/test.ts
+++ b/storage/dynamo/test/test.ts
@@ -19,7 +19,7 @@ const keyvDynamodb = new KeyvDynamo({
 const store = () => new KeyvDynamo({ endpoint: dynamoURL, tableName: faker.string.uuid() });
 
 keyvTestSuite(it, Keyv, store);
-storageTestSuite(it, store, { iterator: false, ttl: false });
+storageTestSuite(it, store, { iterator: false, ttlGranularity: "seconds" });
 
 beforeEach(async () => {
 	const keyv = store();

--- a/storage/etcd/test/test.ts
+++ b/storage/etcd/test/test.ts
@@ -11,7 +11,7 @@ const store = () => new KeyvEtcd({ uri: etcdUrl, busyTimeout: 3000 });
 
 keyvTestSuite(it, Keyv, store);
 keyvIteratorTests(it, Keyv, store);
-storageTestSuite(it, store, { missingValue: null, batch: false });
+storageTestSuite(it, store, { missingValue: null, batch: false, ttlGranularity: "seconds" });
 
 it("default options", (t) => {
 	const store = new KeyvEtcd();


### PR DESCRIPTION
## Summary

The storage-level TTL tests in `@keyv/test-suite` hard-coded sub-second values (`ttl: 100` with a 200ms wait), which backends with second-granularity TTLs can't genuinely honor:

- **etcd**: leases are seconds with a 1s minimum (`Math.max(ttl / 1000, 1)`), so the tests only passed via the adapter's millisecond-precision client-side envelope fallback — real lease expiry was never exercised.
- **DynamoDB**: native TTL is seconds (and lazy), so the suite TTL tests were skipped entirely (`ttl: false`) in favor of custom tests.

This adds a `ttlGranularity` option (`"milliseconds" | "seconds"`, default `"milliseconds"`) to `StorageTestOptions`. In seconds mode, the TTL tests use a 1000ms TTL with a 3000ms expiry wait (matching the pattern already used by etcd's own TTL tests), staying under vitest's 5s default test timeout.

## Changes

- `core/test-suite/src/types.ts`: new `ttlGranularity` option on `StorageTestOptions`
- `core/test-suite/src/storage-ttl.ts`: TTL values and expiry waits scale with the granularity
- `core/test-suite/test/unit.ts`: seconds-mode TTL run against the memory adapter (keeps branch coverage at 100%)
- `core/test-suite/README.md`: documents `storageTestSuite`, its options, and the new `ttlGranularity` option
- `storage/etcd/test/test.ts`: opts into `ttlGranularity: "seconds"` so the tests exercise real lease-scale expiry
- `storage/dynamo/test/test.ts`: re-enables the shared TTL tests (previously `ttl: false`) at seconds granularity — works because the adapter's `get`/`has`/`getMany`/`hasMany` honor expiry client-side via `expiresAtMs`

Out of scope: memcache (also second-granularity via `Math.ceil` but passes today via envelope checks; can adopt the option later) and postgres/sqlite/mysql (keep `ttl: false` — no storage-level TTL support).

## Testing

- `core/test-suite`: 91 tests pass with 100% statement/branch/function/line coverage, biome clean
- etcd/dynamo integration tests require Docker services, which aren't available in this environment — covered by CI (all checks green on the initial push)

https://claude.ai/code/session_01CLTZc164iyxRgDRCiPd62o