### PR TITLE
memcache - chore: upgrade memcache

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -396,8 +396,8 @@ importers:
         specifier: workspace:^
         version: link:../../core/keyv
       memcache:
-        specifier: ^1.4.0
-        version: 1.4.0
+        specifier: ^1.7.0
+        version: 1.7.0
     devDependencies:
       '@keyv/compress-gzip':
         specifier: workspace:^
@@ -3069,8 +3069,8 @@ packages:
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
-  memcache@1.4.0:
-    resolution: {integrity: sha512-rxvbw4H5F8eiHpGyP7nsz0xwy33sFpPNlyDho1P7Dj31llHrE5MzF7uqImXOp9T+DSGRmib26Q60SsrTZfUBgw==}
+  memcache@1.7.0:
+    resolution: {integrity: sha512-rGmUvvjb1gavZWldGT/EsouB8Z+GFgxbwZ7CeEsvi9YRphA8jdOWE6tvbTC22AOSBvce8AXu0L92q13djNH/2g==}
 
   memory-pager@1.5.0:
     resolution: {integrity: sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==}
@@ -4913,7 +4913,7 @@ snapshots:
 
   '@keyv/bigmap@1.3.1(keyv@5.6.0)':
     dependencies:
-      hashery: 1.5.0
+      hashery: 1.5.1
       hookified: 1.15.1
       keyv: 5.6.0
 
@@ -6678,9 +6678,10 @@ snapshots:
 
   mdurl@2.0.0: {}
 
-  memcache@1.4.0:
+  memcache@1.7.0:
     dependencies:
-      hookified: 1.15.1
+      hashery: 2.0.0
+      hookified: 2.2.0
 
   memory-pager@1.5.0: {}
 

--- a/storage/memcache/package.json
+++ b/storage/memcache/package.json
@@ -50,7 +50,7 @@
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
 		"hookified": "^2.0.0",
-		"memcache": "^1.4.0"
+		"memcache": "^1.7.0"
 	},
 	"peerDependencies": {
 		"keyv": "workspace:^"


### PR DESCRIPTION
## Summary
Runtime-phase driver bump for @keyv/memcache (following #1948).

## Versions
- `memcache` `1.4.0` → `1.7.0`

## Tests
- [x] `pnpm build` passes
- [x] `pnpm lint:ci` passes
- [ ] memcache integration tests run in CI against the memcached service — no Docker in this sandbox

## Remaining runtime-phase queue
mongodb → mysql2 → pg (minors) → `@redis/client` 6 (major) → bignumber.js 11, hashery 2, hookified 3, msgpackr 2 (majors, individually) → Docker service images in `scripts/`

https://claude.ai/code/session_01UbQQmCL4uni3MpdpSVyVqW

---
_Generated by [Claude Code](https://claude.ai/code/session_01UbQQmCL4uni3MpdpSVyVqW)_