### PR TITLE
redis - chore: upgrade @redis/client to v6 (breaking)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -517,8 +517,8 @@ importers:
   storage/redis:
     dependencies:
       '@redis/client':
-        specifier: ^5.10.0
-        version: 5.10.0
+        specifier: ^6.0.0
+        version: 6.0.0(@opentelemetry/api@1.9.1)
       cluster-key-slot:
         specifier: ^1.1.2
         version: 1.1.2
@@ -1436,9 +1436,17 @@ packages:
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
 
-  '@redis/client@5.10.0':
-    resolution: {integrity: sha512-JXmM4XCoso6C75Mr3lhKA3eNxSzkYi3nCzxDIKY+YOszYsJjuKbFgVtguVPbLMOttN4iu2fXoc2BGhdnYhIOxA==}
-    engines: {node: '>= 18'}
+  '@redis/client@6.0.0':
+    resolution: {integrity: sha512-NS4iIT25r24sAjNQ2nSRdCW5jPJoV0rxkBee27oTeR+RXaOu89cjIsrww5rPBaYVGVdL1QCx9uz9141gZiSKdQ==}
+    engines: {node: '>= 20.0.0'}
+    peerDependencies:
+      '@node-rs/xxhash': ^1.1.0
+      '@opentelemetry/api': '>=1 <2'
+    peerDependenciesMeta:
+      '@node-rs/xxhash':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
 
   '@rolldown/binding-android-arm64@1.0.0-rc.12':
     resolution: {integrity: sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==}
@@ -5001,9 +5009,11 @@ snapshots:
     dependencies:
       quansync: 1.0.0
 
-  '@redis/client@5.10.0':
+  '@redis/client@6.0.0(@opentelemetry/api@1.9.1)':
     dependencies:
       cluster-key-slot: 1.1.2
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
 
   '@rolldown/binding-android-arm64@1.0.0-rc.12':
     optional: true

--- a/storage/redis/package.json
+++ b/storage/redis/package.json
@@ -49,7 +49,7 @@
 	},
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
-		"@redis/client": "^5.10.0",
+		"@redis/client": "^6.0.0",
 		"cluster-key-slot": "^1.1.2",
 		"hookified": "^2.0.0"
 	},


### PR DESCRIPTION
## Summary
First major of the runtime phase: upgrades @keyv/redis's `@redis/client` to v6 (following #1953).

## Versions
- `@redis/client` `5.10.0` → `6.0.0`

## Breaking notes
node-redis v6 changes, mapped against KeyvRedis's actual API surface:
- **RESP3 is now the protocol default** (was RESP2). The reply-shape changes are confined to geo/CF/stream/search commands — KeyvRedis uses none of them; GET/SET/MGET/EXISTS/DEL/UNLINK/SCAN/FLUSHDB/MULTI are shape-stable across protocols. CI's standalone + cluster + sentinel integration tests exercise the new protocol end-to-end.
- **Removed options**: `unstableResp3*` gates and Sentinel `commandOptions` — verified unused in `storage/redis/src` (zero matches).
- **New defaults**: `commandTimeout` 5 s (was unset), `keepAliveInitialDelay` 30 s (was 5 s), `maintNotifications: "auto"`. Upstream behavior changes that flow through to adapter users; nothing overridden.
- **Node ≥ 20 required** — repo engines are `>= 22.18.0`.

Reference: node-redis v5→v6 migration guide (`docs/v5-to-v6.md`).

## Tests
- [x] `pnpm build` passes (v6 type surface compiles clean — `RedisClientType`/`RedisClientOptions`/cluster/sentinel types unchanged for our usage)
- [x] `pnpm lint:ci` passes
- [ ] redis standalone/cluster/sentinel integration tests run in CI — no Docker in this sandbox

## Remaining runtime-phase queue
bignumber.js 11, hashery 2, hookified 3, msgpackr 2 (majors, individually) → Docker service images in `scripts/`

https://claude.ai/code/session_01UbQQmCL4uni3MpdpSVyVqW

---
_Generated by [Claude Code](https://claude.ai/code/session_01UbQQmCL4uni3MpdpSVyVqW)_