### PR TITLE
test-suite - chore: upgrade bignumber.js to v11 (breaking)

### DIFF
--- a/core/test-suite/package.json
+++ b/core/test-suite/package.json
@@ -57,7 +57,7 @@
 	"dependencies": {
 		"@faker-js/faker": "^10.4.0",
 		"@vitest/coverage-v8": "^4.1.8",
-		"bignumber.js": "^9.3.1",
+		"bignumber.js": "^11.1.3",
 		"json-bigint": "^1.0.0",
 		"timekeeper": "^2.3.1",
 		"vitest": "^4.1.8"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -218,8 +218,8 @@ importers:
         specifier: ^4.1.8
         version: 4.1.8(vitest@4.1.8)
       bignumber.js:
-        specifier: ^9.3.1
-        version: 9.3.1
+        specifier: ^11.1.3
+        version: 11.1.3
       json-bigint:
         specifier: ^1.0.0
         version: 1.0.0
@@ -2103,6 +2103,9 @@ packages:
   better-sqlite3@12.10.0:
     resolution: {integrity: sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==}
     engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x || 26.x}
+
+  bignumber.js@11.1.3:
+    resolution: {integrity: sha512-+esZiNSo6VgFokTsYX6mYqNJfFd/IczzZCd4Z7cR8e+AQWhvIcj6nqQ1h9814D9u/TApU0jjTVmfWL0Pd1ZBdA==}
 
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
@@ -5505,6 +5508,8 @@ snapshots:
     dependencies:
       bindings: 1.5.0
       prebuild-install: 7.1.2
+
+  bignumber.js@11.1.3: {}
 
   bignumber.js@9.3.1: {}
 


### PR DESCRIPTION
## Summary
Runtime-phase major: upgrades @keyv/test-suite's `bignumber.js` two majors (following #1954).

## Versions
- `bignumber.js` `9.3.1` → `11.1.3`

## Breaking notes
- **v10** (Feb 2026): targeted ESM/CJS/browser builds; removed `BigNumber.DEBUG`; constructor no longer calls `toString` on arbitrary objects.
- **v11** (Apr 2026): `STRICT` config (default `true` — throws on invalid input); base-parameter tightening; new `toBigInt`/`fromFormat`.
- The suite's only usage is `BigNumber(BigInt(...)).toString()` in `src/values.ts` — verified directly that v11 accepts BigInt input natively (`BigNumber(BigInt("9223372036854775807")).toString()` → correct value, no throw). No code changes needed.
- 11.1.3 published 2026-06-05, past the 4-day `minimumReleaseAge` gate.

## Tests
- [x] `pnpm build` passes (test-suite, ESM+CJS outputs against v11's new build targets)
- [x] test-suite `test:ci` passes locally (100% lines)
- [x] keyv core `test:ci` passes locally (consumes the values tests)
- [ ] Adapter suites re-run the shared values tests against services in CI

## Remaining runtime-phase queue
hashery 2, hookified 3, msgpackr 2 (majors, individually) → Docker service images in `scripts/`

https://claude.ai/code/session_01UbQQmCL4uni3MpdpSVyVqW

---
_Generated by [Claude Code](https://claude.ai/code/session_01UbQQmCL4uni3MpdpSVyVqW)_