### PR TITLE
bigmap - chore: upgrade hashery to v2 (breaking)

### DIFF
--- a/core/bigmap/package.json
+++ b/core/bigmap/package.json
@@ -48,7 +48,7 @@
 	},
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
-		"hashery": "^1.5.0",
+		"hashery": "^2.0.0",
 		"hookified": "^2.0.0"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,8 +129,8 @@ importers:
   core/bigmap:
     dependencies:
       hashery:
-        specifier: ^1.5.0
-        version: 1.5.0
+        specifier: ^2.0.0
+        version: 2.0.0
       hookified:
         specifier: ^2.0.0
         version: 2.0.1
@@ -2626,10 +2626,6 @@ packages:
   has-tostringtag@1.0.2:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
-
-  hashery@1.5.0:
-    resolution: {integrity: sha512-nhQ6ExaOIqti2FDWoEMWARUqIKyjr2VcZzXShrI+A3zpeiuPWzx6iPftt44LhP74E5sW36B75N6VHbvRtpvO6Q==}
-    engines: {node: '>=20'}
 
   hashery@1.5.1:
     resolution: {integrity: sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==}
@@ -6071,10 +6067,6 @@ snapshots:
   has-tostringtag@1.0.2:
     dependencies:
       has-symbols: 1.1.0
-
-  hashery@1.5.0:
-    dependencies:
-      hookified: 1.15.1
 
   hashery@1.5.1:
     dependencies:


### PR DESCRIPTION
## Summary
Runtime-phase major: upgrades @keyv/bigmap's `hashery` to v2 (following #1955).

## Versions
- `hashery` `1.5.0` → `2.0.0`

## Breaking notes
- hashery v2's breaking change is its adoption of **hookified 2** (`^2.1.1`) — the same major @keyv/bigmap already depends on, so the `export { Hashery } from "hashery"` re-export (bigmap's only integration point) stays type-aligned with the rest of the package.
- Node ≥ 20 required — repo engines are `>= 22.18.0`.
- 2.0.0 published 2026-04-08, well past the release-age gate.

## Tests
- [x] `pnpm build` passes
- [x] bigmap `test:ci` passes locally (100% functions/lines — bigmap needs no services)

## Remaining runtime-phase queue
hookified 3 (core keyv dep) → msgpackr 2 → Docker service images in `scripts/`

https://claude.ai/code/session_01UbQQmCL4uni3MpdpSVyVqW

---
_Generated by [Claude Code](https://claude.ai/code/session_01UbQQmCL4uni3MpdpSVyVqW)_