### PR TITLE
mono - chore: upgrade hookified to v3 (breaking)

### DIFF
--- a/core/bigmap/package.json
+++ b/core/bigmap/package.json
@@ -49,7 +49,7 @@
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
 		"hashery": "^2.0.0",
-		"hookified": "^2.0.0"
+		"hookified": "^3.0.0"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.4.16",

--- a/core/keyv/package.json
+++ b/core/keyv/package.json
@@ -59,7 +59,7 @@
 	},
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
-		"hookified": "^2.0.1"
+		"hookified": "^3.0.0"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.4.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,8 +132,8 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0
       hookified:
-        specifier: ^2.0.0
-        version: 2.0.1
+        specifier: ^3.0.0
+        version: 3.0.0
       keyv:
         specifier: workspace:^
         version: link:../keyv
@@ -169,8 +169,8 @@ importers:
   core/keyv:
     dependencies:
       hookified:
-        specifier: ^2.0.1
-        version: 2.0.1
+        specifier: ^3.0.0
+        version: 3.0.0
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.4.16
@@ -364,8 +364,8 @@ importers:
         specifier: ^3.1063.0
         version: 3.1063.0(@aws-sdk/client-dynamodb@3.1063.0)
       hookified:
-        specifier: ^2.0.0
-        version: 2.0.1
+        specifier: ^3.0.0
+        version: 3.0.0
       keyv:
         specifier: workspace:^
         version: link:../../core/keyv
@@ -377,8 +377,8 @@ importers:
   storage/etcd:
     dependencies:
       hookified:
-        specifier: ^2.0.0
-        version: 2.0.1
+        specifier: ^3.0.0
+        version: 3.0.0
       keyv:
         specifier: workspace:^
         version: link:../../core/keyv
@@ -390,8 +390,8 @@ importers:
   storage/memcache:
     dependencies:
       hookified:
-        specifier: ^2.0.0
-        version: 2.0.1
+        specifier: ^3.0.0
+        version: 3.0.0
       keyv:
         specifier: workspace:^
         version: link:../../core/keyv
@@ -409,8 +409,8 @@ importers:
   storage/mongo:
     dependencies:
       hookified:
-        specifier: ^2.0.0
-        version: 2.0.1
+        specifier: ^3.0.0
+        version: 3.0.0
       keyv:
         specifier: workspace:^
         version: link:../../core/keyv
@@ -443,8 +443,8 @@ importers:
   storage/mysql:
     dependencies:
       hookified:
-        specifier: ^2.0.0
-        version: 2.0.1
+        specifier: ^3.0.0
+        version: 3.0.0
       mysql2:
         specifier: ^3.22.5
         version: 3.22.5(@types/node@24.13.1)
@@ -480,8 +480,8 @@ importers:
   storage/postgres:
     dependencies:
       hookified:
-        specifier: ^2.0.0
-        version: 2.0.1
+        specifier: ^3.0.0
+        version: 3.0.0
       keyv:
         specifier: workspace:^
         version: link:../../core/keyv
@@ -523,8 +523,8 @@ importers:
         specifier: ^1.1.2
         version: 1.1.2
       hookified:
-        specifier: ^2.0.0
-        version: 2.0.1
+        specifier: ^3.0.0
+        version: 3.0.0
       keyv:
         specifier: workspace:^
         version: link:../../core/keyv
@@ -542,8 +542,8 @@ importers:
         specifier: ^12.10.0
         version: 12.10.0
       hookified:
-        specifier: ^2.0.0
-        version: 2.0.1
+        specifier: ^3.0.0
+        version: 3.0.0
       keyv:
         specifier: workspace:^
         version: link:../../core/keyv
@@ -570,8 +570,8 @@ importers:
         specifier: ^1.1.0
         version: 1.1.2
       hookified:
-        specifier: ^2.0.0
-        version: 2.0.1
+        specifier: ^3.0.0
+        version: 3.0.0
       iovalkey:
         specifier: ^0.3.3
         version: 0.3.3
@@ -2691,11 +2691,12 @@ packages:
   hookified@1.15.1:
     resolution: {integrity: sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==}
 
-  hookified@2.0.1:
-    resolution: {integrity: sha512-rCuuGZ7qae0+C0ySqe8nRj8JJ5/6zym5YBs19iga9ju+ubLELkgpvnfi4A6NP8Aow7mCxfCqyAAbkj9QqyEXRg==}
-
   hookified@2.2.0:
     resolution: {integrity: sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==}
+
+  hookified@3.0.0:
+    resolution: {integrity: sha512-x+jzDjd9CWxdgl6u/K4pjnvw7PZx6ZSpiPGAV43uXlJiJy7r2jIEUxxU1Cv7+rwy1GK5Qt5S+Jp7n81DpcUvTA==}
+    engines: {node: '>=22.18.0'}
 
   hosted-git-info@2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
@@ -6194,9 +6195,9 @@ snapshots:
 
   hookified@1.15.1: {}
 
-  hookified@2.0.1: {}
-
   hookified@2.2.0: {}
+
+  hookified@3.0.0: {}
 
   hosted-git-info@2.8.9: {}
 

--- a/storage/dynamo/package.json
+++ b/storage/dynamo/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.1063.0",
     "@aws-sdk/lib-dynamodb": "^3.1063.0",
-    "hookified": "^2.0.0"
+    "hookified": "^3.0.0"
   },
   "devDependencies": {
     "@keyv/test-suite": "workspace:^"

--- a/storage/etcd/package.json
+++ b/storage/etcd/package.json
@@ -49,7 +49,7 @@
 	},
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
-		"hookified": "^2.0.0"
+		"hookified": "^3.0.0"
 	},
 	"devDependencies": {
 		"@keyv/test-suite": "workspace:^"

--- a/storage/memcache/package.json
+++ b/storage/memcache/package.json
@@ -49,7 +49,7 @@
 	},
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
-		"hookified": "^2.0.0",
+		"hookified": "^3.0.0",
 		"memcache": "^1.7.0"
 	},
 	"peerDependencies": {

--- a/storage/mongo/package.json
+++ b/storage/mongo/package.json
@@ -50,7 +50,7 @@
 	},
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
-		"hookified": "^2.0.0",
+		"hookified": "^3.0.0",
 		"mongodb": "^7.2.0"
 	},
 	"devDependencies": {

--- a/storage/mysql/package.json
+++ b/storage/mysql/package.json
@@ -51,7 +51,7 @@
 	},
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
-		"hookified": "^2.0.0",
+		"hookified": "^3.0.0",
 		"mysql2": "^3.22.5"
 	},
 	"devDependencies": {

--- a/storage/postgres/package.json
+++ b/storage/postgres/package.json
@@ -51,7 +51,7 @@
 	},
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
-		"hookified": "^2.0.0",
+		"hookified": "^3.0.0",
 		"pg": "^8.21.0"
 	},
 	"peerDependencies": {

--- a/storage/redis/package.json
+++ b/storage/redis/package.json
@@ -51,7 +51,7 @@
 	"dependencies": {
 		"@redis/client": "^6.0.0",
 		"cluster-key-slot": "^1.1.2",
-		"hookified": "^2.0.0"
+		"hookified": "^3.0.0"
 	},
 	"peerDependencies": {
 		"keyv": "workspace:^"

--- a/storage/sqlite/package.json
+++ b/storage/sqlite/package.json
@@ -53,7 +53,7 @@
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
 		"better-sqlite3": "^12.10.0",
-		"hookified": "^2.0.0"
+		"hookified": "^3.0.0"
 	},
 	"peerDependencies": {
 		"keyv": "workspace:^"

--- a/storage/valkey/package.json
+++ b/storage/valkey/package.json
@@ -54,7 +54,7 @@
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
 		"cluster-key-slot": "^1.1.0",
-		"hookified": "^2.0.0",
+		"hookified": "^3.0.0",
 		"iovalkey": "^0.3.3"
 	},
 	"devDependencies": {


### PR DESCRIPTION
## Summary
The highest-blast-radius major of the runtime phase: upgrades `hookified` to v3 in keyv core, bigmap, and all nine storage adapters that extend `Hookified` (following #1956).

## Versions
- `hookified` `^2.0.x` → `^3.0.0` in: keyv, @keyv/bigmap, @keyv/dynamo, @keyv/etcd, @keyv/memcache, @keyv/mongo, @keyv/mysql, @keyv/postgres, @keyv/redis, @keyv/sqlite, @keyv/valkey

## Breaking notes
- hookified v3's breaking change is the **Node ≥ 22.18.0 floor** (drops Node 20) — identical to the engines this repo's packages already declare since #1945, so consumers' compatibility surface is unchanged.
- **No Hookified class API changes** in v3 (release notes are tooling/infra otherwise). The workspace's entire usage surface — `extends Hookified` (13 classes), `.emit()` (79 call sites), `.on()` (21), `.hook()` (6), `.off()` (1) — verified untouched.
- @keyv/bigmap now carries hookified 3 directly while its `hashery` dependency (v2, from #1956) uses hookified 2 internally — distinct, non-cross-assigned class identities; builds and tests confirm no type conflicts.
- 3.0.0 published 2026-05-24, past the release-age gate.

## Tests
- [x] `pnpm build` passes (all packages, keyv first)
- [x] `pnpm -r lint:ci` passes (all 19 packages)
- [x] `test:ci` passes locally for all 11 non-service packages: keyv, bigmap, test-suite, msgpackr, superjson, sqlite, compression ×3, encryption ×2
- [ ] Service-backed adapter suites (redis, mongo, mysql, postgres, valkey, etcd, memcache, dynamo) run in CI — no Docker in this sandbox

## Remaining runtime-phase queue
msgpackr 2 → Docker service images in `scripts/`

https://claude.ai/code/session_01UbQQmCL4uni3MpdpSVyVqW

---
_Generated by [Claude Code](https://claude.ai/code/session_01UbQQmCL4uni3MpdpSVyVqW)_