### PR TITLE
etcd - chore: upgrade etcd test-service image to 3.6.12 (breaking)

### DIFF
--- a/scripts/docker-compose-arm64.yaml
+++ b/scripts/docker-compose-arm64.yaml
@@ -88,7 +88,7 @@ services:
     ports:
       - "11211:11211"
   keyv_etcd:
-    image: registry.k8s.io/etcd:3.5.15-0
+    image: registry.k8s.io/etcd:3.6.12-0
     platform: linux/arm64/v8
     command:
       - etcd

--- a/scripts/docker-compose.yaml
+++ b/scripts/docker-compose.yaml
@@ -88,7 +88,7 @@ services:
     ports:
       - "11211:11211"
   keyv_etcd:
-    image: registry.k8s.io/etcd:3.5.15-0
+    image: registry.k8s.io/etcd:3.6.12-0
     command:
       - etcd
       - --listen-client-urls=http://0.0.0.0:2379


### PR DESCRIPTION
## Summary
Final dep-management PR: upgrades the only pinned test-service image, etcd, to the newest release line (per maintainer direction on the floating-tags question).

## Images
- `registry.k8s.io/etcd` `3.5.15-0` → `3.6.12-0`

## Locations
- `scripts/docker-compose.yaml:91` — service `keyv_etcd`
- `scripts/docker-compose-arm64.yaml:91` — service `keyv_etcd`

## Checks
- [x] All four compose files parse
- [x] No official etcd image publishes a floating `latest` tag (verified against registry.k8s.io, gcr.io/etcd-development, and quay.io/coreos — all version-tagged only), so per maintainer direction this pins to the newest line instead; future dep-management runs refresh it
- [x] The `keyv_etcd` service config (plain `etcd` binary + CLI flags) is unchanged between 3.5 and 3.6 images
- [ ] No Docker in this sandbox — this PR's CI run pulls 3.6.12-0 and runs the @keyv/etcd integration suite against it, which is the real verification

## Breaking notes
etcd treats minor lines (3.5 → 3.6) as upgrade boundaries with storage-format changes — irrelevant for ephemeral test containers that start fresh each CI run. The `etcd3` JS client used by @keyv/etcd supports both lines.

All other service images (redis, postgres, mysql, mongo, memcached, valkey, dynamodb-local) deliberately stay on floating `:latest` per maintainer preference — CI continuously tests keyv against current service releases.

https://claude.ai/code/session_01UbQQmCL4uni3MpdpSVyVqW

---
_Generated by [Claude Code](https://claude.ai/code/session_01UbQQmCL4uni3MpdpSVyVqW)_