### PR TITLE
etcd - fix: support grpc-gateway v2 error format for etcd 3.6 compatibility

### DIFF
--- a/scripts/docker-compose-arm64.yaml
+++ b/scripts/docker-compose-arm64.yaml
@@ -88,7 +88,7 @@ services:
     ports:
       - "11211:11211"
   keyv_etcd:
-    image: registry.k8s.io/etcd:3.5.15-0
+    image: registry.k8s.io/etcd:3.6.12-0
     platform: linux/arm64/v8
     command:
       - etcd

--- a/scripts/docker-compose.yaml
+++ b/scripts/docker-compose.yaml
@@ -88,7 +88,7 @@ services:
     ports:
       - "11211:11211"
   keyv_etcd:
-    image: registry.k8s.io/etcd:3.5.15-0
+    image: registry.k8s.io/etcd:3.6.12-0
     command:
       - etcd
       - --listen-client-urls=http://0.0.0.0:2379

--- a/storage/etcd/src/client.ts
+++ b/storage/etcd/src/client.ts
@@ -126,13 +126,18 @@ export class EtcdClient {
 		/* v8 ignore next -- @preserve */
 		if (!response.ok) {
 			let errMessage = `etcd request failed: ${response.status} ${response.statusText}`;
-			if (
-				typeof parsed === "object" &&
-				parsed !== null &&
-				"error" in parsed &&
-				typeof (parsed as { error: unknown }).error === "string"
-			) {
-				errMessage = (parsed as { error: string }).error;
+			if (typeof parsed === "object" && parsed !== null) {
+				// etcd <3.6 returns a top-level `error` string. etcd >=3.6 upgraded its
+				// JSON gateway to grpc-gateway v2, which dropped the `error` field and
+				// surfaces failures as a google.rpc.Status with a `message` field
+				// instead. Read whichever the server provides so the real error text is
+				// preserved across all etcd versions.
+				const status = parsed as { error?: unknown; message?: unknown };
+				if (typeof status.error === "string") {
+					errMessage = status.error;
+				} else if (typeof status.message === "string") {
+					errMessage = status.message;
+				}
 			}
 			throw new Error(errMessage);
 		}

--- a/storage/etcd/test/test.ts
+++ b/storage/etcd/test/test.ts
@@ -1,7 +1,7 @@
 import { faker } from "@faker-js/faker";
 import { keyvIteratorTests, keyvTestSuite, storageTestSuite } from "@keyv/test-suite";
 import { Keyv } from "keyv";
-import { it } from "vitest";
+import { expect, it } from "vitest";
 import { EtcdClient, prefixEnd } from "../src/client.js";
 import KeyvEtcd, { createKeyv } from "../src/index.js";
 
@@ -470,6 +470,47 @@ it("EtcdClient surfaces error responses from etcd", async (t) => {
 	}
 	t.expect(error).toBeDefined();
 	t.expect(error?.message).toMatch(/lease/i);
+});
+
+// etcd <3.6 and etcd >=3.6 report errors with different JSON shapes (the
+// grpc-gateway v2 upgrade in 3.6 dropped the top-level `error` field in favour
+// of google.rpc.Status `message`). Stub fetch so both shapes are exercised
+// deterministically, regardless of which etcd version backs the live suite.
+async function expectSurfacedError(responseBody: unknown): Promise<void> {
+	const client = new EtcdClient({ url: "http://127.0.0.1:2379" });
+	const originalFetch = globalThis.fetch;
+	globalThis.fetch = (async () =>
+		new Response(JSON.stringify(responseBody), {
+			status: 404,
+			headers: { "content-type": "application/json" },
+		})) as typeof fetch;
+	try {
+		let error: Error | undefined;
+		try {
+			await client.putRaw({ key: "k", value: "v", lease: "1" });
+		} catch (e) {
+			error = e as Error;
+		}
+		expect(error).toBeDefined();
+		expect(error?.message).toMatch(/lease/i);
+	} finally {
+		globalThis.fetch = originalFetch;
+	}
+}
+
+it("surfaces the legacy `error` field from etcd <3.6", async () => {
+	await expectSurfacedError({
+		error: "etcdserver: requested lease not found",
+		code: 5,
+		message: "etcdserver: requested lease not found",
+	});
+});
+
+it("surfaces the grpc-gateway v2 `message` field from etcd >=3.6", async () => {
+	await expectSurfacedError({
+		code: 5,
+		message: "etcdserver: requested lease not found",
+	});
 });
 
 it("Lease caches the granted ID across concurrent puts", async (t) => {

--- a/storage/etcd/test/test.ts
+++ b/storage/etcd/test/test.ts
@@ -1,7 +1,7 @@
 import { faker } from "@faker-js/faker";
 import { keyvIteratorTests, keyvTestSuite, storageTestSuite } from "@keyv/test-suite";
 import { Keyv } from "keyv";
-import { expect, it } from "vitest";
+import { expect, it, vi } from "vitest";
 import { EtcdClient, prefixEnd } from "../src/client.js";
 import KeyvEtcd, { createKeyv } from "../src/index.js";
 
@@ -478,12 +478,14 @@ it("EtcdClient surfaces error responses from etcd", async (t) => {
 // deterministically, regardless of which etcd version backs the live suite.
 async function expectSurfacedError(responseBody: unknown): Promise<void> {
 	const client = new EtcdClient({ url: "http://127.0.0.1:2379" });
-	const originalFetch = globalThis.fetch;
-	globalThis.fetch = (async () =>
-		new Response(JSON.stringify(responseBody), {
-			status: 404,
-			headers: { "content-type": "application/json" },
-		})) as typeof fetch;
+	vi.stubGlobal(
+		"fetch",
+		async () =>
+			new Response(JSON.stringify(responseBody), {
+				status: 404,
+				headers: { "content-type": "application/json" },
+			}),
+	);
 	try {
 		let error: Error | undefined;
 		try {
@@ -494,7 +496,7 @@ async function expectSurfacedError(responseBody: unknown): Promise<void> {
 		expect(error).toBeDefined();
 		expect(error?.message).toMatch(/lease/i);
 	} finally {
-		globalThis.fetch = originalFetch;
+		vi.unstubAllGlobals();
 	}
 }
 


### PR DESCRIPTION
## What changed

Moving the etcd docker image to the latest release (the **3.6** line) made the `@keyv/etcd` suite fail on a single test: `EtcdClient surfaces error responses from etcd`.

### Root cause

etcd 3.6 upgraded its JSON/HTTP gateway from **grpc-gateway v1 to v2**. v2 dropped the top-level `error` string and now reports failures using the `google.rpc.Status` shape (`code` / `message` / `details`):

```jsonc
// etcd 3.5.x
{"error":"etcdserver: requested lease not found","code":5,"message":"etcdserver: requested lease not found"}

// etcd 3.6.x  (no top-level `error`)
{"code":5,"message":"etcdserver: requested lease not found"}
```

The in-house client read **only** `parsed.error`, so on 3.6 it threw the generic `etcd request failed: 404 Not Found` and lost the real message. Every other endpoint (`range` / `put` / `lease/grant` / `deleterange` / `status`) is byte-for-byte compatible between 3.5 and 3.6, so this was the *only* failing test (104/105 passed on 3.6 before the fix).

### Fix

- `client.ts` now reads `error` (etcd <3.6) and falls back to `message` (etcd ≥3.6), preserving the real error text **across all versions** — it keys off the wire format, not the etcd version.
- Added two **deterministic** tests that stub `fetch` with each JSON shape, so both code paths are locked in regardless of which etcd version backs the live suite.
- Bumped both `docker-compose` pins from `3.5.15-0` → the latest `3.6.12-0` so CI exercises the newest 3.6 line.

## Verification

Ran the full `@keyv/etcd` suite against real etcd containers spanning the whole range:

| etcd version | result |
|---|---|
| `3.5.15-0` (legacy `error`) | **107/107** ✅ |
| `3.6.0-0` (first grpc-gateway v2 release) | **107/107** ✅ |
| `3.6.1-0` | **107/107** ✅ |
| `3.6.12-0` (latest) | **107/107** ✅ |

`client.ts` coverage: 100% statements / functions / lines.

https://claude.ai/code/session_01HQtXXVhuZnu9hC12Ac7UNV

---
_Generated by [Claude Code](https://claude.ai/code/session_01HQtXXVhuZnu9hC12Ac7UNV)_