### PR TITLE
dynamo - fix: strip namespace prefix in iterator and align tests/docs

### DIFF
--- a/storage/dynamo/README.md
+++ b/storage/dynamo/README.md
@@ -15,6 +15,7 @@
 - Namespace support for key isolation across multiple Keyv instances
 - Automatic table creation with `PAY_PER_REQUEST` billing mode
 - `setMany`, `getMany`, `deleteMany`, and `hasMany` batch operations
+- Async `iterator` support with namespace-aware filtering
 - `createKeyv` helper for quick setup
 
 > **Note:** DynamoDB doesn't guarantee data will be deleted immediately upon expiration. See the [DynamoDB TTL documentation](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/TTL.html) for details.
@@ -32,6 +33,8 @@
   - [.namespace](#namespace)
   - [.keyPrefixSeparator](#keyprefixseparator)
   - [.sixHoursInMilliseconds](#sixhoursinmilliseconds)
+  - [.tableName](#tablename)
+  - [.endpoint](#endpoint)
 - [Methods](#methods)
   - [constructor(options?)](#constructoroptions)
   - [.get(key)](#getkey)
@@ -43,6 +46,8 @@
   - [.clear()](#clear)
   - [.has(key)](#haskey)
   - [.hasMany(keys)](#hasmanykeys)
+  - [.iterator()](#iterator)
+  - [.disconnect()](#disconnect)
   - [.formatKey(key)](#formatkeykey)
   - [.createKeyPrefix(key, namespace?)](#createkeyprefixkey-namespace)
   - [.removeKeyPrefix(key, namespace?)](#removekeyprefixkey-namespace)
@@ -254,6 +259,22 @@ The default TTL fallback in milliseconds. Used when no TTL is specified in a `se
 |---|---|
 | `number` | `21600000` (6 hours) |
 
+### .tableName
+
+The DynamoDB table name in use. Read-only.
+
+| Type | Default |
+|---|---|
+| `string` | `'keyv'` |
+
+### .endpoint
+
+The configured DynamoDB endpoint URL, if one was provided. Read-only.
+
+| Type | Default |
+|---|---|
+| `string \| undefined` | `undefined` |
+
 ## Methods
 
 ### constructor(options?)
@@ -367,6 +388,29 @@ const store = new KeyvDynamo({ endpoint: 'http://localhost:8000' });
 await store.set('key1', 'value1');
 await store.set('key2', 'value2');
 const results = await store.hasMany(['key1', 'key2', 'key3']); // [true, true, false]
+```
+
+### .iterator()
+
+Returns an async iterator over all `[key, value]` pairs in the store. If a namespace is set, only keys with that namespace are yielded and the namespace prefix is removed from the returned keys. The namespace does not need to be passed in — it uses the namespace configured on the adapter. Expired entries are skipped and deleted.
+
+```js
+const store = new KeyvDynamo({ endpoint: 'http://localhost:8000' });
+await store.set('key1', 'value1');
+await store.set('key2', 'value2');
+
+for await (const [key, value] of store.iterator()) {
+  console.log(key, value);
+}
+```
+
+### .disconnect()
+
+Disconnects from the DynamoDB client. This is a no-op for DynamoDB since it communicates over HTTP requests and does not maintain a persistent connection.
+
+```js
+const store = new KeyvDynamo({ endpoint: 'http://localhost:8000' });
+await store.disconnect();
 ```
 
 ### .formatKey(key)

--- a/storage/dynamo/src/index.ts
+++ b/storage/dynamo/src/index.ts
@@ -570,6 +570,8 @@ export class KeyvDynamo extends Hookified implements KeyvStorageAdapter {
 
 	/**
 	 * Iterates over all key-value pairs in the store matching the configured namespace.
+	 * Keys are returned without the namespace prefix. Does not require a namespace to be
+	 * passed; it uses the namespace configured on the adapter.
 	 * @yields `[key, value]` pairs as an async generator.
 	 */
 	public async *iterator<Value>(): AsyncGenerator<
@@ -604,7 +606,10 @@ export class KeyvDynamo extends Hookified implements KeyvStorageAdapter {
 					continue;
 				}
 
-				yield [item.id as string, item.value as Awaited<Value>];
+				yield [
+					this.removeKeyPrefix(item.id as string, this._namespace),
+					item.value as Awaited<Value>,
+				];
 			}
 		} while (lastEvaluatedKey);
 	}

--- a/storage/dynamo/test/test.ts
+++ b/storage/dynamo/test/test.ts
@@ -2,7 +2,7 @@
 import process from "node:process";
 import { ResourceInUseException } from "@aws-sdk/client-dynamodb";
 import { faker } from "@faker-js/faker";
-import { keyvTestSuite, storageTestSuite } from "@keyv/test-suite";
+import { keyvIteratorTests, keyvTestSuite, storageTestSuite } from "@keyv/test-suite";
 import Keyv from "keyv";
 import { beforeEach, describe, it, vi } from "vitest";
 import KeyvDynamo, { createKeyv } from "../src/index.js";
@@ -19,337 +19,538 @@ const keyvDynamodb = new KeyvDynamo({
 const store = () => new KeyvDynamo({ endpoint: dynamoURL, tableName: faker.string.uuid() });
 
 keyvTestSuite(it, Keyv, store);
-storageTestSuite(it, store, { iterator: false, ttlGranularity: "seconds" });
+keyvIteratorTests(it, Keyv, store);
+storageTestSuite(it, store, { ttlGranularity: "seconds" });
 
 beforeEach(async () => {
 	const keyv = store();
 	await keyv.clear();
 });
 
-it("should ensure table creation", async (t) => {
-	const store = new KeyvDynamo({
-		endpoint: dynamoURL,
-		tableName: faker.string.uuid(),
-	});
-	const key = faker.string.uuid();
-	const value = faker.lorem.word();
-	await store.set(key, value);
-	await t.expect(store.get(key)).resolves.toBe(value);
-});
-
-it("should be able to create a keyv instance", (t) => {
-	const keyv = new Keyv<string>({ store: keyvDynamodb });
-	t.expect((keyv.store as KeyvDynamo).endpoint).toEqual(dynamoURL);
-});
-
-it("should be able to create a keyv instance with namespace", (t) => {
-	const store = new KeyvDynamo({ endpoint: dynamoURL, namespace: "test" });
-	t.expect(store.endpoint).toEqual(dynamoURL);
-	t.expect(store.namespace).toEqual("test");
-});
-
-it(".clear() entire cache store with default namespace", async (t) => {
-	const store = new KeyvDynamo({ endpoint: dynamoURL });
-	t.expect(await store.clear()).toBeUndefined();
-});
-
-it(".clear() entire cache store with namespace", async (t) => {
-	const store = new KeyvDynamo({ endpoint: dynamoURL, namespace: "test" });
-	t.expect(await store.clear()).toBeUndefined();
-});
-
-it(".clear() an empty store should not fail", async () => {
-	const store = new KeyvDynamo({ endpoint: dynamoURL });
-	await store.clear();
-	await store.clear();
-});
-
-it("should emit error when not ResourceNotFoundException on ensureTable", async (t) => {
-	const store = new KeyvDynamo({
-		endpoint: dynamoURL,
-		tableName: "invalid_table%&#@",
+describe("construction and properties", () => {
+	it("should create a keyv instance from a store", (t) => {
+		const keyv = new Keyv<string>({ store: keyvDynamodb });
+		t.expect((keyv.store as KeyvDynamo).endpoint).toEqual(dynamoURL);
 	});
 
-	const expectedError = new Promise((_resolve, reject) => {
-		store.on("error", reject);
+	it("should create a store with a namespace", (t) => {
+		const namespace = faker.string.alphanumeric(10);
+		const store = new KeyvDynamo({ endpoint: dynamoURL, namespace });
+		t.expect(store.endpoint).toEqual(dynamoURL);
+		t.expect(store.namespace).toEqual(namespace);
 	});
-	await t.expect(expectedError).rejects.toThrow(Error);
+
+	it("should expose the underlying client", (t) => {
+		const store = new KeyvDynamo({ endpoint: dynamoURL });
+		t.expect(store.client).toBeDefined();
+		t.expect(store.client).toHaveProperty("send");
+		t.expect(store.client).toHaveProperty("get");
+		t.expect(store.client).toHaveProperty("put");
+		t.expect(store.client).toHaveProperty("delete");
+		t.expect(store.client).toHaveProperty("batchGet");
+		t.expect(store.client).toHaveProperty("batchWrite");
+		t.expect(store.client).toHaveProperty("scan");
+	});
+
+	it("should get and set the client", (t) => {
+		const store = new KeyvDynamo({ endpoint: dynamoURL });
+		const originalClient = store.client;
+		t.expect(originalClient).toBeDefined();
+		const newStore = new KeyvDynamo({ endpoint: dynamoURL });
+		store.client = newStore.client;
+		t.expect(store.client).toBe(newStore.client);
+	});
+
+	it("should get and set sixHoursInMilliseconds", (t) => {
+		const store = new KeyvDynamo({ endpoint: dynamoURL });
+		t.expect(store.sixHoursInMilliseconds).toBe(6 * 60 * 60 * 1000);
+		store.sixHoursInMilliseconds = 1000;
+		t.expect(store.sixHoursInMilliseconds).toBe(1000);
+	});
 });
 
-it("should handle scan result with undefined Items", async (t) => {
-	const store = new KeyvDynamo({ endpoint: dynamoURL });
-
-	// Mock the scan method to return undefined Items
-	const originalScan = (store as any).client.scan;
-	(store as any).client.scan = vi.fn().mockResolvedValueOnce({
-		Items: undefined,
+describe("namespace and key prefixing", () => {
+	it("should format a key with the namespace and avoid double prefixing", (t) => {
+		const store = new KeyvDynamo({ endpoint: dynamoURL });
+		store.namespace = "ns";
+		t.expect(store.formatKey("key")).toBe("ns:key");
+		t.expect(store.formatKey("ns:key")).toBe("ns:key");
+		store.namespace = undefined;
+		t.expect(store.formatKey("key")).toBe("key");
 	});
 
-	t.expect(await store.clear()).toBeUndefined();
-	(store as any).client.scan = originalScan;
+	it("should create a key prefix when a namespace is provided", (t) => {
+		const store = new KeyvDynamo({ endpoint: dynamoURL });
+		t.expect(store.createKeyPrefix("key", "ns")).toBe("ns:key");
+		t.expect(store.createKeyPrefix("key")).toBe("key");
+		t.expect(store.createKeyPrefix("key", undefined)).toBe("key");
+	});
+
+	it("should remove a key prefix when a namespace is provided", (t) => {
+		const store = new KeyvDynamo({ endpoint: dynamoURL });
+		t.expect(store.removeKeyPrefix("ns:key", "ns")).toBe("key");
+		t.expect(store.removeKeyPrefix("key")).toBe("key");
+		t.expect(store.removeKeyPrefix("key", undefined)).toBe("key");
+	});
+
+	it("should get and set the keyPrefixSeparator", (t) => {
+		const store = new KeyvDynamo({ endpoint: dynamoURL });
+		t.expect(store.keyPrefixSeparator).toBe(":");
+		store.keyPrefixSeparator = "::";
+		t.expect(store.keyPrefixSeparator).toBe("::");
+		t.expect(store.createKeyPrefix("key", "ns")).toBe("ns::key");
+	});
 });
 
-it("should handle namespace filtering when namespace is undefined", async (t) => {
-	const store = new KeyvDynamo({ endpoint: dynamoURL, namespace: undefined });
+describe("get, set, and delete", () => {
+	it("should set and get a value with a namespace", async (t) => {
+		const store = new KeyvDynamo({ endpoint: dynamoURL });
+		store.namespace = faker.string.alphanumeric(10);
+		const key = faker.string.uuid();
+		const value = faker.lorem.word();
+		await store.set(key, value);
+		t.expect(await store.get(key)).toBe(value);
+	});
 
-	const key = faker.string.uuid();
-	const value = faker.lorem.word();
-	await store.set(key, value);
+	it("should delete a value with a namespace", async (t) => {
+		const store = new KeyvDynamo({ endpoint: dynamoURL });
+		store.namespace = faker.string.alphanumeric(10);
+		const key = faker.string.uuid();
+		await store.set(key, faker.lorem.word());
+		t.expect(await store.delete(key)).toBe(true);
+		t.expect(await store.get(key)).toBeUndefined();
+	});
 
-	t.expect(await store.clear()).toBeUndefined();
+	it("should return undefined for a missing key", async (t) => {
+		const store = new KeyvDynamo({ endpoint: dynamoURL });
+		t.expect(await store.get(faker.string.uuid())).toBeUndefined();
+	});
 });
 
-it("should handle ResourceInUseException when table already exists (fallback to wait for table to be created)", async (t) => {
-	const store = new KeyvDynamo({
-		endpoint: dynamoURL,
-		tableName: faker.string.uuid(),
+describe("expiration", () => {
+	it("should store expiresAtMs at millisecond precision", async (t) => {
+		const store = new KeyvDynamo({ endpoint: dynamoURL });
+		const key = faker.string.uuid();
+		const value = faker.lorem.sentence();
+
+		const beforeSet = Date.now();
+		await store.set(key, value, 1000);
+		const afterSet = Date.now();
+
+		const result = await store.client.get({
+			TableName: store.tableName,
+			Key: { id: store.formatKey(key) },
+		});
+
+		t.expect(typeof result.Item?.expiresAtMs).toBe("number");
+		t.expect(result.Item?.expiresAtMs).toBeGreaterThanOrEqual(beforeSet + 1000);
+		t.expect(result.Item?.expiresAtMs).toBeLessThanOrEqual(afterSet + 1000);
+
+		t.expect(typeof result.Item?.expiresAt).toBe("number");
+		t.expect(result.Item?.expiresAt).toBeGreaterThanOrEqual(Math.ceil((beforeSet + 1000) / 1000));
 	});
 
-	const originalSend = (store as any).client.send;
-	(store as any).client.send = vi.fn().mockImplementation((command) => {
-		if (command.constructor.name === "CreateTableCommand") {
-			// Call CreateTableCommand twice to trigger the ResourceInUseException
-			originalSend.call((store as any).client, command).catch(() => {});
-		}
-
-		return originalSend.call((store as any).client, command);
+	it("should return the value for items missing both expiry fields", async (t) => {
+		const store = new KeyvDynamo({ endpoint: dynamoURL });
+		const key = faker.string.uuid();
+		const value = faker.lorem.word();
+		await store.client.put({
+			TableName: store.tableName,
+			Item: {
+				id: store.formatKey(key),
+				value,
+			},
+		});
+		t.expect(await store.get(key)).toBe(value);
 	});
 
-	const key = faker.string.uuid();
-	const value = faker.lorem.word();
-	await store.set(key, value);
-	(store as any).client.send = originalSend;
-	await t.expect(store.get(key)).resolves.toBe(value);
+	it("should return false from has for an expired key", async (t) => {
+		const store = new KeyvDynamo({ endpoint: dynamoURL });
+		const key = faker.string.uuid();
+		// Set with a TTL of 0ms so it expires immediately (expiresAt will be ~now+1s)
+		await store.set(key, faker.lorem.word(), 0);
+		// Manually overwrite with an already-expired expiresAt
+		await store.client.put({
+			TableName: store.tableName,
+			Item: {
+				id: store.formatKey(key),
+				value: faker.lorem.word(),
+				expiresAt: Math.floor(Date.now() / 1000) - 10,
+			},
+		});
+		t.expect(await store.has(key)).toBe(false);
+	});
+
+	it("should return false from hasMany for expired keys", async (t) => {
+		const store = new KeyvDynamo({ endpoint: dynamoURL });
+		const key1 = faker.string.uuid();
+		const key2 = faker.string.uuid();
+		await store.set(key1, faker.lorem.word());
+		await store.set(key2, faker.lorem.word());
+		// Overwrite key1 with an expired expiresAt
+		await store.client.put({
+			TableName: store.tableName,
+			Item: {
+				id: store.formatKey(key1),
+				value: faker.lorem.word(),
+				expiresAt: Math.floor(Date.now() / 1000) - 10,
+			},
+		});
+		const results = await store.hasMany([key1, key2]);
+		t.expect(results).toEqual([false, true]);
+	});
 });
 
-it("should wait for table when it exists but is not ACTIVE", async (t) => {
-	const tableName = faker.string.uuid();
-
-	// First create a store and table
-	const store = new KeyvDynamo({
-		endpoint: dynamoURL,
-		tableName,
+describe("batch operations", () => {
+	it("should set many entries with per-entry ttl", async (t) => {
+		const store = new KeyvDynamo({ endpoint: dynamoURL });
+		const key1 = faker.string.uuid();
+		const key2 = faker.string.uuid();
+		const value1 = faker.lorem.word();
+		const value2 = faker.lorem.word();
+		const result = await store.setMany([
+			{ key: key1, value: value1, ttl: 5000 },
+			{ key: key2, value: value2 },
+		]);
+		t.expect(result).toEqual([true, true]);
+		t.expect(await store.get(key1)).toBe(value1);
+		t.expect(await store.get(key2)).toBe(value2);
 	});
-	const key = faker.string.uuid();
-	const value = faker.lorem.word();
-	await store.set(key, value);
 
-	// Now test ensureTable directly with a mocked CREATING status
-	let describeCallCount = 0;
-	const originalSend = (store as any).client.send;
-	(store as any).client.send = vi.fn().mockImplementation(async (command) => {
-		if (command.constructor.name === "DescribeTableCommand") {
-			describeCallCount++;
-			if (describeCallCount === 1) {
-				// First call returns CREATING status
+	it("should mark all entries false when batchWrite throws", async (t) => {
+		const dynamo = store();
+		dynamo.on("error", () => {});
+		// Wait for table to be ready before mocking
+		await dynamo.set("_warmup", "ok");
+		const originalBatchWrite = dynamo._client.batchWrite.bind(dynamo._client);
+		dynamo._client.batchWrite = async () => {
+			throw new Error("batchWrite failure");
+		};
+
+		const result = await dynamo.setMany([
+			{ key: faker.string.uuid(), value: faker.lorem.word() },
+			{ key: faker.string.uuid(), value: faker.lorem.word() },
+		]);
+		t.expect(result).toEqual([false, false]);
+		dynamo._client.batchWrite = originalBatchWrite;
+	});
+
+	it("should mark unprocessed items as false", async (t) => {
+		const dynamo = store();
+		dynamo.on("error", () => {});
+		// Wait for table to be ready before mocking
+		await dynamo.set("_warmup", "ok");
+		const key2 = faker.string.uuid();
+		const key2Formatted = dynamo.formatKey(key2);
+		dynamo._client.batchWrite = async (input: any) => {
+			const tableName = Object.keys(input.RequestItems)[0];
+			return {
+				UnprocessedItems: {
+					[tableName]: [{ PutRequest: { Item: { id: key2Formatted } } }],
+				},
+			};
+		};
+
+		const result = await dynamo.setMany([
+			{ key: faker.string.uuid(), value: faker.lorem.word() },
+			{ key: key2, value: faker.lorem.word() },
+		]);
+		t.expect(result?.[0]).toBe(true);
+		t.expect(result?.[1]).toBe(false);
+	});
+
+	it("should ignore unprocessed items with a missing id", async (t) => {
+		const dynamo = store();
+		await dynamo.set("_warmup", "ok");
+		dynamo._client.batchWrite = async (input: any) => {
+			const tableName = Object.keys(input.RequestItems)[0];
+			return {
+				UnprocessedItems: {
+					[tableName]: [{ PutRequest: { Item: {} } }],
+				},
+			};
+		};
+		const result = await dynamo.setMany([{ key: faker.string.uuid(), value: faker.lorem.word() }]);
+		t.expect(result).toEqual([true]);
+	});
+
+	it("should retry unprocessed keys in getMany", async (t) => {
+		const dynamo = store();
+		const key1 = faker.string.uuid();
+		const key2 = faker.string.uuid();
+		const value1 = faker.lorem.word();
+		const value2 = faker.lorem.word();
+		await dynamo.set(key1, value1);
+		await dynamo.set(key2, value2);
+
+		const originalBatchGet = dynamo._client.batchGet.bind(dynamo._client);
+		let callCount = 0;
+		dynamo._client.batchGet = async (input: any) => {
+			callCount++;
+			if (callCount === 1) {
+				const tableName = Object.keys(input.RequestItems)[0];
 				return {
-					Table: {
-						TableName: tableName,
-						TableStatus: "CREATING",
+					UnprocessedKeys: {
+						[tableName]: {
+							Keys: [{ id: dynamo.formatKey(key1) }, { id: dynamo.formatKey(key2) }],
+						},
 					},
 				};
 			}
+			return originalBatchGet(input);
+		};
+
+		const result = await dynamo.getMany([key1, key2]);
+		t.expect(result).toEqual([value1, value2]);
+		t.expect(callCount).toBe(2);
+		dynamo._client.batchGet = originalBatchGet;
+	});
+
+	it("should retry unprocessed keys in hasMany", async (t) => {
+		const dynamo = store();
+		const key1 = faker.string.uuid();
+		const key2 = faker.string.uuid();
+		await dynamo.set(key1, faker.lorem.word());
+		await dynamo.set(key2, faker.lorem.word());
+
+		const originalBatchGet = dynamo._client.batchGet.bind(dynamo._client);
+		let callCount = 0;
+		dynamo._client.batchGet = async (input: any) => {
+			callCount++;
+			if (callCount === 1) {
+				const tableName = Object.keys(input.RequestItems)[0];
+				return {
+					UnprocessedKeys: {
+						[tableName]: {
+							Keys: [{ id: dynamo.formatKey(key1) }, { id: dynamo.formatKey(key2) }],
+						},
+					},
+				};
+			}
+			return originalBatchGet(input);
+		};
+
+		const result = await dynamo.hasMany([key1, key2]);
+		t.expect(result).toEqual([true, true]);
+		t.expect(callCount).toBe(2);
+		dynamo._client.batchGet = originalBatchGet;
+	});
+});
+
+describe("clear", () => {
+	it("should clear the entire store with the default namespace", async (t) => {
+		const store = new KeyvDynamo({ endpoint: dynamoURL });
+		t.expect(await store.clear()).toBeUndefined();
+	});
+
+	it("should clear the store with a namespace", async (t) => {
+		const store = new KeyvDynamo({ endpoint: dynamoURL, namespace: faker.string.alphanumeric(10) });
+		t.expect(await store.clear()).toBeUndefined();
+	});
+
+	it("should not fail when clearing an empty store", async () => {
+		const store = new KeyvDynamo({ endpoint: dynamoURL });
+		await store.clear();
+		await store.clear();
+	});
+
+	it("should handle a scan result with undefined Items", async (t) => {
+		const store = new KeyvDynamo({ endpoint: dynamoURL });
+
+		// Mock the scan method to return undefined Items
+		const originalScan = (store as any).client.scan;
+		(store as any).client.scan = vi.fn().mockResolvedValueOnce({
+			Items: undefined,
+		});
+
+		t.expect(await store.clear()).toBeUndefined();
+		(store as any).client.scan = originalScan;
+	});
+
+	it("should clear when the namespace is explicitly undefined", async (t) => {
+		const store = new KeyvDynamo({ endpoint: dynamoURL, namespace: undefined });
+
+		const key = faker.string.uuid();
+		const value = faker.lorem.word();
+		await store.set(key, value);
+
+		t.expect(await store.clear()).toBeUndefined();
+	});
+});
+
+describe("iterator", () => {
+	it("should iterate over all entries with no namespace", async (t) => {
+		const store = new KeyvDynamo({ endpoint: dynamoURL, tableName: faker.string.uuid() });
+		const key1 = faker.string.uuid();
+		const key2 = faker.string.uuid();
+		await store.set(key1, "val1");
+		await store.set(key2, "val2");
+
+		const entries: Array<[string, string]> = [];
+		for await (const entry of store.iterator()) {
+			entries.push(entry as [string, string]);
 		}
-		return originalSend.call((store as any).client, command);
+
+		t.expect(entries.length).toBe(2);
+		const keys = entries.map(([key]) => key);
+		t.expect(keys).toContain(key1);
+		t.expect(keys).toContain(key2);
 	});
 
-	// Call ensureTable directly - this should hit the CREATING branch
-	await store.ensureTable(tableName);
-	t.expect(describeCallCount).toBeGreaterThanOrEqual(1);
-	(store as any).client.send = originalSend;
-});
+	it("should only iterate over namespaced keys and strip the prefix", async (t) => {
+		const tableName = faker.string.uuid();
+		const namespace = faker.string.alphanumeric(10);
+		const store = new KeyvDynamo({ endpoint: dynamoURL, tableName, namespace });
+		const key1 = faker.string.uuid();
+		const key2 = faker.string.uuid();
+		await store.set(key1, "val1");
+		await store.set(key2, "val2");
 
-it("should verify exposed client property", async (t) => {
-	const store = new KeyvDynamo({ endpoint: dynamoURL });
-	t.expect(store.client).toBeDefined();
-	t.expect(store.client).toHaveProperty("send");
-	t.expect(store.client).toHaveProperty("get");
-	t.expect(store.client).toHaveProperty("put");
-	t.expect(store.client).toHaveProperty("delete");
-	t.expect(store.client).toHaveProperty("batchGet");
-	t.expect(store.client).toHaveProperty("batchWrite");
-	t.expect(store.client).toHaveProperty("scan");
-});
+		// Also set a key without the namespace directly
+		const storeNoNs = new KeyvDynamo({ endpoint: dynamoURL, tableName });
+		await storeNoNs.set(faker.string.uuid(), "val3");
 
-it("should handle ResourceInUseException and wait for table", { timeout: 10000 }, async (t) => {
-	const tableName = faker.string.uuid();
-	const store = new KeyvDynamo({
-		endpoint: dynamoURL,
-		tableName,
-	});
-
-	// First create the table
-	const key1 = faker.string.uuid();
-	const value1 = faker.lorem.word();
-	await store.set(key1, value1);
-
-	// Now create another store instance that will hit ResourceInUseException
-	const store2 = new KeyvDynamo({
-		endpoint: dynamoURL,
-		tableName,
-	});
-
-	const originalSend = (store2 as any).client.send;
-	let createTableCalled = false;
-	(store2 as any).client.send = vi.fn().mockImplementation(async (command) => {
-		if (command.constructor.name === "CreateTableCommand" && !createTableCalled) {
-			createTableCalled = true;
-			throw new ResourceInUseException({
-				message: "Table already being created",
-				$metadata: {},
-			});
+		const entries: Array<[string, string]> = [];
+		for await (const entry of store.iterator()) {
+			entries.push(entry as [string, string]);
 		}
-		return originalSend.call((store2 as any).client, command);
+
+		// Should only return the 2 namespaced keys, with the namespace prefix removed
+		t.expect(entries.length).toBe(2);
+		const keys = entries.map(([key]) => key);
+		t.expect(keys).toContain(key1);
+		t.expect(keys).toContain(key2);
+	});
+});
+
+describe("table management", () => {
+	it("should create the table on first use", async (t) => {
+		const store = new KeyvDynamo({
+			endpoint: dynamoURL,
+			tableName: faker.string.uuid(),
+		});
+		const key = faker.string.uuid();
+		const value = faker.lorem.word();
+		await store.set(key, value);
+		await t.expect(store.get(key)).resolves.toBe(value);
 	});
 
-	// This should wait for the table to exist
-	const key2 = faker.string.uuid();
-	const value2 = faker.lorem.word();
-	await store2.set(key2, value2);
-	t.expect(await store2.get(key2)).toBe(value2);
-	(store2 as any).client.send = originalSend;
-});
+	it("should emit an error when ensureTable fails for a non-ResourceNotFound error", async (t) => {
+		const store = new KeyvDynamo({
+			endpoint: dynamoURL,
+			tableName: "invalid_table%&#@",
+		});
 
-it("formatKey prefixes key and avoids double prefix", (t) => {
-	const store = new KeyvDynamo({ endpoint: dynamoURL });
-	store.namespace = "ns";
-	t.expect(store.formatKey("key")).toBe("ns:key");
-	t.expect(store.formatKey("ns:key")).toBe("ns:key");
-	store.namespace = undefined;
-	t.expect(store.formatKey("key")).toBe("key");
-});
-
-it("createKeyPrefix returns prefixed key when namespace is set", (t) => {
-	const store = new KeyvDynamo({ endpoint: dynamoURL });
-	t.expect(store.createKeyPrefix("key", "ns")).toBe("ns:key");
-	t.expect(store.createKeyPrefix("key")).toBe("key");
-	t.expect(store.createKeyPrefix("key", undefined)).toBe("key");
-});
-
-it("removeKeyPrefix strips prefix when namespace is set", (t) => {
-	const store = new KeyvDynamo({ endpoint: dynamoURL });
-	t.expect(store.removeKeyPrefix("ns:key", "ns")).toBe("key");
-	t.expect(store.removeKeyPrefix("key")).toBe("key");
-	t.expect(store.removeKeyPrefix("key", undefined)).toBe("key");
-});
-
-it("keyPrefixSeparator getter and setter", (t) => {
-	const store = new KeyvDynamo({ endpoint: dynamoURL });
-	t.expect(store.keyPrefixSeparator).toBe(":");
-	store.keyPrefixSeparator = "::";
-	t.expect(store.keyPrefixSeparator).toBe("::");
-	t.expect(store.createKeyPrefix("key", "ns")).toBe("ns::key");
-});
-
-it("client getter and setter", (t) => {
-	const store = new KeyvDynamo({ endpoint: dynamoURL });
-	const originalClient = store.client;
-	t.expect(originalClient).toBeDefined();
-	const newStore = new KeyvDynamo({ endpoint: dynamoURL });
-	store.client = newStore.client;
-	t.expect(store.client).toBe(newStore.client);
-});
-
-it("sixHoursInMilliseconds getter and setter", (t) => {
-	const store = new KeyvDynamo({ endpoint: dynamoURL });
-	t.expect(store.sixHoursInMilliseconds).toBe(6 * 60 * 60 * 1000);
-	store.sixHoursInMilliseconds = 1000;
-	t.expect(store.sixHoursInMilliseconds).toBe(1000);
-});
-
-it("get/set with namespace", async (t) => {
-	const store = new KeyvDynamo({ endpoint: dynamoURL });
-	const namespace = faker.string.alphanumeric(10);
-	store.namespace = namespace;
-	const key = faker.string.uuid();
-	const value = faker.lorem.word();
-	await store.set(key, value);
-	t.expect(await store.get(key)).toBe(value);
-});
-
-it("delete with namespace", async (t) => {
-	const store = new KeyvDynamo({ endpoint: dynamoURL });
-	const namespace = faker.string.alphanumeric(10);
-	store.namespace = namespace;
-	const key = faker.string.uuid();
-	await store.set(key, faker.lorem.word());
-	t.expect(await store.delete(key)).toBe(true);
-	t.expect(await store.get(key)).toBeUndefined();
-});
-
-it("get returns value for items missing both expiry fields", async (t) => {
-	const store = new KeyvDynamo({ endpoint: dynamoURL });
-	const key = faker.string.uuid();
-	await store.client.put({
-		TableName: store.tableName,
-		Item: {
-			id: store.formatKey(key),
-			value: "no-expiry",
-		},
-	});
-	t.expect(await store.get(key)).toBe("no-expiry");
-});
-
-it("set stores expiresAtMs at millisecond precision", async (t) => {
-	const dynamo = new KeyvDynamo({ endpoint: dynamoURL });
-	const key = faker.string.uuid();
-	const value = faker.lorem.sentence();
-
-	const beforeSet = Date.now();
-	await dynamo.set(key, value, 1000);
-	const afterSet = Date.now();
-
-	const result = await dynamo.client.get({
-		TableName: dynamo.tableName,
-		Key: { id: dynamo.formatKey(key) },
+		const expectedError = new Promise((_resolve, reject) => {
+			store.on("error", reject);
+		});
+		await t.expect(expectedError).rejects.toThrow(Error);
 	});
 
-	t.expect(typeof result.Item?.expiresAtMs).toBe("number");
-	t.expect(result.Item?.expiresAtMs).toBeGreaterThanOrEqual(beforeSet + 1000);
-	t.expect(result.Item?.expiresAtMs).toBeLessThanOrEqual(afterSet + 1000);
+	it("should fall back to waiting when CreateTable hits ResourceInUseException", async (t) => {
+		const store = new KeyvDynamo({
+			endpoint: dynamoURL,
+			tableName: faker.string.uuid(),
+		});
 
-	t.expect(typeof result.Item?.expiresAt).toBe("number");
-	t.expect(result.Item?.expiresAt).toBeGreaterThanOrEqual(Math.ceil((beforeSet + 1000) / 1000));
-});
+		const originalSend = (store as any).client.send;
+		(store as any).client.send = vi.fn().mockImplementation((command) => {
+			if (command.constructor.name === "CreateTableCommand") {
+				// Call CreateTableCommand twice to trigger the ResourceInUseException
+				originalSend.call((store as any).client, command).catch(() => {});
+			}
 
-it("has returns false for expired key", async (t) => {
-	const store = new KeyvDynamo({ endpoint: dynamoURL });
-	const key = faker.string.uuid();
-	// Set with a TTL of 0ms so it expires immediately (expiresAt will be ~now+1s)
-	await store.set(key, "value", 0);
-	// Manually overwrite with an already-expired expiresAt
-	await store.client.put({
-		TableName: store.tableName,
-		Item: {
-			id: store.formatKey(key),
-			value: "value",
-			expiresAt: Math.floor(Date.now() / 1000) - 10,
-		},
+			return originalSend.call((store as any).client, command);
+		});
+
+		const key = faker.string.uuid();
+		const value = faker.lorem.word();
+		await store.set(key, value);
+		(store as any).client.send = originalSend;
+		await t.expect(store.get(key)).resolves.toBe(value);
 	});
-	t.expect(await store.has(key)).toBe(false);
-});
 
-it("hasMany returns false for expired keys", async (t) => {
-	const store = new KeyvDynamo({ endpoint: dynamoURL });
-	const key1 = faker.string.uuid();
-	const key2 = faker.string.uuid();
-	await store.set(key1, "value1");
-	await store.set(key2, "value2");
-	// Overwrite key1 with an expired expiresAt
-	await store.client.put({
-		TableName: store.tableName,
-		Item: {
-			id: store.formatKey(key1),
-			value: "value1",
-			expiresAt: Math.floor(Date.now() / 1000) - 10,
-		},
+	it("should wait for the table when it exists but is not ACTIVE", async (t) => {
+		const tableName = faker.string.uuid();
+
+		// First create a store and table
+		const store = new KeyvDynamo({
+			endpoint: dynamoURL,
+			tableName,
+		});
+		const key = faker.string.uuid();
+		const value = faker.lorem.word();
+		await store.set(key, value);
+
+		// Now test ensureTable directly with a mocked CREATING status
+		let describeCallCount = 0;
+		const originalSend = (store as any).client.send;
+		(store as any).client.send = vi.fn().mockImplementation(async (command) => {
+			if (command.constructor.name === "DescribeTableCommand") {
+				describeCallCount++;
+				if (describeCallCount === 1) {
+					// First call returns CREATING status
+					return {
+						Table: {
+							TableName: tableName,
+							TableStatus: "CREATING",
+						},
+					};
+				}
+			}
+			return originalSend.call((store as any).client, command);
+		});
+
+		// Call ensureTable directly - this should hit the CREATING branch
+		await store.ensureTable(tableName);
+		t.expect(describeCallCount).toBeGreaterThanOrEqual(1);
+		(store as any).client.send = originalSend;
 	});
-	const results = await store.hasMany([key1, key2]);
-	t.expect(results).toEqual([false, true]);
+
+	it("should wait for the table when CreateTable throws ResourceInUseException", {
+		timeout: 10000,
+	}, async (t) => {
+		const tableName = faker.string.uuid();
+		const store = new KeyvDynamo({
+			endpoint: dynamoURL,
+			tableName,
+		});
+
+		// First create the table
+		const key1 = faker.string.uuid();
+		const value1 = faker.lorem.word();
+		await store.set(key1, value1);
+
+		// Now create another store instance that will hit ResourceInUseException
+		const store2 = new KeyvDynamo({
+			endpoint: dynamoURL,
+			tableName,
+		});
+
+		const originalSend = (store2 as any).client.send;
+		let createTableCalled = false;
+		(store2 as any).client.send = vi.fn().mockImplementation(async (command) => {
+			if (command.constructor.name === "CreateTableCommand" && !createTableCalled) {
+				createTableCalled = true;
+				throw new ResourceInUseException({
+					message: "Table already being created",
+					$metadata: {},
+				});
+			}
+			return originalSend.call((store2 as any).client, command);
+		});
+
+		// This should wait for the table to exist
+		const key2 = faker.string.uuid();
+		const value2 = faker.lorem.word();
+		await store2.set(key2, value2);
+		t.expect(await store2.get(key2)).toBe(value2);
+		(store2 as any).client.send = originalSend;
+	});
 });
 
 describe("createKeyv", () => {
-	it("should create Keyv instance with default options", (t) => {
+	it("should create a Keyv instance with default options", (t) => {
 		const keyv = createKeyv();
 		t.expect(keyv).toBeDefined();
 		t.expect(keyv.store).toBeInstanceOf(KeyvDynamo);
@@ -357,39 +558,36 @@ describe("createKeyv", () => {
 		t.expect((keyv.store as KeyvDynamo).namespace).toBeUndefined();
 	});
 
-	it("should create Keyv instance with string endpoint", (t) => {
+	it("should create a Keyv instance with a string endpoint", (t) => {
 		const keyv = createKeyv(dynamoURL);
 		t.expect(keyv).toBeDefined();
 		t.expect(keyv.store).toBeInstanceOf(KeyvDynamo);
 		t.expect(keyv.namespace).toBeUndefined();
 		t.expect((keyv.store as KeyvDynamo).namespace).toBeUndefined();
-
 		t.expect((keyv.store as KeyvDynamo).endpoint).toBe(dynamoURL);
 	});
 
-	it("should create Keyv instance with custom namespace", (t) => {
+	it("should create a Keyv instance with a custom namespace", (t) => {
 		const namespace = faker.string.alphanumeric(10);
 		const keyv = createKeyv({ endpoint: dynamoURL, namespace });
 		t.expect(keyv).toBeDefined();
 		t.expect(keyv.store).toBeInstanceOf(KeyvDynamo);
 		t.expect(keyv.namespace).toBe(namespace);
 		t.expect((keyv.store as KeyvDynamo).namespace).toBe(namespace);
-
 		t.expect((keyv.store as KeyvDynamo).endpoint).toBe(dynamoURL);
 	});
 
-	it("should create Keyv instance with custom table name", (t) => {
+	it("should create a Keyv instance with a custom table name", (t) => {
 		const tableName = faker.string.alphanumeric(10);
 		const keyv = createKeyv({ endpoint: dynamoURL, tableName });
 		t.expect(keyv).toBeDefined();
 		t.expect(keyv.store).toBeInstanceOf(KeyvDynamo);
 		t.expect(keyv.namespace).toBeUndefined();
 		t.expect((keyv.store as KeyvDynamo).namespace).toBeUndefined();
-
 		t.expect((keyv.store as KeyvDynamo).tableName).toBe(tableName);
 	});
 
-	it("should create Keyv instance with both namespace and table name", (t) => {
+	it("should create a Keyv instance with both a namespace and a table name", (t) => {
 		const namespace = faker.string.alphanumeric(10);
 		const tableName = faker.string.alphanumeric(10);
 		const keyv = createKeyv({ endpoint: dynamoURL, namespace, tableName });
@@ -397,66 +595,56 @@ describe("createKeyv", () => {
 		t.expect(keyv.store).toBeInstanceOf(KeyvDynamo);
 		t.expect(keyv.namespace).toBe(namespace);
 		t.expect((keyv.store as KeyvDynamo).namespace).toBe(namespace);
-
 		t.expect((keyv.store as KeyvDynamo).tableName).toBe(tableName);
 	});
 
-	it("should create functional Keyv instance that can store and retrieve values", async (t) => {
+	it("should store and retrieve values through the Keyv instance", async (t) => {
 		const keyv = createKeyv({ endpoint: dynamoURL });
 		const key = faker.string.uuid();
 		const value = faker.lorem.word();
 
 		await keyv.set(key, value);
-		const retrieved = await keyv.get(key);
-		t.expect(retrieved).toBe(value);
+		t.expect(await keyv.get(key)).toBe(value);
 
 		await keyv.delete(key);
-		const deletedValue = await keyv.get(key);
-		t.expect(deletedValue).toBeUndefined();
+		t.expect(await keyv.get(key)).toBeUndefined();
 	});
 
-	it("should create functional Keyv instance with namespace that can store and retrieve values", async (t) => {
+	it("should share namespaced data across Keyv instances", async (t) => {
 		const namespace = faker.string.alphanumeric(10);
 		const keyv = createKeyv({ endpoint: dynamoURL, namespace });
 		const key = faker.string.uuid();
 		const value = faker.lorem.word();
 
 		await keyv.set(key, value);
-		const retrieved = await keyv.get(key);
-		t.expect(retrieved).toBe(value);
+		t.expect(await keyv.get(key)).toBe(value);
 
 		// Create another Keyv instance with same namespace to verify it can access the same data
 		const keyv2 = createKeyv({ endpoint: dynamoURL, namespace });
-		const retrieved2 = await keyv2.get(key);
-		t.expect(retrieved2).toBe(value);
+		t.expect(await keyv2.get(key)).toBe(value);
 
 		await keyv.delete(key);
-		const deletedValue = await keyv.get(key);
-		t.expect(deletedValue).toBeUndefined();
+		t.expect(await keyv.get(key)).toBeUndefined();
 	});
 
-	it("should handle various data types with createKeyv", async (t) => {
+	it("should handle various data types", async (t) => {
 		const keyv = createKeyv({ endpoint: dynamoURL });
 
-		// Test with string
 		const stringKey = faker.string.uuid();
 		const stringValue = faker.lorem.sentence();
 		await keyv.set(stringKey, stringValue);
 		t.expect(await keyv.get(stringKey)).toBe(stringValue);
 
-		// Test with number
 		const numberKey = faker.string.uuid();
 		const numberValue = faker.number.float({ max: 1000 });
 		await keyv.set(numberKey, numberValue);
 		t.expect(await keyv.get(numberKey)).toBe(numberValue);
 
-		// Test with boolean
 		const boolKey = faker.string.uuid();
 		const boolValue = faker.datatype.boolean();
 		await keyv.set(boolKey, boolValue);
 		t.expect(await keyv.get(boolKey)).toBe(boolValue);
 
-		// Test with object
 		const objectKey = faker.string.uuid();
 		const objectValue = {
 			id: faker.string.uuid(),
@@ -472,7 +660,6 @@ describe("createKeyv", () => {
 		await keyv.set(objectKey, objectValue);
 		t.expect(await keyv.get(objectKey)).toEqual(objectValue);
 
-		// Test with array
 		const arrayKey = faker.string.uuid();
 		const arrayValue = [
 			faker.string.uuid(),
@@ -484,14 +671,11 @@ describe("createKeyv", () => {
 		await keyv.set(arrayKey, arrayValue);
 		t.expect(await keyv.get(arrayKey)).toEqual(arrayValue);
 
-		// Test with Date object
 		const dateKey = faker.string.uuid();
 		const dateValue = faker.date.recent();
 		await keyv.set(dateKey, dateValue);
-		const retrievedDate = await keyv.get(dateKey);
-		t.expect(retrievedDate).toBe(dateValue.toISOString());
+		t.expect(await keyv.get(dateKey)).toBe(dateValue.toISOString());
 
-		// Clean up
 		await keyv.delete(stringKey);
 		await keyv.delete(numberKey);
 		await keyv.delete(boolKey);
@@ -499,178 +683,4 @@ describe("createKeyv", () => {
 		await keyv.delete(arrayKey);
 		await keyv.delete(dateKey);
 	});
-});
-
-it("setMany returns false entries when batchWrite fails", async (t) => {
-	const dynamo = store();
-	dynamo.on("error", () => {});
-	// Wait for table to be ready before mocking
-	await dynamo.set("_warmup", "ok");
-	// Mock batchWrite to simulate failure
-	const originalBatchWrite = dynamo._client.batchWrite.bind(dynamo._client);
-	dynamo._client.batchWrite = async () => {
-		throw new Error("batchWrite failure");
-	};
-
-	const result = await dynamo.setMany([
-		{ key: "key1", value: "val1" },
-		{ key: "key2", value: "val2" },
-	]);
-	t.expect(result).toEqual([false, false]);
-	dynamo._client.batchWrite = originalBatchWrite;
-});
-
-it("setMany marks unprocessed items as false", async (t) => {
-	const dynamo = store();
-	dynamo.on("error", () => {});
-	// Wait for table to be ready before mocking
-	await dynamo.set("_warmup", "ok");
-	// Mock batchWrite to return UnprocessedItems for the second key
-	const key2Formatted = dynamo.formatKey("key2");
-	dynamo._client.batchWrite = async (input: any) => {
-		const tableName = Object.keys(input.RequestItems)[0];
-		return {
-			UnprocessedItems: {
-				[tableName]: [{ PutRequest: { Item: { id: key2Formatted } } }],
-			},
-		};
-	};
-
-	const result = await dynamo.setMany([
-		{ key: "key1", value: "val1" },
-		{ key: "key2", value: "val2" },
-	]);
-	t.expect(result?.[0]).toBe(true);
-	t.expect(result?.[1]).toBe(false);
-});
-
-it("setMany with per-entry ttl", async (t) => {
-	const dynamo = new KeyvDynamo({ endpoint: dynamoURL });
-	const key1 = faker.string.uuid();
-	const key2 = faker.string.uuid();
-	const result = await dynamo.setMany([
-		{ key: key1, value: "val1", ttl: 5000 },
-		{ key: key2, value: "val2" },
-	]);
-	t.expect(result).toEqual([true, true]);
-	t.expect(await dynamo.get(key1)).toBe("val1");
-	t.expect(await dynamo.get(key2)).toBe("val2");
-});
-
-it("setMany handles unprocessed items with missing id", async (t) => {
-	const dynamo = store();
-	await dynamo.set("_warmup", "ok");
-	dynamo._client.batchWrite = async (input: any) => {
-		const tableName = Object.keys(input.RequestItems)[0];
-		return {
-			UnprocessedItems: {
-				[tableName]: [{ PutRequest: { Item: {} } }],
-			},
-		};
-	};
-	const result = await dynamo.setMany([{ key: "key1", value: "val1" }]);
-	t.expect(result).toEqual([true]);
-});
-
-it("getMany retries unprocessed keys", async (t) => {
-	const dynamo = store();
-	const key1 = faker.string.uuid();
-	const key2 = faker.string.uuid();
-	await dynamo.set(key1, "val1");
-	await dynamo.set(key2, "val2");
-
-	const originalBatchGet = dynamo._client.batchGet.bind(dynamo._client);
-	let callCount = 0;
-	dynamo._client.batchGet = async (input: any) => {
-		callCount++;
-		if (callCount === 1) {
-			const tableName = Object.keys(input.RequestItems)[0];
-			return {
-				UnprocessedKeys: {
-					[tableName]: {
-						Keys: [{ id: dynamo.formatKey(key1) }, { id: dynamo.formatKey(key2) }],
-					},
-				},
-			};
-		}
-		return originalBatchGet(input);
-	};
-
-	const result = await dynamo.getMany([key1, key2]);
-	t.expect(result).toEqual(["val1", "val2"]);
-	t.expect(callCount).toBe(2);
-	dynamo._client.batchGet = originalBatchGet;
-});
-
-it("iterator with default namespace", async (t) => {
-	const store = new KeyvDynamo({ endpoint: dynamoURL, tableName: faker.string.uuid() });
-	const key1 = faker.string.uuid();
-	const key2 = faker.string.uuid();
-	await store.set(key1, "val1");
-	await store.set(key2, "val2");
-
-	const entries: Array<[string, string]> = [];
-	for await (const entry of store.iterator()) {
-		entries.push(entry as [string, string]);
-	}
-
-	t.expect(entries.length).toBe(2);
-	const keys = entries.map(([key]) => key);
-	t.expect(keys).toContain(key1);
-	t.expect(keys).toContain(key2);
-});
-
-it("iterator with namespace", async (t) => {
-	const tableName = faker.string.uuid();
-	const namespace = faker.string.alphanumeric(10);
-	const store = new KeyvDynamo({ endpoint: dynamoURL, tableName, namespace });
-	const key1 = faker.string.uuid();
-	const key2 = faker.string.uuid();
-	await store.set(key1, "val1");
-	await store.set(key2, "val2");
-
-	// Also set a key without the namespace directly
-	const storeNoNs = new KeyvDynamo({ endpoint: dynamoURL, tableName });
-	await storeNoNs.set("no-ns-key", "val3");
-
-	const entries: Array<[string, string]> = [];
-	for await (const entry of store.iterator()) {
-		entries.push(entry as [string, string]);
-	}
-
-	// Should only return the 2 namespaced keys
-	t.expect(entries.length).toBe(2);
-	const keys = entries.map(([key]) => key);
-	t.expect(keys).toContain(`${namespace}:${key1}`);
-	t.expect(keys).toContain(`${namespace}:${key2}`);
-});
-
-it("hasMany retries unprocessed keys", async (t) => {
-	const dynamo = store();
-	const key1 = faker.string.uuid();
-	const key2 = faker.string.uuid();
-	await dynamo.set(key1, "val1");
-	await dynamo.set(key2, "val2");
-
-	const originalBatchGet = dynamo._client.batchGet.bind(dynamo._client);
-	let callCount = 0;
-	dynamo._client.batchGet = async (input: any) => {
-		callCount++;
-		if (callCount === 1) {
-			const tableName = Object.keys(input.RequestItems)[0];
-			return {
-				UnprocessedKeys: {
-					[tableName]: {
-						Keys: [{ id: dynamo.formatKey(key1) }, { id: dynamo.formatKey(key2) }],
-					},
-				},
-			};
-		}
-		return originalBatchGet(input);
-	};
-
-	const result = await dynamo.hasMany([key1, key2]);
-	t.expect(result).toEqual([true, true]);
-	t.expect(callCount).toBe(2);
-	dynamo._client.batchGet = originalBatchGet;
 });


### PR DESCRIPTION
## Summary

Full code and test review of `@keyv/dynamo`. This addresses the one real bug found (iterator returned namespace-prefixed keys), brings the tests in line with the other storage modules, and fills the documentation gaps in the README.

## Findings

The adapter was in good shape overall — namespacing is handled natively via `formatKey`, and `get`/`getMany`/`has`/`hasMany` already return `undefined` (never `null`) for missing keys, matching the shared storage suite's default `missingValue`. The one functional issue was the iterator.

## Changes

**Source (`src/index.ts`)**
- `iterator()` now strips the namespace prefix from yielded keys via `removeKeyPrefix`, matching `@keyv/redis` and the shared `storageIteratorTests`/`keyvIteratorTests` expectations (which assert un-prefixed keys). Previously it yielded the full `namespace:key`, which is why the shared iterator suite had been disabled. It still takes no namespace argument and uses the adapter's configured namespace natively.

**Tests (`test/test.ts`)**
- Enabled the shared iterator suites: added `keyvIteratorTests(it, Keyv, store)` and removed the `iterator: false` flag from `storageTestSuite`.
- Reorganized the file into `describe` blocks with uniform `it` descriptions, consistent with the other storage adapters.
- Use `faker` for keys and values throughout (replaced the remaining hard-coded literals).
- Updated the namespaced-iterator test to assert the prefix is stripped.

**Docs (`README.md`)**
- Documented the previously-missing `iterator()` and `disconnect()` methods and the read-only `tableName` and `endpoint` properties, and added them to the table of contents.
- Added iterator support to the Features list.

## Verification

Ran against a local DynamoDB (`amazon/dynamodb-local`):
- `vitest run --coverage`: **111 passed**, 100% line coverage (99.53% stmts / 98.91% branch).
- `biome check`: clean.
- `pnpm build`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014rNjKyLHYugwWohw69KTzy

---
_Generated by [Claude Code](https://claude.ai/code/session_014rNjKyLHYugwWohw69KTzy)_