### PR TITLE
mongo - test: uniform test suite, fix README API docs

### DIFF
--- a/storage/mongo/README.md
+++ b/storage/mongo/README.md
@@ -218,9 +218,8 @@ In standard mode, uses a single unordered MongoDB `bulkWrite` operation for effi
 
 ```js
 const store = new KeyvMongo('mongodb://localhost:27017');
-const keyv = new Keyv({ store });
 
-const results = await keyv.set([
+const results = await store.setMany([
   { key: 'key1', value: 'value1' },
   { key: 'key2', value: 'value2', ttl: 5000 },
 ]); // [true, true]
@@ -258,12 +257,11 @@ In standard mode, uses a single MongoDB query with the `$in` operator for effici
 
 ```js
 const store = new KeyvMongo('mongodb://localhost:27017');
-const keyv = new Keyv({ store });
 
-await keyv.set('key1', 'value1');
-await keyv.set('key2', 'value2');
+await store.set('key1', 'value1');
+await store.set('key2', 'value2');
 
-const values = await keyv.get(['key1', 'key2', 'key3']);
+const values = await store.getMany(['key1', 'key2', 'key3']);
 console.log(values); // ['value1', 'value2', undefined]
 ```
 
@@ -294,12 +292,11 @@ Uses a single MongoDB query with the `$in` operator for efficiency in both stand
 
 ```js
 const store = new KeyvMongo('mongodb://localhost:27017');
-const keyv = new Keyv({ store });
 
-await keyv.set('key1', 'value1');
-await keyv.set('key2', 'value2');
+await store.set('key1', 'value1');
+await store.set('key2', 'value2');
 
-const results = await keyv.has(['key1', 'key2', 'key3']);
+const results = await store.hasMany(['key1', 'key2', 'key3']);
 console.log(results); // [true, true, false]
 ```
 
@@ -326,16 +323,15 @@ console.log(await keyv.delete('nonexistent')); // false
 - `keys` *(string[])* - Array of keys to delete.
 - Returns: `Promise<boolean[]>` - An array of booleans indicating whether each key was deleted.
 
-In standard mode, uses a single MongoDB query with the `$in` operator. In GridFS mode, all matching files are found and deleted in parallel.
+Each key is deleted individually in parallel so that per-key success/failure information is preserved in the returned array.
 
 ```js
 const store = new KeyvMongo('mongodb://localhost:27017');
-const keyv = new Keyv({ store });
 
-await keyv.set('key1', 'value1');
-await keyv.set('key2', 'value2');
+await store.set('key1', 'value1');
+await store.set('key2', 'value2');
 
-const results = await keyv.delete(['key1', 'key2', 'key3']); // [true, true, false]
+const results = await store.deleteMany(['key1', 'key2', 'key3']); // [true, true, false]
 ```
 
 ### clear
@@ -541,4 +537,4 @@ await store.clearUnusedFor(3600); // remove files unused for 1 hour
 
 ## License
 
-[MIT © Jared Wray](LISCENCE)
+[MIT © Jared Wray](LICENSE)

--- a/storage/mongo/test/test.ts
+++ b/storage/mongo/test/test.ts
@@ -1,17 +1,17 @@
 // biome-ignore-all lint/suspicious/noExplicitAny: test file
 import { faker } from "@faker-js/faker";
-import { keyvIteratorTests, keyvTestSuite, storageTestSuite } from "@keyv/test-suite";
+import { delay, keyvIteratorTests, keyvTestSuite, storageTestSuite } from "@keyv/test-suite";
 import Keyv from "keyv";
-import { afterAll, it } from "vitest";
+import { afterAll, describe, expect, test } from "vitest";
 import KeyvMongo, { createKeyv } from "../src/index.js";
 
 const options = { serverSelectionTimeoutMS: 5000, db: "keyvdb" };
 const mongoURL = "mongodb://127.0.0.1:27017";
 const store = () => new KeyvMongo(mongoURL, options);
 
-keyvTestSuite(it, Keyv, store);
-keyvIteratorTests(it, Keyv, store);
-storageTestSuite(it, store);
+keyvTestSuite(test, Keyv, store);
+keyvIteratorTests(test, Keyv, store);
+storageTestSuite(test, store);
 
 afterAll(async () => {
 	let keyv = new KeyvMongo({ ...options });
@@ -21,866 +21,788 @@ afterAll(async () => {
 	await keyv.disconnect();
 });
 
-it("Collection option merges into default options if URL is passed", (t) => {
-	const store = new KeyvMongo(mongoURL, { collection: "foo" });
-	t.expect(store.url).toBe(mongoURL);
-	t.expect(store.collection).toBe("foo");
-});
-
-it("URI is passed it is correct", (t) => {
-	const options_ = { uri: "mongodb://127.0.0.1:27017" };
-	const store = new KeyvMongo(options_);
-	t.expect(store.url).toBe(options_.uri);
-});
-
-it("default properties are set correctly", (t) => {
-	const store = new KeyvMongo();
-	t.expect(store.url).toBe("mongodb://127.0.0.1:27017");
-	t.expect(store.collection).toBe("keyv");
-	t.expect(store.useGridFS).toBe(false);
-	t.expect(store.db).toBeUndefined();
-	t.expect(store.namespace).toBeUndefined();
-	t.expect(store.readPreference).toBeUndefined();
-});
-
-it("properties can be set via constructor options", (t) => {
-	const store = new KeyvMongo({
-		url: mongoURL,
-		collection: "custom",
-		useGridFS: true,
-		db: "testdb",
+describe("constructor", () => {
+	test("merges the collection option into defaults when a url string is passed", () => {
+		const store = new KeyvMongo(mongoURL, { collection: "foo" });
+		expect(store.url).toBe(mongoURL);
+		expect(store.collection).toBe("foo");
 	});
-	t.expect(store.url).toBe(mongoURL);
-	t.expect(store.collection).toBe("custom");
-	t.expect(store.useGridFS).toBe(true);
-	t.expect(store.db).toBe("testdb");
-});
 
-it("properties can be modified via setters", (t) => {
-	const store = new KeyvMongo();
-	store.url = "mongodb://localhost:27018";
-	t.expect(store.url).toBe("mongodb://localhost:27018");
-	store.namespace = "test-ns";
-	t.expect(store.namespace).toBe("test-ns");
-	store.collection = "custom-collection";
-	t.expect(store.collection).toBe("custom-collection");
-	store.db = "mydb";
-	t.expect(store.db).toBe("mydb");
-	store.readPreference = undefined;
-	t.expect(store.readPreference).toBeUndefined();
-});
-
-it("constructor with undefined url and options sets properties", (t) => {
-	const store = new KeyvMongo(undefined, {
-		collection: "from-options",
-		db: "optionsdb",
-		readPreference: "primary" as any,
+	test("uses the uri option as the url", () => {
+		const store = new KeyvMongo({ uri: mongoURL });
+		expect(store.url).toBe(mongoURL);
 	});
-	t.expect(store.collection).toBe("from-options");
-	t.expect(store.db).toBe("optionsdb");
-	t.expect(store.readPreference).toBe("primary");
-});
 
-it("properties are set correctly with url and options", (t) => {
-	const store = new KeyvMongo(mongoURL, { collection: "cache", ...options });
-	t.expect(store.url).toBe(mongoURL);
-	t.expect(store.collection).toBe("cache");
-});
-
-it("Stores value in GridFS", async (t) => {
-	const store = new KeyvMongo({ useGridFS: true, ...options });
-	const key = faker.string.alphanumeric(10);
-	const result = await store.set(key, "keyv1", 0);
-	const get = await store.get(key);
-	t.expect(result).toBe(true);
-	t.expect(get).toBe("keyv1");
-});
-
-it("Gets value from GridFS", async (t) => {
-	const store = new KeyvMongo({ useGridFS: true, ...options });
-	const key = faker.string.alphanumeric(10);
-	await store.set(key, "keyv1");
-	const result = await store.get(key);
-	t.expect(result).toBe("keyv1");
-});
-
-it("Deletes value from GridFS", async (t) => {
-	const store = new KeyvMongo({ useGridFS: true, ...options });
-	const key = faker.string.alphanumeric(10);
-	await store.set(key, "keyv1");
-	const result = await store.delete(key);
-	t.expect(result).toBeTruthy();
-});
-
-it("Deletes non existent value from GridFS", async (t) => {
-	const store = new KeyvMongo({ useGridFS: true, ...options });
-	const result = await store.delete(faker.string.alphanumeric(10));
-	t.expect(result).toBeFalsy();
-});
-
-it("Stores value with TTL in GridFS", async (t) => {
-	const store = new KeyvMongo({ useGridFS: true, ...options });
-	const key = faker.string.alphanumeric(10);
-	const result = await store.set(key, "keyv1", 0);
-	t.expect(result).toBe(true);
-});
-
-it("Clears expired value from GridFS", async (t) => {
-	const store = new KeyvMongo({ useGridFS: true, ...options });
-	const key = faker.string.alphanumeric(10);
-	await store.set(key, "expired-value", 0);
-	const cleared = await store.clearExpired();
-	t.expect(cleared).toBeTruthy();
-});
-
-it("Clears unused files from GridFS", async (t) => {
-	const store = new KeyvMongo({ useGridFS: true, ...options });
-	const key = faker.string.alphanumeric(10);
-	await store.set(key, "unused-value");
-	const cleared = await store.clearUnusedFor(0);
-	t.expect(cleared).toBeTruthy();
-});
-
-it("Clears expired value only when GridFS options is true", async (t) => {
-	const store = new KeyvMongo(Object.assign(options));
-	const cleared = await store.clearExpired();
-	t.expect(cleared).toBeFalsy();
-});
-
-it("Clears unused files only when GridFS options is true", async (t) => {
-	const store = new KeyvMongo(Object.assign(options));
-	const cleared = await store.clearUnusedFor(5);
-	t.expect(cleared).toBeFalsy();
-});
-
-it("Gets non-existent file and return should be undefined", async (t) => {
-	const store = new KeyvMongo({ useGridFS: true, ...options });
-	const result = await store.get(faker.string.alphanumeric(10));
-	t.expect(typeof result).toBe("undefined");
-});
-
-it("Non-string keys are not permitted in delete", async (t) => {
-	const store = new KeyvMongo({ useGridFS: true, ...options });
-	// @ts-expect-error - test invalid input
-	const result = await store.delete({
-		ok: true,
+	test("sets default properties", () => {
+		const store = new KeyvMongo();
+		expect(store.url).toBe(mongoURL);
+		expect(store.collection).toBe("keyv");
+		expect(store.useGridFS).toBe(false);
+		expect(store.db).toBeUndefined();
+		expect(store.namespace).toBeUndefined();
+		expect(store.readPreference).toBeUndefined();
 	});
-	t.expect(result).toBeFalsy();
-});
 
-it(".deleteMany([keys]) should delete multiple gridfs key", async (t) => {
-	const keyv = new KeyvMongo({ useGridFS: true, ...options });
-	const keys = [
-		faker.string.alphanumeric(10),
-		faker.string.alphanumeric(10),
-		faker.string.alphanumeric(10),
-	];
-	await keyv.set(keys[0], "bar");
-	await keyv.set(keys[1], "bar1");
-	await keyv.set(keys[2], "bar2");
-	t.expect(await keyv.deleteMany(keys)).toBeTruthy();
-	t.expect(await keyv.get(keys[0])).toBeUndefined();
-	t.expect(await keyv.get(keys[1])).toBeUndefined();
-	t.expect(await keyv.get(keys[2])).toBeUndefined();
-});
-
-it(".deleteMany([keys]) with nonexistent gridfs keys resolves to false", async (t) => {
-	const keyv = new KeyvMongo({ useGridFS: true, ...options });
-	t.expect(
-		await keyv.deleteMany([faker.string.alphanumeric(10), faker.string.alphanumeric(10)]),
-	).toEqual([false, false]);
-});
-
-it(".getMany([keys]) using GridFS should return array values", async (t) => {
-	const keyv = new KeyvMongo({ useGridFS: true, ...options });
-	const keys = [
-		faker.string.alphanumeric(10),
-		faker.string.alphanumeric(10),
-		faker.string.alphanumeric(10),
-	];
-	await keyv.set(keys[0], "bar");
-	await keyv.set(keys[1], "bar1");
-	await keyv.set(keys[2], "bar2");
-	const values = await keyv.getMany<string>(keys);
-	t.expect(Array.isArray(values)).toBeTruthy();
-	t.expect(values[0]).toBe("bar");
-	t.expect(values[1]).toBe("bar1");
-	t.expect(values[2]).toBe("bar2");
-});
-
-it(".getMany([keys]) using GridFS should return array values with undefined", async (t) => {
-	const keyv = new KeyvMongo({ useGridFS: true, ...options });
-	const keys = [
-		faker.string.alphanumeric(10),
-		faker.string.alphanumeric(10),
-		faker.string.alphanumeric(10),
-	];
-	await keyv.set(keys[0], "bar");
-	await keyv.set(keys[2], "bar2");
-	const values = await keyv.getMany<string>(keys);
-	t.expect(Array.isArray(values)).toBeTruthy();
-	t.expect(values[0]).toBe("bar");
-	t.expect(values[1]).toBeUndefined();
-	t.expect(values[2]).toBe("bar2");
-});
-
-it(".getMany([keys]) using GridFS should return empty array for all no existent keys", async (t) => {
-	const keyv = new KeyvMongo({ useGridFS: true, ...options });
-	const values = await keyv.getMany<string>([
-		faker.string.alphanumeric(10),
-		faker.string.alphanumeric(10),
-		faker.string.alphanumeric(10),
-	]);
-	t.expect(Array.isArray(values)).toBeTruthy();
-	t.expect(values).toStrictEqual([undefined, undefined, undefined]);
-});
-
-it("Clears entire cache store", async (t) => {
-	const store = new KeyvMongo({ useGridFS: true, ...options });
-	const result = await store.clear();
-	t.expect(typeof result).toBe("undefined");
-});
-
-it("Clears entire cache store with default namespace", async (t) => {
-	const store = new KeyvMongo({ ...options });
-	const result = await store.clear();
-	t.expect(typeof result).toBe("undefined");
-});
-
-it("Clears an empty store should not fail", async (_t) => {
-	const store = new KeyvMongo({ ...options });
-	await store.clear();
-	await store.clear();
-});
-
-it("Clears an empty store GridFS should not fail", async (_t) => {
-	const store = new KeyvMongo({ useGridFS: true, ...options });
-	await store.clear();
-	await store.clear();
-});
-
-it("iterator with default namespace", async (t) => {
-	const store = new KeyvMongo({ ...options });
-	await store.clear();
-	const key1 = faker.string.alphanumeric(10);
-	const key2 = faker.string.alphanumeric(10);
-	await store.set(key1, "bar");
-	await store.set(key2, "bar2");
-	const results: Array<[string, string]> = [];
-	for await (const entry of store.iterator()) {
-		results.push(entry as [string, string]);
-	}
-
-	t.expect(results.length).toBeGreaterThanOrEqual(2);
-	const keys = results.map(([k]) => k);
-	t.expect(keys).toContain(key1);
-	t.expect(keys).toContain(key2);
-});
-
-it("iterator with namespace", async (t) => {
-	const ns = faker.string.alphanumeric(8);
-	const store = new KeyvMongo({ namespace: ns, ...options });
-	await store.clear();
-	const key1 = faker.string.alphanumeric(10);
-	const key2 = faker.string.alphanumeric(10);
-	await store.set(key1, "bar");
-	await store.set(key2, "bar2");
-	const results: Array<[string, string]> = [];
-	for await (const entry of store.iterator()) {
-		results.push(entry as [string, string]);
-	}
-
-	t.expect(results.length).toBe(2);
-	const keys = results.map(([k]) => k);
-	t.expect(keys).toContain(key1);
-	t.expect(keys).toContain(key2);
-});
-
-it("iterator with default namespace using GridFS", async (t) => {
-	const store = new KeyvMongo({ useGridFS: true, ...options });
-	await store.clear();
-	const key1 = faker.string.alphanumeric(10);
-	const key2 = faker.string.alphanumeric(10);
-	await store.set(key1, "bar");
-	await store.set(key2, "bar2");
-	const results: Array<[string, string]> = [];
-	for await (const entry of store.iterator()) {
-		results.push(entry as [string, string]);
-	}
-
-	t.expect(results.length).toBeGreaterThanOrEqual(2);
-	const keys = results.map(([k]) => k);
-	t.expect(keys).toContain(key1);
-	t.expect(keys).toContain(key2);
-});
-
-it("iterator with namespace using GridFS", async (t) => {
-	const ns = faker.string.alphanumeric(8);
-	const store = new KeyvMongo({
-		namespace: ns,
-		useGridFS: true,
-		...options,
+	test("sets properties from constructor options", () => {
+		const store = new KeyvMongo({
+			url: mongoURL,
+			collection: "custom",
+			useGridFS: true,
+			db: "testdb",
+		});
+		expect(store.url).toBe(mongoURL);
+		expect(store.collection).toBe("custom");
+		expect(store.useGridFS).toBe(true);
+		expect(store.db).toBe("testdb");
 	});
-	await store.clear();
-	const key1 = faker.string.alphanumeric(10);
-	const key2 = faker.string.alphanumeric(10);
-	await store.set(key1, "bar");
-	await store.set(key2, "bar2");
-	const results: Array<[string, string]> = [];
-	for await (const entry of store.iterator()) {
-		results.push(entry as [string, string]);
-	}
 
-	t.expect(results.length).toBe(2);
-	const keys = results.map(([k]) => k);
-	t.expect(keys).toContain(key1);
-	t.expect(keys).toContain(key2);
-});
-
-it("Close connection successfully on GridFS", async (t) => {
-	const keyv = new KeyvMongo({ useGridFS: true, ...options });
-	t.expect(await keyv.get(faker.string.alphanumeric(10))).toBeUndefined();
-	await keyv.disconnect();
-	try {
-		await keyv.get(faker.string.alphanumeric(10));
-		t.expect.fail();
-	} catch {
-		t.expect(true).toBeTruthy();
-	}
-});
-
-it("Close connection successfully", async (t) => {
-	const ns = faker.string.alphanumeric(8);
-	const keyv = new KeyvMongo({ namespace: ns, ...options });
-	t.expect(await keyv.get(faker.string.alphanumeric(10))).toBeUndefined();
-	await keyv.disconnect();
-	try {
-		await keyv.get(faker.string.alphanumeric(10));
-		t.expect.fail();
-	} catch {
-		t.expect(true).toBeTruthy();
-	}
-});
-
-it("Close connection should fail", async (t) => {
-	const ns = faker.string.alphanumeric(8);
-	const keyv = new KeyvMongo({ namespace: ns, ...options });
-	try {
-		await keyv.disconnect();
-	} catch {
-		t.expect(true).toBeTruthy();
-	}
-});
-
-it("createKeyv with URI string returns a Keyv instance", async (t) => {
-	const keyv = createKeyv(mongoURL);
-	t.expect(keyv).toBeInstanceOf(Keyv);
-	const key = faker.string.alphanumeric(10);
-	await keyv.set(key, "value");
-	t.expect(await keyv.get(key)).toBe("value");
-});
-
-it("createKeyv with options object returns a Keyv instance", async (t) => {
-	const keyv = createKeyv({ url: mongoURL, collection: "keyv", ...options });
-	t.expect(keyv).toBeInstanceOf(Keyv);
-	const key = faker.string.alphanumeric(10);
-	await keyv.set(key, "value");
-	t.expect(await keyv.get(key)).toBe("value");
-});
-
-it("createKeyv with namespace option", async (t) => {
-	const ns = faker.string.alphanumeric(8);
-	const keyv = createKeyv({ namespace: ns, url: mongoURL, ...options });
-	t.expect(keyv.namespace).toBe(ns);
-	const key = faker.string.alphanumeric(10);
-	await keyv.set(key, "bar");
-	t.expect(await keyv.get(key)).toBe("bar");
-	const storeInstance = keyv.store as KeyvMongo;
-	const rawValue = await storeInstance.get(`${ns}:${key}`);
-	t.expect(rawValue).toBeDefined();
-});
-
-it("createKeyv with different namespaces do not conflict", async (t) => {
-	const nsA = faker.string.alphanumeric(8);
-	const nsB = faker.string.alphanumeric(8);
-	const keyvA = createKeyv({ namespace: nsA, url: mongoURL, ...options });
-	const keyvB = createKeyv({ namespace: nsB, url: mongoURL, ...options });
-
-	const key = faker.string.alphanumeric(10);
-	await keyvA.set(key, "valueA");
-	await keyvB.set(key, "valueB");
-
-	t.expect(await keyvA.get(key)).toBe("valueA");
-	t.expect(await keyvB.get(key)).toBe("valueB");
-
-	// clear only affects its own namespace
-	await keyvA.clear();
-	t.expect(await keyvA.get(key)).toBeUndefined();
-	t.expect(await keyvB.get(key)).toBe("valueB");
-});
-
-// Native namespace tests - Standard mode
-it("native namespace: same key in different namespaces stored independently", async (t) => {
-	const ns1 = faker.string.alphanumeric(8);
-	const ns2 = faker.string.alphanumeric(8);
-	const mongo1 = new KeyvMongo({ ...options });
-	mongo1.namespace = ns1;
-	const mongo2 = new KeyvMongo({ ...options });
-	mongo2.namespace = ns2;
-
-	const key = faker.string.alphanumeric(10);
-	await mongo1.set(`${ns1}:${key}`, "value1");
-	await mongo2.set(`${ns2}:${key}`, "value2");
-
-	t.expect(await mongo1.get(`${ns1}:${key}`)).toBe("value1");
-	t.expect(await mongo2.get(`${ns2}:${key}`)).toBe("value2");
-});
-
-it("native namespace: null namespace stores and retrieves correctly", async (t) => {
-	const keyv = new KeyvMongo({ ...options });
-	const key = faker.string.alphanumeric(10);
-	await keyv.set(key, "testvalue");
-	t.expect(await keyv.get(key)).toBe("testvalue");
-});
-
-it("native namespace: clear only clears the specified namespace", async (t) => {
-	const ns1 = faker.string.alphanumeric(8);
-	const ns2 = faker.string.alphanumeric(8);
-	const mongo1 = new KeyvMongo({ ...options });
-	mongo1.namespace = ns1;
-	const mongo2 = new KeyvMongo({ ...options });
-	mongo2.namespace = ns2;
-
-	const key = faker.string.alphanumeric(10);
-	await mongo1.set(`${ns1}:${key}`, "value1");
-	await mongo2.set(`${ns2}:${key}`, "value2");
-
-	await mongo1.clear();
-
-	t.expect(await mongo1.get(`${ns1}:${key}`)).toBeUndefined();
-	t.expect(await mongo2.get(`${ns2}:${key}`)).toBe("value2");
-});
-
-it("native namespace: delete scoped to namespace", async (t) => {
-	const ns1 = faker.string.alphanumeric(8);
-	const ns2 = faker.string.alphanumeric(8);
-	const mongo1 = new KeyvMongo({ ...options });
-	mongo1.namespace = ns1;
-	const mongo2 = new KeyvMongo({ ...options });
-	mongo2.namespace = ns2;
-
-	const key = faker.string.alphanumeric(10);
-	await mongo1.set(`${ns1}:${key}`, "val1");
-	await mongo2.set(`${ns2}:${key}`, "val2");
-
-	const deleted = await mongo1.delete(`${ns1}:${key}`);
-	t.expect(deleted).toBe(true);
-	t.expect(await mongo1.get(`${ns1}:${key}`)).toBeUndefined();
-	t.expect(await mongo2.get(`${ns2}:${key}`)).toBe("val2");
-});
-
-it("native namespace: deleteMany scoped to namespace", async (t) => {
-	const ns1 = faker.string.alphanumeric(8);
-	const ns2 = faker.string.alphanumeric(8);
-	const mongo1 = new KeyvMongo({ ...options });
-	mongo1.namespace = ns1;
-	const mongo2 = new KeyvMongo({ ...options });
-	mongo2.namespace = ns2;
-
-	const key = faker.string.alphanumeric(10);
-	await mongo1.set(`${ns1}:${key}`, "val1");
-	await mongo2.set(`${ns2}:${key}`, "val2");
-
-	const deleted = await mongo1.deleteMany([`${ns1}:${key}`]);
-	t.expect(deleted).toEqual([true]);
-	t.expect(await mongo1.get(`${ns1}:${key}`)).toBeUndefined();
-	t.expect(await mongo2.get(`${ns2}:${key}`)).toBe("val2");
-});
-
-it("native namespace: has scoped to namespace", async (t) => {
-	const ns1 = faker.string.alphanumeric(8);
-	const ns2 = faker.string.alphanumeric(8);
-	const mongo1 = new KeyvMongo({ ...options });
-	mongo1.namespace = ns1;
-	const mongo2 = new KeyvMongo({ ...options });
-	mongo2.namespace = ns2;
-
-	const key = faker.string.alphanumeric(10);
-	await mongo1.set(`${ns1}:${key}`, "val1");
-
-	t.expect(await mongo1.has(`${ns1}:${key}`)).toBe(true);
-	t.expect(await mongo2.has(`${ns2}:${key}`)).toBe(false);
-});
-
-it("native namespace: iterator only returns keys from correct namespace", async (t) => {
-	const ns1 = faker.string.alphanumeric(8);
-	const ns2 = faker.string.alphanumeric(8);
-	const mongo1 = new KeyvMongo({ ...options });
-	mongo1.namespace = ns1;
-	const mongo2 = new KeyvMongo({ ...options });
-	mongo2.namespace = ns2;
-
-	const key1 = faker.string.alphanumeric(10);
-	const key2 = faker.string.alphanumeric(10);
-	await mongo1.set(key1, "val1");
-	await mongo1.set(key2, "val2");
-	await mongo2.set(faker.string.alphanumeric(10), "val3");
-
-	const keys: string[] = [];
-	for await (const [key] of mongo1.iterator()) {
-		keys.push(key);
-	}
-
-	t.expect(keys.length).toBe(2);
-	t.expect(keys).toContain(key1);
-	t.expect(keys).toContain(key2);
-});
-
-it("native namespace: two Keyv instances with different namespaces do not conflict", async (t) => {
-	const nsA = faker.string.alphanumeric(8);
-	const nsB = faker.string.alphanumeric(8);
-	const mongoA = new KeyvMongo({ ...options });
-	const mongoB = new KeyvMongo({ ...options });
-	const keyvA = new Keyv({ store: mongoA, namespace: nsA });
-	const keyvB = new Keyv({ store: mongoB, namespace: nsB });
-
-	const key = faker.string.alphanumeric(10);
-	t.expect(await keyvA.set(key, "valueA")).toBe(true);
-	t.expect(await keyvA.get(key)).toBe("valueA");
-	t.expect(await keyvB.set(key, "valueB")).toBe(true);
-	t.expect(await keyvB.get(key)).toBe("valueB");
-	// Ensure they didn't overwrite each other
-	t.expect(await keyvA.get(key)).toBe("valueA");
-});
-
-it("native namespace: getMany scoped to namespace", async (t) => {
-	const ns1 = faker.string.alphanumeric(8);
-	const ns2 = faker.string.alphanumeric(8);
-	const mongo1 = new KeyvMongo({ ...options });
-	mongo1.namespace = ns1;
-	const mongo2 = new KeyvMongo({ ...options });
-	mongo2.namespace = ns2;
-
-	const key = faker.string.alphanumeric(10);
-	await mongo1.set(`${ns1}:${key}`, "val1");
-	await mongo2.set(`${ns2}:${key}`, "val2");
-
-	const results = await mongo1.getMany([`${ns1}:${key}`]);
-	t.expect(results).toEqual(["val1"]);
-
-	const results2 = await mongo1.getMany([`${ns2}:${key}`]);
-	t.expect(results2).toEqual([undefined]);
-});
-
-// Native namespace tests - GridFS mode
-it("native namespace GridFS: same key in different namespaces stored independently", async (t) => {
-	const ns1 = faker.string.alphanumeric(8);
-	const ns2 = faker.string.alphanumeric(8);
-	const mongo1 = new KeyvMongo({ useGridFS: true, ...options });
-	mongo1.namespace = ns1;
-	const mongo2 = new KeyvMongo({ useGridFS: true, ...options });
-	mongo2.namespace = ns2;
-
-	const key = faker.string.alphanumeric(10);
-	await mongo1.set(`${ns1}:${key}`, "value1");
-	await mongo2.set(`${ns2}:${key}`, "value2");
-
-	t.expect(await mongo1.get(`${ns1}:${key}`)).toBe("value1");
-	t.expect(await mongo2.get(`${ns2}:${key}`)).toBe("value2");
-});
-
-it("native namespace GridFS: clear only clears the specified namespace", async (t) => {
-	const ns1 = faker.string.alphanumeric(8);
-	const ns2 = faker.string.alphanumeric(8);
-	const mongo1 = new KeyvMongo({ useGridFS: true, ...options });
-	mongo1.namespace = ns1;
-	const mongo2 = new KeyvMongo({ useGridFS: true, ...options });
-	mongo2.namespace = ns2;
-
-	const key = faker.string.alphanumeric(10);
-	await mongo1.set(`${ns1}:${key}`, "value1");
-	await mongo2.set(`${ns2}:${key}`, "value2");
-
-	await mongo1.clear();
-
-	t.expect(await mongo1.get(`${ns1}:${key}`)).toBeUndefined();
-	t.expect(await mongo2.get(`${ns2}:${key}`)).toBe("value2");
-});
-
-it("native namespace GridFS: delete scoped to namespace", async (t) => {
-	const ns1 = faker.string.alphanumeric(8);
-	const ns2 = faker.string.alphanumeric(8);
-	const mongo1 = new KeyvMongo({ useGridFS: true, ...options });
-	mongo1.namespace = ns1;
-	const mongo2 = new KeyvMongo({ useGridFS: true, ...options });
-	mongo2.namespace = ns2;
-
-	const key = faker.string.alphanumeric(10);
-	await mongo1.set(`${ns1}:${key}`, "val1");
-	await mongo2.set(`${ns2}:${key}`, "val2");
-
-	const deleted = await mongo1.delete(`${ns1}:${key}`);
-	t.expect(deleted).toBe(true);
-	t.expect(await mongo1.get(`${ns1}:${key}`)).toBeUndefined();
-	t.expect(await mongo2.get(`${ns2}:${key}`)).toBe("val2");
-});
-
-it("native namespace GridFS: has scoped to namespace", async (t) => {
-	const ns1 = faker.string.alphanumeric(8);
-	const ns2 = faker.string.alphanumeric(8);
-	const mongo1 = new KeyvMongo({ useGridFS: true, ...options });
-	mongo1.namespace = ns1;
-	const mongo2 = new KeyvMongo({ useGridFS: true, ...options });
-	mongo2.namespace = ns2;
-
-	const key = faker.string.alphanumeric(10);
-	await mongo1.set(`${ns1}:${key}`, "val1");
-
-	t.expect(await mongo1.has(`${ns1}:${key}`)).toBe(true);
-	t.expect(await mongo2.has(`${ns2}:${key}`)).toBe(false);
-});
-
-it("native namespace GridFS: two Keyv instances with different namespaces do not conflict", async (t) => {
-	const nsA = faker.string.alphanumeric(8);
-	const nsB = faker.string.alphanumeric(8);
-	const mongoA = new KeyvMongo({ useGridFS: true, ...options });
-	const mongoB = new KeyvMongo({ useGridFS: true, ...options });
-	const keyvA = new Keyv({ store: mongoA, namespace: nsA });
-	const keyvB = new Keyv({ store: mongoB, namespace: nsB });
-
-	const key = faker.string.alphanumeric(10);
-	t.expect(await keyvA.set(key, "valueA")).toBe(true);
-	t.expect(await keyvA.get(key)).toBe("valueA");
-	t.expect(await keyvB.set(key, "valueB")).toBe(true);
-	t.expect(await keyvB.get(key)).toBe("valueB");
-	// Ensure they didn't overwrite each other
-	t.expect(await keyvA.get(key)).toBe("valueA");
-});
-
-it("setMany with TTL in standard mode", async (t) => {
-	const store = new KeyvMongo({ ...options });
-	const keys = [faker.string.alphanumeric(10), faker.string.alphanumeric(10)];
-	await store.setMany([
-		{ key: keys[0], value: "val1", ttl: 60000 },
-		{ key: keys[1], value: "val2" },
-	]);
-	t.expect(await store.get(keys[0])).toBe("val1");
-	t.expect(await store.get(keys[1])).toBe("val2");
-});
-
-it("setMany upserts existing keys in standard mode", async (t) => {
-	const store = new KeyvMongo({ ...options });
-	const key = faker.string.alphanumeric(10);
-	await store.set(key, "original");
-	await store.setMany([{ key, value: "updated" }]);
-	t.expect(await store.get(key)).toBe("updated");
-});
-
-it("setMany with namespace in standard mode", async (t) => {
-	const ns = faker.string.alphanumeric(8);
-	const store = new KeyvMongo({ ...options });
-	store.namespace = ns;
-	const keys = [`${ns}:${faker.string.alphanumeric(10)}`, `${ns}:${faker.string.alphanumeric(10)}`];
-	await store.setMany([
-		{ key: keys[0], value: "val1" },
-		{ key: keys[1], value: "val2" },
-	]);
-	t.expect(await store.get(keys[0])).toBe("val1");
-	t.expect(await store.get(keys[1])).toBe("val2");
-});
-
-// setMany tests - GridFS mode
-it("setMany sets multiple keys in GridFS mode", async (t) => {
-	const store = new KeyvMongo({ useGridFS: true, ...options });
-	const keys = [faker.string.alphanumeric(10), faker.string.alphanumeric(10)];
-	await store.setMany([
-		{ key: keys[0], value: "val1" },
-		{ key: keys[1], value: "val2" },
-	]);
-	t.expect(await store.get(keys[0])).toBe("val1");
-	t.expect(await store.get(keys[1])).toBe("val2");
-});
-
-it("hasMany with namespace in standard mode", async (t) => {
-	const ns1 = faker.string.alphanumeric(8);
-	const ns2 = faker.string.alphanumeric(8);
-	const store1 = new KeyvMongo({ ...options });
-	store1.namespace = ns1;
-	const store2 = new KeyvMongo({ ...options });
-	store2.namespace = ns2;
-
-	const key = faker.string.alphanumeric(10);
-	await store1.set(`${ns1}:${key}`, "val1");
-	await store2.set(`${ns2}:${key}`, "val2");
-
-	const results = await store1.hasMany([
-		`${ns1}:${key}`,
-		`${ns1}:${faker.string.alphanumeric(10)}`,
-	]);
-	t.expect(results).toEqual([true, false]);
-});
-
-// hasMany tests - GridFS mode
-it("hasMany checks multiple keys in GridFS mode", async (t) => {
-	const store = new KeyvMongo({ useGridFS: true, ...options });
-	const keys = [
-		faker.string.alphanumeric(10),
-		faker.string.alphanumeric(10),
-		faker.string.alphanumeric(10),
-	];
-	await store.set(keys[0], "val1");
-	await store.set(keys[1], "val2");
-	const results = await store.hasMany(keys);
-	t.expect(results).toEqual([true, true, false]);
-});
-
-it("hasMany with namespace in GridFS mode", async (t) => {
-	const ns1 = faker.string.alphanumeric(8);
-	const ns2 = faker.string.alphanumeric(8);
-	const store1 = new KeyvMongo({ useGridFS: true, ...options });
-	store1.namespace = ns1;
-	const store2 = new KeyvMongo({ useGridFS: true, ...options });
-	store2.namespace = ns2;
-
-	const key = faker.string.alphanumeric(10);
-	await store1.set(`${ns1}:${key}`, "val1");
-	await store2.set(`${ns2}:${key}`, "val2");
-
-	const results = await store1.hasMany([
-		`${ns1}:${key}`,
-		`${ns1}:${faker.string.alphanumeric(10)}`,
-	]);
-	t.expect(results).toEqual([true, false]);
-});
-
-it("setMany returns false entries on bulkWrite error in standard mode", async (t) => {
-	const store = new KeyvMongo({ ...options });
-	const client = await store.connect;
-	// Close the connection to make bulkWrite throw
-	await client.mongoClient.close();
-	let emittedError = false;
-	store.on("error", () => {
-		emittedError = true;
+	test("updates properties via setters", () => {
+		const store = new KeyvMongo();
+		store.url = "mongodb://localhost:27018";
+		expect(store.url).toBe("mongodb://localhost:27018");
+		store.namespace = "test-ns";
+		expect(store.namespace).toBe("test-ns");
+		store.collection = "custom-collection";
+		expect(store.collection).toBe("custom-collection");
+		store.db = "mydb";
+		expect(store.db).toBe("mydb");
+		store.readPreference = undefined;
+		expect(store.readPreference).toBeUndefined();
 	});
-	const result = await store.setMany([
-		{ key: "key1", value: "val1" },
-		{ key: "key2", value: "val2" },
-	]);
-	t.expect(result).toEqual([false, false]);
-	t.expect(emittedError).toBe(true);
-});
 
-it("setMany handles MongoBulkWriteError with per-entry tracking", async (t) => {
-	const { MongoBulkWriteError } = await import("mongodb");
-	const store = new KeyvMongo({ ...options });
-	const client = await store.connect;
-	const originalBulkWrite = client.store.bulkWrite.bind(client.store);
-	// Mock bulkWrite to throw a MongoBulkWriteError with a write error at index 1
-	client.store.bulkWrite = async () => {
-		const bulkError = new MongoBulkWriteError(
-			{
-				message: "write error",
-				code: 11000,
-				writeErrors: [{ index: 1, code: 11000, errmsg: "dup key" }] as any,
-			},
-			{
-				insertedCount: 1,
-				matchedCount: 0,
-				modifiedCount: 0,
-				deletedCount: 0,
-				upsertedCount: 0,
-				insertedIds: {},
-				upsertedIds: {},
-			} as any,
-		);
-		throw bulkError;
-	};
-
-	let emittedError = false;
-	store.on("error", () => {
-		emittedError = true;
+	test("sets properties from options when the url is undefined", () => {
+		const store = new KeyvMongo(undefined, {
+			collection: "from-options",
+			db: "optionsdb",
+			readPreference: "primary" as any,
+		});
+		expect(store.collection).toBe("from-options");
+		expect(store.db).toBe("optionsdb");
+		expect(store.readPreference).toBe("primary");
 	});
-	const result = await store.setMany([
-		{ key: "key1", value: "val1" },
-		{ key: "key2", value: "val2" },
-		{ key: "key3", value: "val3" },
-	]);
-	t.expect(result).toEqual([true, false, true]);
-	t.expect(emittedError).toBe(true);
-	client.store.bulkWrite = originalBulkWrite;
+
+	test("sets the url and collection from a url string and options", () => {
+		const store = new KeyvMongo(mongoURL, { collection: "cache", ...options });
+		expect(store.url).toBe(mongoURL);
+		expect(store.collection).toBe("cache");
+	});
 });
 
-it("setMany returns per-entry results on GridFS error", async (t) => {
-	const store = new KeyvMongo({ useGridFS: true, ...options });
-	// Mock the set method to throw for the second call
-	let callCount = 0;
-	const originalSet = store.set.bind(store);
-	store.set = async (key: string, value: any, ttl?: number) => {
-		callCount++;
-		if (callCount === 2) {
-			throw new Error("GridFS set failure");
+describe("get", () => {
+	test("returns undefined for a missing key", async () => {
+		const store = new KeyvMongo({ ...options });
+		expect(await store.get(faker.string.alphanumeric(10))).toBeUndefined();
+	});
+
+	test("returns undefined and deletes an expired entry", async () => {
+		const store = new KeyvMongo({ ...options });
+		const key = faker.string.alphanumeric(10);
+		await store.set(key, "expiring-value", 1);
+		await delay(50);
+		expect(await store.get(key)).toBeUndefined();
+	});
+
+	test("returns undefined for a missing key in GridFS", async () => {
+		const store = new KeyvMongo({ useGridFS: true, ...options });
+		expect(await store.get(faker.string.alphanumeric(10))).toBeUndefined();
+	});
+
+	test("returns a stored value in GridFS", async () => {
+		const store = new KeyvMongo({ useGridFS: true, ...options });
+		const key = faker.string.alphanumeric(10);
+		await store.set(key, "keyv1");
+		expect(await store.get(key)).toBe("keyv1");
+	});
+
+	test("returns undefined and deletes an expired entry in GridFS", async () => {
+		const store = new KeyvMongo({ useGridFS: true, ...options });
+		const key = faker.string.alphanumeric(10);
+		await store.set(key, "expiring-value", 1);
+		await delay(50);
+		expect(await store.get(key)).toBeUndefined();
+	});
+});
+
+describe("getMany", () => {
+	test("returns values in order in GridFS", async () => {
+		const store = new KeyvMongo({ useGridFS: true, ...options });
+		const keys = [
+			faker.string.alphanumeric(10),
+			faker.string.alphanumeric(10),
+			faker.string.alphanumeric(10),
+		];
+		await store.set(keys[0], "bar");
+		await store.set(keys[1], "bar1");
+		await store.set(keys[2], "bar2");
+		expect(await store.getMany<string>(keys)).toEqual(["bar", "bar1", "bar2"]);
+	});
+
+	test("returns undefined for missing keys among present ones in GridFS", async () => {
+		const store = new KeyvMongo({ useGridFS: true, ...options });
+		const keys = [
+			faker.string.alphanumeric(10),
+			faker.string.alphanumeric(10),
+			faker.string.alphanumeric(10),
+		];
+		await store.set(keys[0], "bar");
+		await store.set(keys[2], "bar2");
+		expect(await store.getMany<string>(keys)).toEqual(["bar", undefined, "bar2"]);
+	});
+
+	test("returns all undefined when no keys exist in GridFS", async () => {
+		const store = new KeyvMongo({ useGridFS: true, ...options });
+		const values = await store.getMany<string>([
+			faker.string.alphanumeric(10),
+			faker.string.alphanumeric(10),
+			faker.string.alphanumeric(10),
+		]);
+		expect(values).toStrictEqual([undefined, undefined, undefined]);
+	});
+});
+
+describe("set and setMany", () => {
+	test("stores and returns a value in GridFS", async () => {
+		const store = new KeyvMongo({ useGridFS: true, ...options });
+		const key = faker.string.alphanumeric(10);
+		const result = await store.set(key, "keyv1", 0);
+		expect(result).toBe(true);
+		expect(await store.get(key)).toBe("keyv1");
+	});
+
+	test("stores a value with a ttl in GridFS", async () => {
+		const store = new KeyvMongo({ useGridFS: true, ...options });
+		const key = faker.string.alphanumeric(10);
+		expect(await store.set(key, "keyv1", 0)).toBe(true);
+	});
+
+	test("setMany stores multiple values with a per-entry ttl", async () => {
+		const store = new KeyvMongo({ ...options });
+		const keys = [faker.string.alphanumeric(10), faker.string.alphanumeric(10)];
+		await store.setMany([
+			{ key: keys[0], value: "val1", ttl: 60000 },
+			{ key: keys[1], value: "val2" },
+		]);
+		expect(await store.get(keys[0])).toBe("val1");
+		expect(await store.get(keys[1])).toBe("val2");
+	});
+
+	test("setMany upserts existing keys", async () => {
+		const store = new KeyvMongo({ ...options });
+		const key = faker.string.alphanumeric(10);
+		await store.set(key, "original");
+		await store.setMany([{ key, value: "updated" }]);
+		expect(await store.get(key)).toBe("updated");
+	});
+
+	test("setMany stores multiple values in GridFS", async () => {
+		const store = new KeyvMongo({ useGridFS: true, ...options });
+		const keys = [faker.string.alphanumeric(10), faker.string.alphanumeric(10)];
+		await store.setMany([
+			{ key: keys[0], value: "val1" },
+			{ key: keys[1], value: "val2" },
+		]);
+		expect(await store.get(keys[0])).toBe("val1");
+		expect(await store.get(keys[1])).toBe("val2");
+	});
+
+	test("setMany emits an error and returns false entries on connection failure", async () => {
+		const store = new KeyvMongo({ ...options });
+		const client = await store.connect;
+		// Close the connection to make bulkWrite throw.
+		await client.mongoClient.close();
+		let emittedError = false;
+		store.on("error", () => {
+			emittedError = true;
+		});
+		const result = await store.setMany([
+			{ key: faker.string.alphanumeric(10), value: "val1" },
+			{ key: faker.string.alphanumeric(10), value: "val2" },
+		]);
+		expect(result).toEqual([false, false]);
+		expect(emittedError).toBe(true);
+	});
+
+	test("setMany tracks per-entry failures on a MongoBulkWriteError", async () => {
+		const { MongoBulkWriteError } = await import("mongodb");
+		const store = new KeyvMongo({ ...options });
+		const client = await store.connect;
+		const originalBulkWrite = client.store.bulkWrite.bind(client.store);
+		// Mock bulkWrite to throw a MongoBulkWriteError with a write error at index 1.
+		client.store.bulkWrite = async () => {
+			throw new MongoBulkWriteError(
+				{
+					message: "write error",
+					code: 11000,
+					writeErrors: [{ index: 1, code: 11000, errmsg: "dup key" }] as any,
+				},
+				{
+					insertedCount: 1,
+					matchedCount: 0,
+					modifiedCount: 0,
+					deletedCount: 0,
+					upsertedCount: 0,
+					insertedIds: {},
+					upsertedIds: {},
+				} as any,
+			);
+		};
+
+		let emittedError = false;
+		store.on("error", () => {
+			emittedError = true;
+		});
+		const result = await store.setMany([
+			{ key: "key1", value: "val1" },
+			{ key: "key2", value: "val2" },
+			{ key: "key3", value: "val3" },
+		]);
+		expect(result).toEqual([true, false, true]);
+		expect(emittedError).toBe(true);
+		client.store.bulkWrite = originalBulkWrite;
+	});
+
+	test("setMany returns per-entry results when a GridFS set fails", async () => {
+		const store = new KeyvMongo({ useGridFS: true, ...options });
+		// Mock the set method to throw for the second call.
+		let callCount = 0;
+		const originalSet = store.set.bind(store);
+		store.set = async (key: string, value: any, ttl?: number) => {
+			callCount++;
+			if (callCount === 2) {
+				throw new Error("GridFS set failure");
+			}
+
+			return originalSet(key, value, ttl);
+		};
+
+		const result = await store.setMany([
+			{ key: "key1", value: "val1" },
+			{ key: "key2", value: "val2" },
+		]);
+		expect(result).toEqual([true, false]);
+		store.set = originalSet;
+	});
+});
+
+describe("has and hasMany", () => {
+	test("hasMany checks multiple keys in GridFS", async () => {
+		const store = new KeyvMongo({ useGridFS: true, ...options });
+		const keys = [
+			faker.string.alphanumeric(10),
+			faker.string.alphanumeric(10),
+			faker.string.alphanumeric(10),
+		];
+		await store.set(keys[0], "val1");
+		await store.set(keys[1], "val2");
+		expect(await store.hasMany(keys)).toEqual([true, true, false]);
+	});
+});
+
+describe("delete and deleteMany", () => {
+	test("deletes a value in GridFS", async () => {
+		const store = new KeyvMongo({ useGridFS: true, ...options });
+		const key = faker.string.alphanumeric(10);
+		await store.set(key, "keyv1");
+		expect(await store.delete(key)).toBe(true);
+	});
+
+	test("returns false when deleting a missing key in GridFS", async () => {
+		const store = new KeyvMongo({ useGridFS: true, ...options });
+		expect(await store.delete(faker.string.alphanumeric(10))).toBe(false);
+	});
+
+	test("returns false for a non-string key", async () => {
+		const store = new KeyvMongo({ useGridFS: true, ...options });
+		// @ts-expect-error - test invalid input
+		expect(await store.delete({ ok: true })).toBe(false);
+	});
+
+	test("deleteMany deletes multiple keys in GridFS", async () => {
+		const store = new KeyvMongo({ useGridFS: true, ...options });
+		const keys = [
+			faker.string.alphanumeric(10),
+			faker.string.alphanumeric(10),
+			faker.string.alphanumeric(10),
+		];
+		await store.set(keys[0], "bar");
+		await store.set(keys[1], "bar1");
+		await store.set(keys[2], "bar2");
+		expect(await store.deleteMany(keys)).toEqual([true, true, true]);
+		expect(await store.get(keys[0])).toBeUndefined();
+		expect(await store.get(keys[1])).toBeUndefined();
+		expect(await store.get(keys[2])).toBeUndefined();
+	});
+
+	test("deleteMany returns false for missing keys in GridFS", async () => {
+		const store = new KeyvMongo({ useGridFS: true, ...options });
+		expect(
+			await store.deleteMany([faker.string.alphanumeric(10), faker.string.alphanumeric(10)]),
+		).toEqual([false, false]);
+	});
+
+	test("returns false when the GridFS bucket delete throws", async () => {
+		const store = new KeyvMongo({ useGridFS: true, ...options });
+		const key = faker.string.alphanumeric(10);
+		await store.set(key, "some-data");
+		const client = await store.connect;
+		// Close the connection to make bucket.delete throw.
+		await client.mongoClient.close();
+		expect(await store.delete(key)).toBe(false);
+	});
+});
+
+describe("clear", () => {
+	test("clears the store in GridFS", async () => {
+		const store = new KeyvMongo({ useGridFS: true, ...options });
+		expect(await store.clear()).toBeUndefined();
+	});
+
+	test("clears the store with the default namespace", async () => {
+		const store = new KeyvMongo({ ...options });
+		expect(await store.clear()).toBeUndefined();
+	});
+
+	test("clearing an empty store does not throw", async () => {
+		const store = new KeyvMongo({ ...options });
+		await store.clear();
+		await store.clear();
+	});
+
+	test("clearing an empty store does not throw in GridFS", async () => {
+		const store = new KeyvMongo({ useGridFS: true, ...options });
+		await store.clear();
+		await store.clear();
+	});
+});
+
+describe("iterator", () => {
+	test("iterates over keys in the default namespace", async () => {
+		const store = new KeyvMongo({ ...options });
+		await store.clear();
+		const key1 = faker.string.alphanumeric(10);
+		const key2 = faker.string.alphanumeric(10);
+		await store.set(key1, "bar");
+		await store.set(key2, "bar2");
+		const keys: string[] = [];
+		for await (const [key] of store.iterator()) {
+			keys.push(key);
 		}
 
-		return originalSet(key, value, ttl);
-	};
-
-	const result = await store.setMany([
-		{ key: "key1", value: "val1" },
-		{ key: "key2", value: "val2" },
-	]);
-	t.expect(result).toEqual([true, false]);
-	store.set = originalSet;
-});
-
-it("GridFS delete returns false when bucket.delete throws", async (t) => {
-	const store = new KeyvMongo({ useGridFS: true, ...options });
-	const key = faker.string.alphanumeric(10);
-	await store.set(key, "some-data");
-	const client = await store.connect;
-	// Close the connection to make bucket.delete throw
-	await client.mongoClient.close();
-	const result = await store.delete(key);
-	t.expect(result).toBe(false);
-});
-
-const delay = async (ms: number) =>
-	new Promise<void>((resolve) => {
-		setTimeout(resolve, ms);
+		expect(keys).toContain(key1);
+		expect(keys).toContain(key2);
 	});
 
-it("GridFS get returns undefined for expired entry and deletes it", async (t) => {
-	const store = new KeyvMongo({ useGridFS: true, ...options });
-	const key = faker.string.alphanumeric(10);
-	await store.set(key, "expiring-value", 1);
-	await delay(50);
-	const result = await store.get(key);
-	t.expect(result).toBeUndefined();
+	test("iterates over keys within a namespace", async () => {
+		const store = new KeyvMongo({ namespace: faker.string.alphanumeric(8), ...options });
+		await store.clear();
+		const key1 = faker.string.alphanumeric(10);
+		const key2 = faker.string.alphanumeric(10);
+		await store.set(key1, "bar");
+		await store.set(key2, "bar2");
+		const keys: string[] = [];
+		for await (const [key] of store.iterator()) {
+			keys.push(key);
+		}
+
+		expect(keys).toEqual(expect.arrayContaining([key1, key2]));
+		expect(keys.length).toBe(2);
+	});
+
+	test("iterates over keys in the default namespace in GridFS", async () => {
+		const store = new KeyvMongo({ useGridFS: true, ...options });
+		await store.clear();
+		const key1 = faker.string.alphanumeric(10);
+		const key2 = faker.string.alphanumeric(10);
+		await store.set(key1, "bar");
+		await store.set(key2, "bar2");
+		const keys: string[] = [];
+		for await (const [key] of store.iterator()) {
+			keys.push(key);
+		}
+
+		expect(keys).toContain(key1);
+		expect(keys).toContain(key2);
+	});
+
+	test("iterates over keys within a namespace in GridFS", async () => {
+		const store = new KeyvMongo({
+			namespace: faker.string.alphanumeric(8),
+			useGridFS: true,
+			...options,
+		});
+		await store.clear();
+		const key1 = faker.string.alphanumeric(10);
+		const key2 = faker.string.alphanumeric(10);
+		await store.set(key1, "bar");
+		await store.set(key2, "bar2");
+		const keys: string[] = [];
+		for await (const [key] of store.iterator()) {
+			keys.push(key);
+		}
+
+		expect(keys).toEqual(expect.arrayContaining([key1, key2]));
+		expect(keys.length).toBe(2);
+	});
+
+	test("skips and deletes expired entries in GridFS", async () => {
+		const store = new KeyvMongo({ useGridFS: true, ...options });
+		await store.clear();
+		const expiredKey = faker.string.alphanumeric(10);
+		const freshKey = faker.string.alphanumeric(10);
+		await store.set(expiredKey, "expired-value", 1);
+		await store.set(freshKey, "fresh-value");
+		await delay(50);
+		const entries: Array<[string, unknown]> = [];
+		for await (const entry of store.iterator()) {
+			entries.push(entry as [string, unknown]);
+		}
+
+		expect(entries.length).toBe(1);
+		expect(entries[0][0]).toBe(freshKey);
+	});
 });
 
-it("GridFS iterator skips and deletes expired entries", async (t) => {
-	const store = new KeyvMongo({ useGridFS: true, ...options });
-	await store.clear();
-	const expiredKey = faker.string.alphanumeric(10);
-	const freshKey = faker.string.alphanumeric(10);
-	await store.set(expiredKey, "expired-value", 1);
-	await store.set(freshKey, "fresh-value");
-	await delay(50);
-	const entries: Array<[string, unknown]> = [];
-	for await (const entry of store.iterator()) {
-		entries.push(entry as [string, unknown]);
-	}
+describe("namespace", () => {
+	test("stores and retrieves with the default namespace", async () => {
+		const store = new KeyvMongo({ ...options });
+		const key = faker.string.alphanumeric(10);
+		await store.set(key, "testvalue");
+		expect(await store.get(key)).toBe("testvalue");
+	});
 
-	t.expect(entries.length).toBe(1);
-	t.expect(entries[0][0]).toBe(freshKey);
+	test("stores the same key independently across namespaces", async () => {
+		const ns1 = faker.string.alphanumeric(8);
+		const ns2 = faker.string.alphanumeric(8);
+		const store1 = new KeyvMongo({ namespace: ns1, ...options });
+		const store2 = new KeyvMongo({ namespace: ns2, ...options });
+
+		const key = faker.string.alphanumeric(10);
+		await store1.set(`${ns1}:${key}`, "value1");
+		await store2.set(`${ns2}:${key}`, "value2");
+
+		expect(await store1.get(`${ns1}:${key}`)).toBe("value1");
+		expect(await store2.get(`${ns2}:${key}`)).toBe("value2");
+	});
+
+	test("clear only affects the configured namespace", async () => {
+		const ns1 = faker.string.alphanumeric(8);
+		const ns2 = faker.string.alphanumeric(8);
+		const store1 = new KeyvMongo({ namespace: ns1, ...options });
+		const store2 = new KeyvMongo({ namespace: ns2, ...options });
+
+		const key = faker.string.alphanumeric(10);
+		await store1.set(`${ns1}:${key}`, "value1");
+		await store2.set(`${ns2}:${key}`, "value2");
+
+		await store1.clear();
+
+		expect(await store1.get(`${ns1}:${key}`)).toBeUndefined();
+		expect(await store2.get(`${ns2}:${key}`)).toBe("value2");
+	});
+
+	test("delete is scoped to the namespace", async () => {
+		const ns1 = faker.string.alphanumeric(8);
+		const ns2 = faker.string.alphanumeric(8);
+		const store1 = new KeyvMongo({ namespace: ns1, ...options });
+		const store2 = new KeyvMongo({ namespace: ns2, ...options });
+
+		const key = faker.string.alphanumeric(10);
+		await store1.set(`${ns1}:${key}`, "val1");
+		await store2.set(`${ns2}:${key}`, "val2");
+
+		expect(await store1.delete(`${ns1}:${key}`)).toBe(true);
+		expect(await store1.get(`${ns1}:${key}`)).toBeUndefined();
+		expect(await store2.get(`${ns2}:${key}`)).toBe("val2");
+	});
+
+	test("deleteMany is scoped to the namespace", async () => {
+		const ns1 = faker.string.alphanumeric(8);
+		const ns2 = faker.string.alphanumeric(8);
+		const store1 = new KeyvMongo({ namespace: ns1, ...options });
+		const store2 = new KeyvMongo({ namespace: ns2, ...options });
+
+		const key = faker.string.alphanumeric(10);
+		await store1.set(`${ns1}:${key}`, "val1");
+		await store2.set(`${ns2}:${key}`, "val2");
+
+		expect(await store1.deleteMany([`${ns1}:${key}`])).toEqual([true]);
+		expect(await store1.get(`${ns1}:${key}`)).toBeUndefined();
+		expect(await store2.get(`${ns2}:${key}`)).toBe("val2");
+	});
+
+	test("has is scoped to the namespace", async () => {
+		const ns1 = faker.string.alphanumeric(8);
+		const ns2 = faker.string.alphanumeric(8);
+		const store1 = new KeyvMongo({ namespace: ns1, ...options });
+		const store2 = new KeyvMongo({ namespace: ns2, ...options });
+
+		const key = faker.string.alphanumeric(10);
+		await store1.set(`${ns1}:${key}`, "val1");
+
+		expect(await store1.has(`${ns1}:${key}`)).toBe(true);
+		expect(await store2.has(`${ns2}:${key}`)).toBe(false);
+	});
+
+	test("hasMany is scoped to the namespace", async () => {
+		const ns1 = faker.string.alphanumeric(8);
+		const store1 = new KeyvMongo({ namespace: ns1, ...options });
+
+		const key = faker.string.alphanumeric(10);
+		await store1.set(`${ns1}:${key}`, "val1");
+
+		expect(
+			await store1.hasMany([`${ns1}:${key}`, `${ns1}:${faker.string.alphanumeric(10)}`]),
+		).toEqual([true, false]);
+	});
+
+	test("getMany is scoped to the namespace", async () => {
+		const ns1 = faker.string.alphanumeric(8);
+		const ns2 = faker.string.alphanumeric(8);
+		const store1 = new KeyvMongo({ namespace: ns1, ...options });
+		const store2 = new KeyvMongo({ namespace: ns2, ...options });
+
+		const key = faker.string.alphanumeric(10);
+		await store1.set(`${ns1}:${key}`, "val1");
+		await store2.set(`${ns2}:${key}`, "val2");
+
+		expect(await store1.getMany([`${ns1}:${key}`])).toEqual(["val1"]);
+		expect(await store1.getMany([`${ns2}:${key}`])).toEqual([undefined]);
+	});
+
+	test("setMany is scoped to the namespace", async () => {
+		const ns = faker.string.alphanumeric(8);
+		const store = new KeyvMongo({ namespace: ns, ...options });
+		const keys = [
+			`${ns}:${faker.string.alphanumeric(10)}`,
+			`${ns}:${faker.string.alphanumeric(10)}`,
+		];
+		await store.setMany([
+			{ key: keys[0], value: "val1" },
+			{ key: keys[1], value: "val2" },
+		]);
+		expect(await store.get(keys[0])).toBe("val1");
+		expect(await store.get(keys[1])).toBe("val2");
+	});
+
+	test("iterator only yields keys from the configured namespace", async () => {
+		const ns1 = faker.string.alphanumeric(8);
+		const ns2 = faker.string.alphanumeric(8);
+		const store1 = new KeyvMongo({ namespace: ns1, ...options });
+		const store2 = new KeyvMongo({ namespace: ns2, ...options });
+
+		const key1 = faker.string.alphanumeric(10);
+		const key2 = faker.string.alphanumeric(10);
+		await store1.set(key1, "val1");
+		await store1.set(key2, "val2");
+		await store2.set(faker.string.alphanumeric(10), "val3");
+
+		const keys: string[] = [];
+		for await (const [key] of store1.iterator()) {
+			keys.push(key);
+		}
+
+		expect(keys.length).toBe(2);
+		expect(keys).toEqual(expect.arrayContaining([key1, key2]));
+	});
+
+	test("two Keyv instances with different namespaces do not conflict", async () => {
+		const nsA = faker.string.alphanumeric(8);
+		const nsB = faker.string.alphanumeric(8);
+		const keyvA = new Keyv({ store: new KeyvMongo({ ...options }), namespace: nsA });
+		const keyvB = new Keyv({ store: new KeyvMongo({ ...options }), namespace: nsB });
+
+		const key = faker.string.alphanumeric(10);
+		expect(await keyvA.set(key, "valueA")).toBe(true);
+		expect(await keyvB.set(key, "valueB")).toBe(true);
+		expect(await keyvA.get(key)).toBe("valueA");
+		expect(await keyvB.get(key)).toBe("valueB");
+	});
+
+	test("stores the same key independently across namespaces in GridFS", async () => {
+		const ns1 = faker.string.alphanumeric(8);
+		const ns2 = faker.string.alphanumeric(8);
+		const store1 = new KeyvMongo({ namespace: ns1, useGridFS: true, ...options });
+		const store2 = new KeyvMongo({ namespace: ns2, useGridFS: true, ...options });
+
+		const key = faker.string.alphanumeric(10);
+		await store1.set(`${ns1}:${key}`, "value1");
+		await store2.set(`${ns2}:${key}`, "value2");
+
+		expect(await store1.get(`${ns1}:${key}`)).toBe("value1");
+		expect(await store2.get(`${ns2}:${key}`)).toBe("value2");
+	});
+
+	test("clear only affects the configured namespace in GridFS", async () => {
+		const ns1 = faker.string.alphanumeric(8);
+		const ns2 = faker.string.alphanumeric(8);
+		const store1 = new KeyvMongo({ namespace: ns1, useGridFS: true, ...options });
+		const store2 = new KeyvMongo({ namespace: ns2, useGridFS: true, ...options });
+
+		const key = faker.string.alphanumeric(10);
+		await store1.set(`${ns1}:${key}`, "value1");
+		await store2.set(`${ns2}:${key}`, "value2");
+
+		await store1.clear();
+
+		expect(await store1.get(`${ns1}:${key}`)).toBeUndefined();
+		expect(await store2.get(`${ns2}:${key}`)).toBe("value2");
+	});
+
+	test("delete is scoped to the namespace in GridFS", async () => {
+		const ns1 = faker.string.alphanumeric(8);
+		const ns2 = faker.string.alphanumeric(8);
+		const store1 = new KeyvMongo({ namespace: ns1, useGridFS: true, ...options });
+		const store2 = new KeyvMongo({ namespace: ns2, useGridFS: true, ...options });
+
+		const key = faker.string.alphanumeric(10);
+		await store1.set(`${ns1}:${key}`, "val1");
+		await store2.set(`${ns2}:${key}`, "val2");
+
+		expect(await store1.delete(`${ns1}:${key}`)).toBe(true);
+		expect(await store1.get(`${ns1}:${key}`)).toBeUndefined();
+		expect(await store2.get(`${ns2}:${key}`)).toBe("val2");
+	});
+
+	test("has is scoped to the namespace in GridFS", async () => {
+		const ns1 = faker.string.alphanumeric(8);
+		const ns2 = faker.string.alphanumeric(8);
+		const store1 = new KeyvMongo({ namespace: ns1, useGridFS: true, ...options });
+		const store2 = new KeyvMongo({ namespace: ns2, useGridFS: true, ...options });
+
+		const key = faker.string.alphanumeric(10);
+		await store1.set(`${ns1}:${key}`, "val1");
+
+		expect(await store1.has(`${ns1}:${key}`)).toBe(true);
+		expect(await store2.has(`${ns2}:${key}`)).toBe(false);
+	});
+
+	test("hasMany is scoped to the namespace in GridFS", async () => {
+		const ns1 = faker.string.alphanumeric(8);
+		const store1 = new KeyvMongo({ namespace: ns1, useGridFS: true, ...options });
+
+		const key = faker.string.alphanumeric(10);
+		await store1.set(`${ns1}:${key}`, "val1");
+
+		expect(
+			await store1.hasMany([`${ns1}:${key}`, `${ns1}:${faker.string.alphanumeric(10)}`]),
+		).toEqual([true, false]);
+	});
+
+	test("two Keyv instances with different namespaces do not conflict in GridFS", async () => {
+		const nsA = faker.string.alphanumeric(8);
+		const nsB = faker.string.alphanumeric(8);
+		const keyvA = new Keyv({
+			store: new KeyvMongo({ useGridFS: true, ...options }),
+			namespace: nsA,
+		});
+		const keyvB = new Keyv({
+			store: new KeyvMongo({ useGridFS: true, ...options }),
+			namespace: nsB,
+		});
+
+		const key = faker.string.alphanumeric(10);
+		expect(await keyvA.set(key, "valueA")).toBe(true);
+		expect(await keyvB.set(key, "valueB")).toBe(true);
+		expect(await keyvA.get(key)).toBe("valueA");
+		expect(await keyvB.get(key)).toBe("valueB");
+	});
 });
 
-it("GridFS clearExpired deletes expired files", async (t) => {
-	const store = new KeyvMongo({ useGridFS: true, ...options });
-	await store.clear();
-	const key = faker.string.alphanumeric(10);
-	await store.set(key, "expiring-value", 1);
-	await delay(50);
-	await store.clearExpired();
-	const result = await store.get(key);
-	t.expect(result).toBeUndefined();
+describe("GridFS maintenance", () => {
+	test("clearExpired removes expired files", async () => {
+		const store = new KeyvMongo({ useGridFS: true, ...options });
+		await store.clear();
+		const key = faker.string.alphanumeric(10);
+		await store.set(key, "expiring-value", 1);
+		await delay(50);
+		expect(await store.clearExpired()).toBe(true);
+		expect(await store.get(key)).toBeUndefined();
+	});
+
+	test("clearExpired returns false when not in GridFS mode", async () => {
+		const store = new KeyvMongo({ ...options });
+		expect(await store.clearExpired()).toBe(false);
+	});
+
+	test("clearUnusedFor removes unused files", async () => {
+		const store = new KeyvMongo({ useGridFS: true, ...options });
+		const key = faker.string.alphanumeric(10);
+		await store.set(key, "unused-value");
+		expect(await store.clearUnusedFor(0)).toBe(true);
+	});
+
+	test("clearUnusedFor returns false when not in GridFS mode", async () => {
+		const store = new KeyvMongo({ ...options });
+		expect(await store.clearUnusedFor(5)).toBe(false);
+	});
+});
+
+describe("disconnect", () => {
+	test("closes the connection", async () => {
+		const keyv = new KeyvMongo({ namespace: faker.string.alphanumeric(8), ...options });
+		expect(await keyv.get(faker.string.alphanumeric(10))).toBeUndefined();
+		await keyv.disconnect();
+		await expect(keyv.get(faker.string.alphanumeric(10))).rejects.toBeDefined();
+	});
+
+	test("closes the connection in GridFS", async () => {
+		const keyv = new KeyvMongo({ useGridFS: true, ...options });
+		expect(await keyv.get(faker.string.alphanumeric(10))).toBeUndefined();
+		await keyv.disconnect();
+		await expect(keyv.get(faker.string.alphanumeric(10))).rejects.toBeDefined();
+	});
+
+	test("disconnecting an unused connection does not throw", async () => {
+		const keyv = new KeyvMongo({ namespace: faker.string.alphanumeric(8), ...options });
+		await expect(keyv.disconnect()).resolves.toBeUndefined();
+	});
+});
+
+describe("createKeyv", () => {
+	test("returns a Keyv instance from a uri string", async () => {
+		const keyv = createKeyv(mongoURL);
+		expect(keyv).toBeInstanceOf(Keyv);
+		const key = faker.string.alphanumeric(10);
+		await keyv.set(key, "value");
+		expect(await keyv.get(key)).toBe("value");
+	});
+
+	test("returns a Keyv instance from an options object", async () => {
+		const keyv = createKeyv({ url: mongoURL, collection: "keyv", ...options });
+		expect(keyv).toBeInstanceOf(Keyv);
+		const key = faker.string.alphanumeric(10);
+		await keyv.set(key, "value");
+		expect(await keyv.get(key)).toBe("value");
+	});
+
+	test("applies the namespace option", async () => {
+		const ns = faker.string.alphanumeric(8);
+		const keyv = createKeyv({ namespace: ns, url: mongoURL, ...options });
+		expect(keyv.namespace).toBe(ns);
+		const key = faker.string.alphanumeric(10);
+		await keyv.set(key, "bar");
+		expect(await keyv.get(key)).toBe("bar");
+		// The adapter stores the value under the namespaced key.
+		const storeInstance = keyv.store as KeyvMongo;
+		expect(await storeInstance.get(`${ns}:${key}`)).toBeDefined();
+	});
+
+	test("isolates different namespaces", async () => {
+		const nsA = faker.string.alphanumeric(8);
+		const nsB = faker.string.alphanumeric(8);
+		const keyvA = createKeyv({ namespace: nsA, url: mongoURL, ...options });
+		const keyvB = createKeyv({ namespace: nsB, url: mongoURL, ...options });
+
+		const key = faker.string.alphanumeric(10);
+		await keyvA.set(key, "valueA");
+		await keyvB.set(key, "valueB");
+
+		expect(await keyvA.get(key)).toBe("valueA");
+		expect(await keyvB.get(key)).toBe("valueB");
+
+		// clear only affects its own namespace.
+		await keyvA.clear();
+		expect(await keyvA.get(key)).toBeUndefined();
+		expect(await keyvB.get(key)).toBe("valueB");
+	});
 });


### PR DESCRIPTION
## Summary

Full code and test review of `@keyv/mongo`, aligning it with the other recently-reviewed storage adapters (etcd, dynamo, memcache).

### README / API documentation
- **Fixed batch-method examples** that incorrectly called the singular methods with an array — `keyv.set([...])`, `keyv.get([...])`, `keyv.has([...])`, `keyv.delete([...])` now correctly use `store.setMany`, `store.getMany`, `store.hasMany`, and `store.deleteMany`, matching the actual API and the other adapters' docs.
- **Corrected the `deleteMany` description** — the implementation deletes each key individually in parallel (preserving per-key success/failure), not via a single `$in` query as previously documented.
- **Fixed the broken License link** (`LISCENCE` → `LICENSE`).

### Tests
- **Restructured into uniform `describe` / `test` / `expect` blocks** grouped by method (`constructor`, `get`, `getMany`, `set and setMany`, `has and hasMany`, `delete and deleteMany`, `clear`, `iterator`, `namespace`, `GridFS maintenance`, `disconnect`, `createKeyv`), with lowercase descriptive names — consistent with the other storage modules (e.g. memcache).
- Continue to use **faker** for keys/values throughout.
- Use the **shared `delay` helper** from `@keyv/test-suite` instead of a local copy.
- All previous coverage (GridFS error paths, `MongoBulkWriteError` per-entry tracking, expiry handling, native-namespace isolation) is preserved.

### Review confirmations
The following were verified as already correctly implemented in the adapter and are now covered by the cleaned-up tests:
- ✅ **Namespace is fully supported natively** — keys are stored with a `namespace` field and all operations (`get`/`set`/`delete`/`has`/`clear`/`iterator` + `*Many`) filter by it, in both standard and GridFS modes.
- ✅ **`iterator()` does not require a namespace argument** — it uses the namespace configured on the instance.
- ✅ **Missing values return `undefined`, never `null`** — `get`/`getMany` resolve to `undefined`; `null` only appears as a stored `expiresAt` field value and in Mongo query operators.

### Testing
- `biome check` — passes
- `tsc --noEmit` on `src` + `test` — passes
- Integration tests require a live MongoDB (run in CI with services); not runnable in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BygTr9tPhttWTD3WiGshug

---
_Generated by [Claude Code](https://claude.ai/code/session_01BygTr9tPhttWTD3WiGshug)_