### PR TITLE
mysql - fix: return undefined not null, guard getMany, and align tests/docs

### DIFF
--- a/storage/mysql/README.md
+++ b/storage/mysql/README.md
@@ -113,9 +113,6 @@ const store = new KeyvMysql({ uri, keyLength: 512 });
 store.keyLength; // 512
 ```
 
-
-The `opts` getter still exists for backward compatibility but should not be used for new code.
-
 ### New features
 
 #### Native TTL support with `expires` column
@@ -407,21 +404,23 @@ await keyvMysql.disconnect();
 
 ## SSL
 
+SSL options are passed through to `mysql2` as part of the options object. The constructor takes a single argument, so include the `uri` alongside the `ssl` configuration:
+
 ```js
 import Keyv from 'keyv';
 import KeyvMysql from '@keyv/mysql';
 import fs from 'fs';
+import path from 'path';
 
-const options = {
+const keyvMysql = new KeyvMysql({
+	uri: 'mysql://user:pass@localhost:3306/dbname',
 	ssl: {
 		rejectUnauthorized: false,
 		ca: fs.readFileSync(path.join(__dirname, '/certs/ca.pem')).toString(),
 		key: fs.readFileSync(path.join(__dirname, '/certs/client-key.pem')).toString(),
 		cert: fs.readFileSync(path.join(__dirname, '/certs/client-cert.pem')).toString(),
 	},
-};
-
-const keyvMysql = new KeyvMysql('mysql://user:pass@localhost:3306/dbname', options);
+});
 const keyv = new Keyv({ store: keyvMysql });
 ```
 

--- a/storage/mysql/src/index.ts
+++ b/storage/mysql/src/index.ts
@@ -305,6 +305,12 @@ export class KeyvMysql extends Hookified implements KeyvStorageAdapter {
 			return query;
 		});
 
+		// Prevent an unhandled rejection when an instance is constructed but never
+		// queried (e.g. the shared pool is closed by another instance before the
+		// table-creation queries finish). Real query failures still surface to
+		// callers because `this.query` awaits the same `connected` promise below.
+		connected.catch(() => {});
+
 		this.query = async <T>(sqlString: string): QueryType<T> => {
 			const query = await connected;
 			return query(sqlString) as QueryType<T>;
@@ -335,7 +341,8 @@ export class KeyvMysql extends Hookified implements KeyvStorageAdapter {
 			return undefined as KeyvStorageGetResult<Value>;
 		}
 
-		return row.value as KeyvStorageGetResult<Value>;
+		// Coerce a SQL NULL value to undefined so the adapter never returns null.
+		return (row.value ?? undefined) as KeyvStorageGetResult<Value>;
 	}
 
 	/**
@@ -344,6 +351,10 @@ export class KeyvMysql extends Hookified implements KeyvStorageAdapter {
 	 * @returns Array of stored values in the same order as the input keys, with undefined for missing keys
 	 */
 	public async getMany<Value>(keys: string[]) {
+		if (keys.length === 0) {
+			return [];
+		}
+
 		const strippedKeys = keys.map((k) => this.removeKeyPrefix(k));
 		const ns = this.getNamespaceValue();
 		const now = Date.now();
@@ -367,7 +378,10 @@ export class KeyvMysql extends Hookified implements KeyvStorageAdapter {
 			await this.query(mysql.format(delSql, [expiredKeys, ns]));
 		}
 
-		return strippedKeys.map((key) => validMap.get(key) as KeyvStorageGetResult<Value | undefined>);
+		// Coerce missing keys and SQL NULL values to undefined so the adapter never returns null.
+		return strippedKeys.map(
+			(key) => (validMap.get(key) ?? undefined) as KeyvStorageGetResult<Value | undefined>,
+		);
 	}
 
 	/**

--- a/storage/mysql/test/ssl.ts
+++ b/storage/mysql/test/ssl.ts
@@ -1,7 +1,11 @@
 import fs from "node:fs";
 import path from "node:path";
-import { beforeEach, it } from "vitest";
+import { faker } from "@faker-js/faker";
+import { beforeEach, describe, expect, test } from "vitest";
 import KeyvMysql from "../src/index.js";
+import { endPool } from "../src/pool.js";
+
+const uri = "mysql://root@localhost:3307/keyv_test";
 
 const options = {
 	ssl: {
@@ -13,26 +17,31 @@ const options = {
 };
 
 beforeEach(async () => {
-	const keyv = new KeyvMysql({
-		uri: "mysql://root@localhost:3307/keyv_test",
-		...options,
-	});
+	const keyv = new KeyvMysql({ uri, ...options });
 	await keyv.clear();
 });
 
-it("throws if ssl is not used", async (t) => {
-	try {
-		new KeyvMysql({ uri: "mysql://root@localhost:3307/keyv_test" });
-	} catch {
-		t.expect(true).toBeTruthy();
-	}
-});
-
-it("set with ssl ", async (t) => {
-	const keyv = new KeyvMysql({
-		uri: "mysql://root@localhost:3307/keyv_test",
-		...options,
+describe("ssl", () => {
+	test("rejects when ssl is required but not provided", async () => {
+		// The shared pool is cached by uri, so reset it to force a fresh
+		// non-ssl connection (and reset again afterwards for the ssl tests).
+		endPool();
+		try {
+			const keyv = new KeyvMysql({ uri });
+			await keyv.get(faker.string.alphanumeric(10));
+			expect.fail();
+		} catch {
+			expect(true).toBeTruthy();
+		} finally {
+			endPool();
+		}
 	});
-	await keyv.set("key", "value");
-	t.expect(await keyv.get("key")).toBe("value");
+
+	test("sets and gets a value over an ssl connection", async () => {
+		const keyv = new KeyvMysql({ uri, ...options });
+		const key = faker.string.alphanumeric(10);
+		const value = faker.string.alphanumeric(10);
+		await keyv.set(key, value);
+		expect(await keyv.get(key)).toBe(value);
+	});
 });

--- a/storage/mysql/test/ssl.ts
+++ b/storage/mysql/test/ssl.ts
@@ -28,10 +28,7 @@ describe("ssl", () => {
 		endPool();
 		try {
 			const keyv = new KeyvMysql({ uri });
-			await keyv.get(faker.string.alphanumeric(10));
-			expect.fail();
-		} catch {
-			expect(true).toBeTruthy();
+			await expect(keyv.get(faker.string.alphanumeric(10))).rejects.toThrow();
 		} finally {
 			endPool();
 		}

--- a/storage/mysql/test/test.ts
+++ b/storage/mysql/test/test.ts
@@ -2,700 +2,698 @@ import { faker } from "@faker-js/faker";
 import { delay, keyvIteratorTests, keyvTestSuite, storageTestSuite } from "@keyv/test-suite";
 import Keyv from "keyv";
 import type mysql from "mysql2";
-import { it } from "vitest";
+import { beforeEach, describe, expect, test } from "vitest";
 import KeyvMysql, { createKeyv } from "../src/index.js";
 import { parseConnectionString } from "../src/pool.js";
 
 const uri = "mysql://root@localhost:3306/keyv_test";
 
-const store = () => new KeyvMysql(uri);
-keyvTestSuite(it, Keyv, store);
-const iteratorStore = () => new KeyvMysql({ uri, iterationLimit: 2 });
-keyvIteratorTests(it, Keyv, iteratorStore);
-storageTestSuite(it, store, {
-	ttl: false,
-	batch: false,
-	iterator: false,
-	namespace: false,
-	disconnect: false,
-});
+const store = () => new KeyvMysql({ uri, iterationLimit: 2 });
 
-it("iterator with explicit namespace", async (t) => {
-	const ns = faker.string.alphanumeric(8);
-	const keyv = new KeyvMysql({ uri });
-	keyv.namespace = ns;
-	const key1 = faker.string.alphanumeric(10);
-	const val1 = faker.string.alphanumeric(10);
-	const key2 = faker.string.alphanumeric(10);
-	const val2 = faker.string.alphanumeric(10);
-	const key3 = faker.string.alphanumeric(10);
-	const val3 = faker.string.alphanumeric(10);
-	await keyv.set(key1, val1);
-	await keyv.set(key2, val2);
-	await keyv.set(key3, val3);
-	const collected = new Map<string, string>();
-	for await (const [key, value] of keyv.iterator(ns)) {
-		collected.set(key, value);
-	}
+keyvTestSuite(test, Keyv, store);
+keyvIteratorTests(test, Keyv, store);
+storageTestSuite(test, store, { ttl: false });
 
-	t.expect(collected.size).toBe(3);
-	t.expect(collected.get(key1)).toBe(val1);
-	t.expect(collected.get(key2)).toBe(val2);
-	t.expect(collected.get(key3)).toBe(val3);
-});
-
-it("iterator with default namespace", async (t) => {
-	const keyv = new KeyvMysql({ uri });
-	await keyv.clear();
-	const key1 = faker.string.alphanumeric(10);
-	const val1 = faker.string.alphanumeric(10);
-	const key2 = faker.string.alphanumeric(10);
-	const val2 = faker.string.alphanumeric(10);
-	await keyv.set(key1, val1);
-	await keyv.set(key2, val2);
-	const collected = new Map<string, string>();
-	for await (const [key, value] of keyv.iterator()) {
-		collected.set(key, value);
-	}
-
-	t.expect(collected.size).toBeGreaterThanOrEqual(2);
-	t.expect(collected.get(key1)).toBe(val1);
-	t.expect(collected.get(key2)).toBe(val2);
+beforeEach(async () => {
+	const keyv = store();
 	await keyv.clear();
 });
 
-it(".clear() with undefined namespace", async (t) => {
-	const keyv = store();
-	t.expect(await keyv.clear()).toBeUndefined();
+describe("constructor", () => {
+	test("sets default properties", () => {
+		const keyv = new KeyvMysql(uri);
+		expect(keyv.uri).toBe(uri);
+		expect(keyv.table).toBe("keyv");
+		expect(keyv.keyLength).toBe(255);
+		expect(keyv.namespaceLength).toBe(255);
+		expect(keyv.iterationLimit).toBe(10);
+		expect(keyv.intervalExpiration).toBeUndefined();
+		expect(keyv.namespace).toBeUndefined();
+	});
+
+	test("sets properties from constructor options", () => {
+		const keyv = new KeyvMysql({
+			uri,
+			table: "custom_table",
+			keyLength: 512,
+			namespaceLength: 128,
+			iterationLimit: 50,
+		});
+		expect(keyv.uri).toBe(uri);
+		expect(keyv.table).toBe("custom_table");
+		expect(keyv.keyLength).toBe(512);
+		expect(keyv.namespaceLength).toBe(128);
+		expect(keyv.iterationLimit).toBe(50);
+	});
+
+	test("sets the uri when a string is passed", () => {
+		const keyv = new KeyvMysql(uri);
+		expect(keyv.uri).toBe(uri);
+		expect(keyv.table).toBe("keyv");
+	});
+
+	test("updates properties via setters", () => {
+		const keyv = new KeyvMysql(uri);
+		keyv.uri = "mysql://otherhost";
+		expect(keyv.uri).toBe("mysql://otherhost");
+		keyv.table = "updated_table";
+		expect(keyv.table).toBe("updated_table");
+		keyv.keyLength = 1024;
+		expect(keyv.keyLength).toBe(1024);
+		keyv.namespaceLength = 128;
+		expect(keyv.namespaceLength).toBe(128);
+		keyv.iterationLimit = 100;
+		expect(keyv.iterationLimit).toBe(100);
+		keyv.intervalExpiration = 30;
+		expect(keyv.intervalExpiration).toBe(30);
+		keyv.namespace = "test-ns";
+		expect(keyv.namespace).toBe("test-ns");
+		keyv.namespace = undefined;
+		expect(keyv.namespace).toBeUndefined();
+	});
 });
 
-const connectionSamples = [
-	{
-		username: "root",
-		password: "password",
-		host: "localhost",
-		port: 3306,
-		database: "keyv_dbname",
-	},
-	{
-		username: "root",
-		password: "password",
-		host: "127.0.0.1",
-		port: 3306,
-		database: "keyv_dbname",
-	},
-	{
-		username: "test user",
-		password: "very strong pass-word",
-		host: "test-stg-cluster.cluster-hqpowufs.ap-dqhowd-1.rds.amazonaws.com",
-		port: 5006,
-		database: "keyv_dbname",
-	},
-	{
-		// Special characters
-		username: "John Noêl",
-		password: "f.[;@4IWS0,vv)X-dDe FLn+Ün",
-		host: "[::1]",
-		port: 3306,
-		database: "keyv_dbname",
-	},
-	{
-		// No password
-		username: "nopassword",
-		host: "[::1]",
-		port: 3306,
-		database: "keyv_dbname",
-	},
-	{
-		// No port
-		username: "noport",
-		password: "f.[;@4IWS0,vv)X-dDe#Ln+Ün",
-		host: "[::1]",
-		database: "keyv_dbname",
-	},
-	{
-		// No password & no port
-		username: "nopasswordnoport",
-		host: "[::1]",
-		database: "tablau-èdd",
-	},
-];
+describe("get", () => {
+	test("returns undefined for a missing key", async () => {
+		const keyv = new KeyvMysql(uri);
+		expect(await keyv.get(faker.string.alphanumeric(10))).toBeUndefined();
+	});
 
-it("validate connection strings", (t) => {
-	for (const connection of connectionSamples) {
-		const newConnectionString = `mysql://${connection.username}:${connection.password ?? ""}@${connection.host}:${connection.port ?? ""}/${connection.database}`;
-		const parsedConnection = parseConnectionString(newConnectionString);
+	test("returns a previously set value", async () => {
+		const keyv = new KeyvMysql(uri);
+		const key = faker.string.alphanumeric(10);
+		const value = faker.string.alphanumeric(10);
+		await keyv.set(key, value);
+		expect(await keyv.get(key)).toBe(value);
+	});
 
-		t.expect(parsedConnection.user).toBe(connection.username);
-		t.expect(parsedConnection.password).toBe(connection.password);
-		t.expect(parsedConnection.host).toBe(connection.host);
-		t.expect(parsedConnection.port).toBe(connection.port);
-		t.expect(parsedConnection.database).toBe(connection.database);
-	}
+	test("returns undefined (not null) for a key stored with a null value", async () => {
+		const keyv = new KeyvMysql(uri);
+		const key = faker.string.alphanumeric(10);
+		await keyv.set(key, null);
+		const result = await keyv.get(key);
+		expect(result).toBeUndefined();
+		expect(result).not.toBeNull();
+	});
 });
 
-it("close connection successfully", async (t) => {
-	const keyv = store();
-	const key = faker.string.alphanumeric(10);
-	t.expect(await keyv.get(key)).toBeUndefined();
-	await keyv.disconnect();
-	try {
-		await keyv.get(key);
-		t.expect.fail();
-	} catch {
-		t.expect(true).toBeTruthy();
-	}
+describe("getMany", () => {
+	test("returns undefined (not null) for keys stored with a null value", async () => {
+		const keyv = new KeyvMysql(uri);
+		const key = faker.string.alphanumeric(10);
+		await keyv.set(key, null);
+		const results = await keyv.getMany([key, faker.string.alphanumeric(10)]);
+		expect(results).toEqual([undefined, undefined]);
+		expect(results[0]).not.toBeNull();
+	});
 });
 
-it("set intervalExpiration to 1 second", async (t) => {
-	const keyvMySql = new KeyvMysql({ uri, intervalExpiration: 1 });
-	const keyv = new Keyv({ store: keyvMySql });
-	const key1 = faker.string.alphanumeric(10);
-	const val1 = faker.string.alphanumeric(10);
-	const key2 = faker.string.alphanumeric(10);
-	const val2 = faker.string.alphanumeric(10);
-	// Ttl: 2s
-	await keyv.set(key1, val1, 2000);
-	// No ttl -> undefined -> (expires:null) -> infinite
-	await keyv.set(key2, val2);
-	const value1 = await keyv.get(key1);
-	t.expect(value1).toBe(val1);
-	await delay(2500);
-	const value2 = await keyv.get(key1);
-	t.expect(value2).toBeUndefined();
-	const value3 = await keyv.get(key2);
-	t.expect(value3).toBe(val2);
+describe("set and setMany", () => {
+	test("setMany updates existing keys", async () => {
+		const keyv = new KeyvMysql(uri);
+		const key = faker.string.alphanumeric(10);
+		await keyv.set(key, "original");
+		await keyv.setMany([{ key, value: "updated" }]);
+		expect(await keyv.get(key)).toBe("updated");
+	});
+
+	test("setMany emits an error and returns false entries on query error", async () => {
+		const keyv = new KeyvMysql(uri);
+		let emittedError = false;
+		keyv.on("error", () => {
+			emittedError = true;
+		});
+		// Close the connection to force an error.
+		await keyv.disconnect();
+		const result = await keyv.setMany([
+			{ key: "key1", value: "val1" },
+			{ key: "key2", value: "val2" },
+		]);
+		expect(result).toEqual([false, false]);
+		expect(emittedError).toBe(true);
+	});
 });
 
-it(".has() prevents SQL injection with DROP TABLE", async (t) => {
-	const keyv = new KeyvMysql(uri);
-	const safeKey = faker.string.alphanumeric(10);
-	await keyv.set(safeKey, "value");
-	const result = await keyv.has("'; DROP TABLE keyv; --");
-	t.expect(result).toBe(false);
-	const safeKeyExists = await keyv.has(safeKey);
-	t.expect(safeKeyExists).toBe(true);
+describe("has and hasMany", () => {
+	test("has returns false and deletes an expired key", async () => {
+		const keyv = new KeyvMysql(uri);
+		const key = faker.string.alphanumeric(10);
+		const expiredValue = JSON.stringify({ value: "old", expires: Date.now() - 1000 });
+		await keyv.set(key, expiredValue);
+		expect(await keyv.has(key)).toBe(false);
+		// The expired key should have been deleted.
+		expect(await keyv.get(key)).toBeUndefined();
+	});
+
+	test("hasMany returns false for expired keys and deletes them", async () => {
+		const keyv = new KeyvMysql(uri);
+		const expiredKey1 = faker.string.alphanumeric(10);
+		const expiredKey2 = faker.string.alphanumeric(10);
+		const validKey = faker.string.alphanumeric(10);
+		const expiredValue = JSON.stringify({ value: "old", expires: Date.now() - 1000 });
+		const validValue = JSON.stringify({ value: "fresh", expires: Date.now() + 60_000 });
+		await keyv.set(expiredKey1, expiredValue);
+		await keyv.set(expiredKey2, expiredValue);
+		await keyv.set(validKey, validValue);
+		const result = await keyv.hasMany([expiredKey1, expiredKey2, validKey]);
+		expect(result).toStrictEqual([false, false, true]);
+		// The expired keys should have been deleted.
+		expect(await keyv.get(expiredKey1)).toBeUndefined();
+		expect(await keyv.get(expiredKey2)).toBeUndefined();
+	});
 });
 
-it(".has() handles keys with single quotes", async (t) => {
-	const keyv = new KeyvMysql(uri);
-	const keyWithQuote = "key'with'quotes";
-	await keyv.set(keyWithQuote, "value");
-	t.expect(await keyv.has(keyWithQuote)).toBe(true);
+describe("SQL injection prevention", () => {
+	test("has prevents a DROP TABLE injection", async () => {
+		const keyv = new KeyvMysql(uri);
+		const safeKey = faker.string.alphanumeric(10);
+		await keyv.set(safeKey, "value");
+		expect(await keyv.has("'; DROP TABLE keyv; --")).toBe(false);
+		// The table and the safe key should still be intact.
+		expect(await keyv.has(safeKey)).toBe(true);
+	});
+
+	test("has handles keys with single quotes", async () => {
+		const keyv = new KeyvMysql(uri);
+		const keyWithQuote = "key'with'quotes";
+		await keyv.set(keyWithQuote, "value");
+		expect(await keyv.has(keyWithQuote)).toBe(true);
+	});
+
+	test("has prevents an OR-condition injection", async () => {
+		const keyv = new KeyvMysql(uri);
+		const realKey = faker.string.alphanumeric(10);
+		await keyv.set(realKey, "value");
+		expect(await keyv.has("nonexistent' OR '1'='1")).toBe(false);
+	});
+
+	test("has handles keys with special SQL characters", async () => {
+		const keyv = new KeyvMysql(uri);
+		const specialKeys = [
+			"key;with;semicolon",
+			"key--with--dashes",
+			"key/*comment*/",
+			"key\\with\\backslash",
+		];
+		for (const key of specialKeys) {
+			await keyv.set(key, "value");
+			expect(await keyv.has(key)).toBe(true);
+		}
+
+		expect(await keyv.has("nonexistent;key")).toBe(false);
+	});
+
+	test("has prevents a UNION-based injection", async () => {
+		const keyv = new KeyvMysql(uri);
+		expect(await keyv.has("' UNION SELECT 1 --")).toBe(false);
+	});
 });
 
-it(".has() prevents SQL injection with OR condition", async (t) => {
-	const keyv = new KeyvMysql(uri);
-	const realKey = faker.string.alphanumeric(10);
-	await keyv.set(realKey, "value");
-	const result = await keyv.has("nonexistent' OR '1'='1");
-	t.expect(result).toBe(false);
+describe("clear", () => {
+	test("returns undefined with the default namespace", async () => {
+		const keyv = new KeyvMysql(uri);
+		expect(await keyv.clear()).toBeUndefined();
+	});
 });
 
-it(".has() handles keys with special SQL characters", async (t) => {
-	const keyv = new KeyvMysql(uri);
-	const specialKeys = [
-		"key;with;semicolon",
-		"key--with--dashes",
-		"key/*comment*/",
-		"key\\with\\backslash",
+describe("clearExpired", () => {
+	test("removes expired entries and keeps valid ones", async () => {
+		const keyv = new KeyvMysql(uri);
+		const expiredKey = faker.string.alphanumeric(10);
+		const validKey = faker.string.alphanumeric(10);
+		const noExpiryKey = faker.string.alphanumeric(10);
+		const expired = JSON.stringify({ value: "old", expires: 1 });
+		const valid = JSON.stringify({ value: "new", expires: 9999999999999 });
+		const noExpiry = JSON.stringify({ value: "forever" });
+		await keyv.set(expiredKey, expired);
+		await keyv.set(validKey, valid);
+		await keyv.set(noExpiryKey, noExpiry);
+		await keyv.clearExpired();
+		expect(await keyv.get(expiredKey)).toBeUndefined();
+		expect(await keyv.get(validKey)).toBe(valid);
+		expect(await keyv.get(noExpiryKey)).toBe(noExpiry);
+	});
+
+	test("is a no-op when no entries are expired", async () => {
+		const keyv = new KeyvMysql(uri);
+		const key = faker.string.alphanumeric(10);
+		const valid = JSON.stringify({ value: "bar", expires: 9999999999999 });
+		await keyv.set(key, valid);
+		await keyv.clearExpired();
+		expect(await keyv.get(key)).toBe(valid);
+	});
+});
+
+describe("expires column", () => {
+	test("set extracts and stores expires from the value", async () => {
+		const keyv = new KeyvMysql(uri);
+		const key = faker.string.alphanumeric(10);
+		const valueWithExpires = JSON.stringify({ value: "bar", expires: 9999999999999 });
+		await keyv.set(key, valueWithExpires);
+		const rows = await keyv.query<mysql.RowDataPacket[]>(
+			`SELECT expires FROM \`keyv\` WHERE id = '${key}' AND namespace = ''`,
+		);
+		expect(Number(rows[0].expires)).toBe(9999999999999);
+	});
+
+	test("set stores null expires when the value has no expires field", async () => {
+		const keyv = new KeyvMysql(uri);
+		const key = faker.string.alphanumeric(10);
+		await keyv.set(key, "plain string value");
+		const rows = await keyv.query<mysql.RowDataPacket[]>(
+			`SELECT expires FROM \`keyv\` WHERE id = '${key}' AND namespace = ''`,
+		);
+		expect(rows[0].expires).toBeNull();
+	});
+
+	test("set updates the expires column on upsert", async () => {
+		const keyv = new KeyvMysql(uri);
+		const key = faker.string.alphanumeric(10);
+		await keyv.set(key, JSON.stringify({ value: "bar", expires: 1000 }));
+		const rows1 = await keyv.query<mysql.RowDataPacket[]>(
+			`SELECT expires FROM \`keyv\` WHERE id = '${key}' AND namespace = ''`,
+		);
+		expect(Number(rows1[0].expires)).toBe(1000);
+		await keyv.set(key, JSON.stringify({ value: "bar", expires: 2000 }));
+		const rows2 = await keyv.query<mysql.RowDataPacket[]>(
+			`SELECT expires FROM \`keyv\` WHERE id = '${key}' AND namespace = ''`,
+		);
+		expect(Number(rows2[0].expires)).toBe(2000);
+	});
+
+	test("setMany extracts and stores expires for each entry", async () => {
+		const keyv = new KeyvMysql(uri);
+		const key1 = faker.string.alphanumeric(10);
+		const key2 = faker.string.alphanumeric(10);
+		await keyv.setMany([
+			{ key: key1, value: JSON.stringify({ value: "a", expires: 5000 }) },
+			{ key: key2, value: JSON.stringify({ value: "b" }) },
+		]);
+		const rows = await keyv.query<mysql.RowDataPacket[]>(
+			`SELECT id, expires FROM \`keyv\` WHERE id IN ('${key1}', '${key2}') AND namespace = ''`,
+		);
+		const row1 = rows.find((r) => r.id === key1);
+		const row2 = rows.find((r) => r.id === key2);
+		expect(Number(row1?.expires)).toBe(5000);
+		expect(row2?.expires).toBeNull();
+	});
+
+	test("set stores null expires when the value is a number", async () => {
+		const keyv = new KeyvMysql(uri);
+		const key = faker.string.alphanumeric(10);
+		await keyv.set(key, 42);
+		const rows = await keyv.query<mysql.RowDataPacket[]>(
+			`SELECT expires FROM \`keyv\` WHERE id = '${key}' AND namespace = ''`,
+		);
+		expect(rows[0].expires).toBeNull();
+	});
+
+	test("set stores null expires when the value is null", async () => {
+		const keyv = new KeyvMysql(uri);
+		const key = faker.string.alphanumeric(10);
+		await keyv.set(key, null);
+		const rows = await keyv.query<mysql.RowDataPacket[]>(
+			`SELECT expires FROM \`keyv\` WHERE id = '${key}' AND namespace = ''`,
+		);
+		expect(rows[0].expires).toBeNull();
+	});
+
+	test("is populated when using Keyv core with a TTL", async () => {
+		const keyvMysql = new KeyvMysql(uri);
+		const keyv = new Keyv({ store: keyvMysql });
+		const key = faker.string.alphanumeric(10);
+		const value = faker.string.alphanumeric(10);
+		await keyv.set(key, value, 60_000);
+		const rows = await keyvMysql.query<mysql.RowDataPacket[]>(
+			`SELECT expires FROM \`keyv\` WHERE id = '${key}' AND namespace = ''`,
+		);
+		expect(rows[0].expires).not.toBeNull();
+		const expires = Number(rows[0].expires);
+		const now = Date.now();
+		expect(expires).toBeGreaterThan(now);
+		expect(expires).toBeLessThanOrEqual(now + 60_000 + 1000);
+	});
+});
+
+describe("intervalExpiration", () => {
+	test("deletes expired keys on the configured schedule", async () => {
+		const keyvMysql = new KeyvMysql({ uri, intervalExpiration: 1 });
+		const keyv = new Keyv({ store: keyvMysql });
+		const key1 = faker.string.alphanumeric(10);
+		const val1 = faker.string.alphanumeric(10);
+		const key2 = faker.string.alphanumeric(10);
+		const val2 = faker.string.alphanumeric(10);
+		// key1 has a 2s ttl; key2 has no ttl (infinite).
+		await keyv.set(key1, val1, 2000);
+		await keyv.set(key2, val2);
+		expect(await keyv.get(key1)).toBe(val1);
+		await delay(2500);
+		expect(await keyv.get(key1)).toBeUndefined();
+		expect(await keyv.get(key2)).toBe(val2);
+	});
+});
+
+describe("namespace", () => {
+	test("stores the same key independently across namespaces", async () => {
+		const ns1 = faker.string.alphanumeric(8);
+		const ns2 = faker.string.alphanumeric(8);
+		const mysql1 = new KeyvMysql(uri);
+		mysql1.namespace = ns1;
+		const mysql2 = new KeyvMysql(uri);
+		mysql2.namespace = ns2;
+
+		const key = faker.string.alphanumeric(10);
+		const val1 = faker.string.alphanumeric(10);
+		const val2 = faker.string.alphanumeric(10);
+		await mysql1.set(`${ns1}:${key}`, val1);
+		await mysql2.set(`${ns2}:${key}`, val2);
+
+		expect(await mysql1.get(`${ns1}:${key}`)).toBe(val1);
+		expect(await mysql2.get(`${ns2}:${key}`)).toBe(val2);
+	});
+
+	test("stores and retrieves with the default namespace", async () => {
+		const keyv = new KeyvMysql(uri);
+		const key = faker.string.alphanumeric(10);
+		const value = faker.string.alphanumeric(10);
+		await keyv.set(key, value);
+		expect(await keyv.get(key)).toBe(value);
+	});
+
+	test("clear only affects the configured namespace", async () => {
+		const ns1 = faker.string.alphanumeric(8);
+		const ns2 = faker.string.alphanumeric(8);
+		const mysql1 = new KeyvMysql(uri);
+		mysql1.namespace = ns1;
+		const mysql2 = new KeyvMysql(uri);
+		mysql2.namespace = ns2;
+
+		const key = faker.string.alphanumeric(10);
+		const val1 = faker.string.alphanumeric(10);
+		const val2 = faker.string.alphanumeric(10);
+		await mysql1.set(`${ns1}:${key}`, val1);
+		await mysql2.set(`${ns2}:${key}`, val2);
+
+		await mysql1.clear();
+
+		expect(await mysql1.get(`${ns1}:${key}`)).toBeUndefined();
+		expect(await mysql2.get(`${ns2}:${key}`)).toBe(val2);
+	});
+
+	test("delete is scoped to the namespace", async () => {
+		const ns1 = faker.string.alphanumeric(8);
+		const ns2 = faker.string.alphanumeric(8);
+		const mysql1 = new KeyvMysql(uri);
+		mysql1.namespace = ns1;
+		const mysql2 = new KeyvMysql(uri);
+		mysql2.namespace = ns2;
+
+		const key = faker.string.alphanumeric(10);
+		const val1 = faker.string.alphanumeric(10);
+		const val2 = faker.string.alphanumeric(10);
+		await mysql1.set(`${ns1}:${key}`, val1);
+		await mysql2.set(`${ns2}:${key}`, val2);
+
+		expect(await mysql1.delete(`${ns1}:${key}`)).toBe(true);
+		expect(await mysql1.get(`${ns1}:${key}`)).toBeUndefined();
+		expect(await mysql2.get(`${ns2}:${key}`)).toBe(val2);
+	});
+
+	test("deleteMany is scoped to the namespace", async () => {
+		const ns1 = faker.string.alphanumeric(8);
+		const ns2 = faker.string.alphanumeric(8);
+		const mysql1 = new KeyvMysql(uri);
+		mysql1.namespace = ns1;
+		const mysql2 = new KeyvMysql(uri);
+		mysql2.namespace = ns2;
+
+		const key = faker.string.alphanumeric(10);
+		const val1 = faker.string.alphanumeric(10);
+		const val2 = faker.string.alphanumeric(10);
+		await mysql1.set(`${ns1}:${key}`, val1);
+		await mysql2.set(`${ns2}:${key}`, val2);
+
+		expect(await mysql1.deleteMany([`${ns1}:${key}`])).toEqual([true]);
+		expect(await mysql1.get(`${ns1}:${key}`)).toBeUndefined();
+		expect(await mysql2.get(`${ns2}:${key}`)).toBe(val2);
+	});
+
+	test("has is scoped to the namespace", async () => {
+		const ns1 = faker.string.alphanumeric(8);
+		const ns2 = faker.string.alphanumeric(8);
+		const mysql1 = new KeyvMysql(uri);
+		mysql1.namespace = ns1;
+		const mysql2 = new KeyvMysql(uri);
+		mysql2.namespace = ns2;
+
+		const key = faker.string.alphanumeric(10);
+		const val = faker.string.alphanumeric(10);
+		await mysql1.set(`${ns1}:${key}`, val);
+
+		expect(await mysql1.has(`${ns1}:${key}`)).toBe(true);
+		// ns2 should not see ns1's key.
+		expect(await mysql2.has(`${ns2}:${key}`)).toBe(false);
+	});
+
+	test("hasMany is scoped to the namespace", async () => {
+		const ns1 = faker.string.alphanumeric(8);
+		const ns2 = faker.string.alphanumeric(8);
+		const mysql1 = new KeyvMysql(uri);
+		mysql1.namespace = ns1;
+		const mysql2 = new KeyvMysql(uri);
+		mysql2.namespace = ns2;
+
+		const key = faker.string.alphanumeric(10);
+		const val1 = faker.string.alphanumeric(10);
+		const val2 = faker.string.alphanumeric(10);
+		await mysql1.set(`${ns1}:${key}`, val1);
+		await mysql2.set(`${ns2}:${key}`, val2);
+
+		expect(await mysql1.hasMany([`${ns1}:${key}`])).toEqual([true]);
+		expect(await mysql1.hasMany([`${ns2}:${key}`])).toEqual([false]);
+	});
+
+	test("getMany is scoped to the namespace", async () => {
+		const ns1 = faker.string.alphanumeric(8);
+		const ns2 = faker.string.alphanumeric(8);
+		const mysql1 = new KeyvMysql(uri);
+		mysql1.namespace = ns1;
+		const mysql2 = new KeyvMysql(uri);
+		mysql2.namespace = ns2;
+
+		const key = faker.string.alphanumeric(10);
+		const val1 = faker.string.alphanumeric(10);
+		const val2 = faker.string.alphanumeric(10);
+		await mysql1.set(`${ns1}:${key}`, val1);
+		await mysql2.set(`${ns2}:${key}`, val2);
+
+		expect(await mysql1.getMany([`${ns1}:${key}`])).toEqual([val1]);
+		expect(await mysql1.getMany([`${ns2}:${key}`])).toEqual([undefined]);
+	});
+
+	test("setMany is scoped to the namespace", async () => {
+		const ns1 = faker.string.alphanumeric(8);
+		const ns2 = faker.string.alphanumeric(8);
+		const mysql1 = new KeyvMysql(uri);
+		mysql1.namespace = ns1;
+		const mysql2 = new KeyvMysql(uri);
+		mysql2.namespace = ns2;
+
+		const key1 = faker.string.alphanumeric(10);
+		const key2 = faker.string.alphanumeric(10);
+		const val1 = faker.string.alphanumeric(10);
+		const val2 = faker.string.alphanumeric(10);
+		await mysql1.setMany([
+			{ key: `${ns1}:${key1}`, value: val1 },
+			{ key: `${ns1}:${key2}`, value: val2 },
+		]);
+
+		expect(await mysql1.get(`${ns1}:${key1}`)).toBe(val1);
+		expect(await mysql1.get(`${ns1}:${key2}`)).toBe(val2);
+		// ns2 should not see ns1's keys.
+		expect(await mysql2.get(`${ns2}:${key1}`)).toBeUndefined();
+	});
+
+	test("two Keyv instances with different namespaces do not conflict", async () => {
+		const nsA = faker.string.alphanumeric(8);
+		const nsB = faker.string.alphanumeric(8);
+		const keyvA = new Keyv({ store: new KeyvMysql(uri), namespace: nsA });
+		const keyvB = new Keyv({ store: new KeyvMysql(uri), namespace: nsB });
+
+		const key = faker.string.alphanumeric(10);
+		const valA = faker.string.alphanumeric(10);
+		const valB = faker.string.alphanumeric(10);
+		expect(await keyvA.set(key, valA)).toBe(true);
+		expect(await keyvA.get(key)).toBe(valA);
+		expect(await keyvB.set(key, valB)).toBe(true);
+		expect(await keyvB.get(key)).toBe(valB);
+		// Ensure they didn't overwrite each other.
+		expect(await keyvA.get(key)).toBe(valA);
+	});
+});
+
+describe("iterator", () => {
+	test("iterates over the default namespace", async () => {
+		const keyv = new KeyvMysql(uri);
+		await keyv.clear();
+		const key1 = faker.string.alphanumeric(10);
+		const val1 = faker.string.alphanumeric(10);
+		const key2 = faker.string.alphanumeric(10);
+		const val2 = faker.string.alphanumeric(10);
+		await keyv.set(key1, val1);
+		await keyv.set(key2, val2);
+		const collected = new Map<string, string>();
+		for await (const [key, value] of keyv.iterator()) {
+			collected.set(key, value);
+		}
+
+		expect(collected.get(key1)).toBe(val1);
+		expect(collected.get(key2)).toBe(val2);
+	});
+
+	test("iterates over a configured namespace without passing it to iterator()", async () => {
+		const ns = faker.string.alphanumeric(8);
+		const keyv = new KeyvMysql(uri);
+		keyv.namespace = ns;
+		const key1 = faker.string.alphanumeric(10);
+		const val1 = faker.string.alphanumeric(10);
+		const key2 = faker.string.alphanumeric(10);
+		const val2 = faker.string.alphanumeric(10);
+		const key3 = faker.string.alphanumeric(10);
+		const val3 = faker.string.alphanumeric(10);
+		await keyv.set(key1, val1);
+		await keyv.set(key2, val2);
+		await keyv.set(key3, val3);
+		const collected = new Map<string, string>();
+		for await (const [key, value] of keyv.iterator()) {
+			collected.set(key, value);
+		}
+
+		expect(collected.size).toBe(3);
+		expect(collected.get(key1)).toBe(val1);
+		expect(collected.get(key2)).toBe(val2);
+		expect(collected.get(key3)).toBe(val3);
+	});
+
+	test("only yields keys from the configured namespace", async () => {
+		const ns1 = faker.string.alphanumeric(8);
+		const ns2 = faker.string.alphanumeric(8);
+		const mysql1 = new KeyvMysql(uri);
+		mysql1.namespace = ns1;
+		const mysql2 = new KeyvMysql(uri);
+		mysql2.namespace = ns2;
+
+		const key1 = faker.string.alphanumeric(10);
+		const key2 = faker.string.alphanumeric(10);
+		const key3 = faker.string.alphanumeric(10);
+		await mysql1.set(key1, "val1");
+		await mysql1.set(key2, "val2");
+		await mysql2.set(key3, "val3");
+
+		const keys: string[] = [];
+		for await (const [key] of mysql1.iterator()) {
+			keys.push(key);
+		}
+
+		expect(keys.length).toBe(2);
+		expect(keys).toContain(key1);
+		expect(keys).toContain(key2);
+	});
+});
+
+describe("disconnect", () => {
+	test("closes the connection", async () => {
+		const keyv = new KeyvMysql(uri);
+		const key = faker.string.alphanumeric(10);
+		expect(await keyv.get(key)).toBeUndefined();
+		await keyv.disconnect();
+		await expect(keyv.get(key)).rejects.toBeDefined();
+	});
+});
+
+describe("connection string", () => {
+	const connectionSamples = [
+		{
+			username: "root",
+			password: "password",
+			host: "localhost",
+			port: 3306,
+			database: "keyv_dbname",
+		},
+		{
+			username: "root",
+			password: "password",
+			host: "127.0.0.1",
+			port: 3306,
+			database: "keyv_dbname",
+		},
+		{
+			username: "test user",
+			password: "very strong pass-word",
+			host: "test-stg-cluster.cluster-hqpowufs.ap-dqhowd-1.rds.amazonaws.com",
+			port: 5006,
+			database: "keyv_dbname",
+		},
+		{
+			// Special characters
+			username: "John Noêl",
+			password: "f.[;@4IWS0,vv)X-dDe FLn+Ün",
+			host: "[::1]",
+			port: 3306,
+			database: "keyv_dbname",
+		},
+		{
+			// No password
+			username: "nopassword",
+			host: "[::1]",
+			port: 3306,
+			database: "keyv_dbname",
+		},
+		{
+			// No port
+			username: "noport",
+			password: "f.[;@4IWS0,vv)X-dDe#Ln+Ün",
+			host: "[::1]",
+			database: "keyv_dbname",
+		},
+		{
+			// No password & no port
+			username: "nopasswordnoport",
+			host: "[::1]",
+			database: "tablau-èdd",
+		},
 	];
-	for (const key of specialKeys) {
-		await keyv.set(key, "value");
-		t.expect(await keyv.has(key)).toBe(true);
-	}
-	t.expect(await keyv.has("nonexistent;key")).toBe(false);
-});
 
-it(".has() prevents UNION-based SQL injection", async (t) => {
-	const keyv = new KeyvMysql(uri);
-	const result = await keyv.has("' UNION SELECT 1 --");
-	t.expect(result).toBe(false);
-});
+	test("parses connection strings into pool options", () => {
+		for (const connection of connectionSamples) {
+			const connectionString = `mysql://${connection.username}:${connection.password ?? ""}@${connection.host}:${connection.port ?? ""}/${connection.database}`;
+			const parsed = parseConnectionString(connectionString);
 
-it(".setMany() updates existing keys", async (t) => {
-	const keyv = new KeyvMysql(uri);
-	const key = faker.string.alphanumeric(10);
-	await keyv.set(key, "original");
-	await keyv.setMany([{ key, value: "updated" }]);
-	t.expect(await keyv.get(key)).toBe("updated");
-});
-
-// Expires column tests
-it("set() extracts and stores expires in the expires column", async (t) => {
-	const keyv = new KeyvMysql(uri);
-	const key = faker.string.alphanumeric(10);
-	const valueWithExpires = JSON.stringify({
-		value: "bar",
-		expires: 9999999999999,
+			expect(parsed.user).toBe(connection.username);
+			expect(parsed.password).toBe(connection.password);
+			expect(parsed.host).toBe(connection.host);
+			expect(parsed.port).toBe(connection.port);
+			expect(parsed.database).toBe(connection.database);
+		}
 	});
-	await keyv.set(key, valueWithExpires);
-	const rows = await keyv.query<mysql.RowDataPacket[]>(
-		`SELECT expires FROM \`keyv\` WHERE id = '${key}' AND namespace = ''`,
-	);
-	t.expect(Number(rows[0].expires)).toBe(9999999999999);
 });
 
-it("set() stores null expires when value has no expires field", async (t) => {
-	const keyv = new KeyvMysql(uri);
-	const key = faker.string.alphanumeric(10);
-	await keyv.set(key, "plain string value");
-	const rows = await keyv.query<mysql.RowDataPacket[]>(
-		`SELECT expires FROM \`keyv\` WHERE id = '${key}' AND namespace = ''`,
-	);
-	t.expect(rows[0].expires).toBeNull();
-});
-
-it("set() updates expires column on upsert", async (t) => {
-	const keyv = new KeyvMysql(uri);
-	const key = faker.string.alphanumeric(10);
-	const value1 = JSON.stringify({ value: "bar", expires: 1000 });
-	const value2 = JSON.stringify({ value: "bar", expires: 2000 });
-	await keyv.set(key, value1);
-	const rows1 = await keyv.query<mysql.RowDataPacket[]>(
-		`SELECT expires FROM \`keyv\` WHERE id = '${key}' AND namespace = ''`,
-	);
-	t.expect(Number(rows1[0].expires)).toBe(1000);
-	await keyv.set(key, value2);
-	const rows2 = await keyv.query<mysql.RowDataPacket[]>(
-		`SELECT expires FROM \`keyv\` WHERE id = '${key}' AND namespace = ''`,
-	);
-	t.expect(Number(rows2[0].expires)).toBe(2000);
-});
-
-it("setMany() extracts and stores expires for each entry", async (t) => {
-	const keyv = new KeyvMysql(uri);
-	const key1 = faker.string.alphanumeric(10);
-	const key2 = faker.string.alphanumeric(10);
-	await keyv.setMany([
-		{ key: key1, value: JSON.stringify({ value: "a", expires: 5000 }) },
-		{ key: key2, value: JSON.stringify({ value: "b" }) },
-	]);
-	const rows = await keyv.query<mysql.RowDataPacket[]>(
-		`SELECT id, expires FROM \`keyv\` WHERE id IN ('${key1}', '${key2}') AND namespace = ''`,
-	);
-	const row1 = rows.find((r) => r.id === key1);
-	const row2 = rows.find((r) => r.id === key2);
-	t.expect(Number(row1?.expires)).toBe(5000);
-	t.expect(row2?.expires).toBeNull();
-});
-
-it("clearExpired() removes expired entries and keeps valid ones", async (t) => {
-	const keyv = new KeyvMysql(uri);
-	const expiredKey = faker.string.alphanumeric(10);
-	const validKey = faker.string.alphanumeric(10);
-	const noExpiryKey = faker.string.alphanumeric(10);
-	// Expired entry (timestamp in the past)
-	const expired = JSON.stringify({ value: "old", expires: 1 });
-	// Valid entry (far future)
-	const valid = JSON.stringify({ value: "new", expires: 9999999999999 });
-	// No expiry
-	const noExpiry = JSON.stringify({ value: "forever" });
-	await keyv.set(expiredKey, expired);
-	await keyv.set(validKey, valid);
-	await keyv.set(noExpiryKey, noExpiry);
-	await keyv.clearExpired();
-	t.expect(await keyv.get(expiredKey)).toBeUndefined();
-	t.expect(await keyv.get(validKey)).toBe(valid);
-	t.expect(await keyv.get(noExpiryKey)).toBe(noExpiry);
-});
-
-it("clearExpired() is a no-op when no entries are expired", async (t) => {
-	const keyv = new KeyvMysql(uri);
-	const key = faker.string.alphanumeric(10);
-	const valid = JSON.stringify({ value: "bar", expires: 9999999999999 });
-	await keyv.set(key, valid);
-	await keyv.clearExpired();
-	t.expect(await keyv.get(key)).toBe(valid);
-});
-
-it("expires column is populated when using Keyv core with TTL", async (t) => {
-	const keyvMysql = new KeyvMysql(uri);
-	const keyv = new Keyv({ store: keyvMysql });
-	const key = faker.string.alphanumeric(10);
-	const value = faker.string.alphanumeric(10);
-	await keyv.set(key, value, 60_000);
-	const rows = await keyvMysql.query<mysql.RowDataPacket[]>(
-		`SELECT expires FROM \`keyv\` WHERE id = '${key}' AND namespace = ''`,
-	);
-	t.expect(rows[0].expires).not.toBeNull();
-	// expires should be roughly Date.now() + 60000
-	const expires = Number(rows[0].expires);
-	const now = Date.now();
-	t.expect(expires).toBeGreaterThan(now);
-	t.expect(expires).toBeLessThanOrEqual(now + 60_000 + 1000);
-});
-
-// Native namespace tests
-it("native namespace: same key in different namespaces stored independently", async (t) => {
-	const ns1 = faker.string.alphanumeric(8);
-	const ns2 = faker.string.alphanumeric(8);
-	const mysql1 = new KeyvMysql({ uri });
-	mysql1.namespace = ns1;
-	const mysql2 = new KeyvMysql({ uri });
-	mysql2.namespace = ns2;
-
-	const key = faker.string.alphanumeric(10);
-	const val1 = faker.string.alphanumeric(10);
-	const val2 = faker.string.alphanumeric(10);
-	await mysql1.set(`${ns1}:${key}`, val1);
-	await mysql2.set(`${ns2}:${key}`, val2);
-
-	t.expect(await mysql1.get(`${ns1}:${key}`)).toBe(val1);
-	t.expect(await mysql2.get(`${ns2}:${key}`)).toBe(val2);
-});
-
-it("native namespace: null namespace stores and retrieves correctly", async (t) => {
-	const keyv = new KeyvMysql({ uri });
-	const key = faker.string.alphanumeric(10);
-	const value = faker.string.alphanumeric(10);
-	await keyv.set(key, value);
-	t.expect(await keyv.get(key)).toBe(value);
-});
-
-it("native namespace: clear only clears the specified namespace", async (t) => {
-	const ns1 = faker.string.alphanumeric(8);
-	const ns2 = faker.string.alphanumeric(8);
-	const mysql1 = new KeyvMysql({ uri });
-	mysql1.namespace = ns1;
-	const mysql2 = new KeyvMysql({ uri });
-	mysql2.namespace = ns2;
-
-	const key = faker.string.alphanumeric(10);
-	const val1 = faker.string.alphanumeric(10);
-	const val2 = faker.string.alphanumeric(10);
-	await mysql1.set(`${ns1}:${key}`, val1);
-	await mysql2.set(`${ns2}:${key}`, val2);
-
-	await mysql1.clear();
-
-	t.expect(await mysql1.get(`${ns1}:${key}`)).toBeUndefined();
-	t.expect(await mysql2.get(`${ns2}:${key}`)).toBe(val2);
-});
-
-it("native namespace: delete scoped to namespace", async (t) => {
-	const ns1 = faker.string.alphanumeric(8);
-	const ns2 = faker.string.alphanumeric(8);
-	const mysql1 = new KeyvMysql({ uri });
-	mysql1.namespace = ns1;
-	const mysql2 = new KeyvMysql({ uri });
-	mysql2.namespace = ns2;
-
-	const key = faker.string.alphanumeric(10);
-	const val1 = faker.string.alphanumeric(10);
-	const val2 = faker.string.alphanumeric(10);
-	await mysql1.set(`${ns1}:${key}`, val1);
-	await mysql2.set(`${ns2}:${key}`, val2);
-
-	const deleted = await mysql1.delete(`${ns1}:${key}`);
-	t.expect(deleted).toBe(true);
-	t.expect(await mysql1.get(`${ns1}:${key}`)).toBeUndefined();
-	t.expect(await mysql2.get(`${ns2}:${key}`)).toBe(val2);
-});
-
-it("native namespace: deleteMany scoped to namespace", async (t) => {
-	const ns1 = faker.string.alphanumeric(8);
-	const ns2 = faker.string.alphanumeric(8);
-	const mysql1 = new KeyvMysql({ uri });
-	mysql1.namespace = ns1;
-	const mysql2 = new KeyvMysql({ uri });
-	mysql2.namespace = ns2;
-
-	const key = faker.string.alphanumeric(10);
-	const val1 = faker.string.alphanumeric(10);
-	const val2 = faker.string.alphanumeric(10);
-	await mysql1.set(`${ns1}:${key}`, val1);
-	await mysql2.set(`${ns2}:${key}`, val2);
-
-	const deleted = await mysql1.deleteMany([`${ns1}:${key}`]);
-	t.expect(deleted).toEqual([true]);
-	t.expect(await mysql1.get(`${ns1}:${key}`)).toBeUndefined();
-	t.expect(await mysql2.get(`${ns2}:${key}`)).toBe(val2);
-});
-
-it("native namespace: has scoped to namespace", async (t) => {
-	const ns1 = faker.string.alphanumeric(8);
-	const ns2 = faker.string.alphanumeric(8);
-	const mysql1 = new KeyvMysql({ uri });
-	mysql1.namespace = ns1;
-	const mysql2 = new KeyvMysql({ uri });
-	mysql2.namespace = ns2;
-
-	const key = faker.string.alphanumeric(10);
-	const val = faker.string.alphanumeric(10);
-	await mysql1.set(`${ns1}:${key}`, val);
-
-	t.expect(await mysql1.has(`${ns1}:${key}`)).toBe(true);
-	// ns2 should not see ns1's key
-	t.expect(await mysql2.has(`${ns2}:${key}`)).toBe(false);
-});
-
-it("native namespace: hasMany scoped to namespace", async (t) => {
-	const ns1 = faker.string.alphanumeric(8);
-	const ns2 = faker.string.alphanumeric(8);
-	const mysql1 = new KeyvMysql({ uri });
-	mysql1.namespace = ns1;
-	const mysql2 = new KeyvMysql({ uri });
-	mysql2.namespace = ns2;
-
-	const key = faker.string.alphanumeric(10);
-	const val1 = faker.string.alphanumeric(10);
-	const val2 = faker.string.alphanumeric(10);
-	await mysql1.set(`${ns1}:${key}`, val1);
-	await mysql2.set(`${ns2}:${key}`, val2);
-
-	const result1 = await mysql1.hasMany([`${ns1}:${key}`]);
-	t.expect(result1).toEqual([true]);
-
-	const result2 = await mysql1.hasMany([`${ns2}:${key}`]);
-	t.expect(result2).toEqual([false]);
-});
-
-it("native namespace: iterator only returns keys from correct namespace", async (t) => {
-	const ns1 = faker.string.alphanumeric(8);
-	const ns2 = faker.string.alphanumeric(8);
-	const mysql1 = new KeyvMysql({ uri });
-	mysql1.namespace = ns1;
-	const mysql2 = new KeyvMysql({ uri });
-	mysql2.namespace = ns2;
-
-	const key1 = faker.string.alphanumeric(10);
-	const key2 = faker.string.alphanumeric(10);
-	const key3 = faker.string.alphanumeric(10);
-	await mysql1.set(key1, "val1");
-	await mysql1.set(key2, "val2");
-	await mysql2.set(key3, "val3");
-
-	const keys: string[] = [];
-	for await (const [key] of mysql1.iterator(ns1)) {
-		keys.push(key);
-	}
-
-	t.expect(keys.length).toBe(2);
-	t.expect(keys).toContain(key1);
-	t.expect(keys).toContain(key2);
-});
-
-it("native namespace: two Keyv instances with different namespaces do not conflict", async (t) => {
-	const nsA = faker.string.alphanumeric(8);
-	const nsB = faker.string.alphanumeric(8);
-	const mysqlA = new KeyvMysql({ uri });
-	const mysqlB = new KeyvMysql({ uri });
-	const keyvA = new Keyv({ store: mysqlA, namespace: nsA });
-	const keyvB = new Keyv({ store: mysqlB, namespace: nsB });
-
-	const key = faker.string.alphanumeric(10);
-	const valA = faker.string.alphanumeric(10);
-	const valB = faker.string.alphanumeric(10);
-	t.expect(await keyvA.set(key, valA)).toBe(true);
-	t.expect(await keyvA.get(key)).toBe(valA);
-	t.expect(await keyvB.set(key, valB)).toBe(true);
-	t.expect(await keyvB.get(key)).toBe(valB);
-	// Ensure they didn't overwrite each other
-	t.expect(await keyvA.get(key)).toBe(valA);
-});
-
-it("native namespace: getMany scoped to namespace", async (t) => {
-	const ns1 = faker.string.alphanumeric(8);
-	const ns2 = faker.string.alphanumeric(8);
-	const mysql1 = new KeyvMysql({ uri });
-	mysql1.namespace = ns1;
-	const mysql2 = new KeyvMysql({ uri });
-	mysql2.namespace = ns2;
-
-	const key = faker.string.alphanumeric(10);
-	const val1 = faker.string.alphanumeric(10);
-	const val2 = faker.string.alphanumeric(10);
-	await mysql1.set(`${ns1}:${key}`, val1);
-	await mysql2.set(`${ns2}:${key}`, val2);
-
-	const results = await mysql1.getMany([`${ns1}:${key}`]);
-	t.expect(results).toEqual([val1]);
-
-	const results2 = await mysql1.getMany([`${ns2}:${key}`]);
-	t.expect(results2).toEqual([undefined]);
-});
-
-it("native namespace: setMany scoped to namespace", async (t) => {
-	const ns1 = faker.string.alphanumeric(8);
-	const ns2 = faker.string.alphanumeric(8);
-	const mysql1 = new KeyvMysql({ uri });
-	mysql1.namespace = ns1;
-	const mysql2 = new KeyvMysql({ uri });
-	mysql2.namespace = ns2;
-
-	const key1 = faker.string.alphanumeric(10);
-	const key2 = faker.string.alphanumeric(10);
-	const val1 = faker.string.alphanumeric(10);
-	const val2 = faker.string.alphanumeric(10);
-	await mysql1.setMany([
-		{ key: `${ns1}:${key1}`, value: val1 },
-		{ key: `${ns1}:${key2}`, value: val2 },
-	]);
-
-	t.expect(await mysql1.get(`${ns1}:${key1}`)).toBe(val1);
-	t.expect(await mysql1.get(`${ns1}:${key2}`)).toBe(val2);
-	// ns2 should not see ns1's keys
-	t.expect(await mysql2.get(`${ns2}:${key1}`)).toBeUndefined();
-});
-
-// Property getter/setter tests
-it("properties have correct defaults", (t) => {
-	const keyv = new KeyvMysql(uri);
-	t.expect(keyv.uri).toBe(uri);
-	t.expect(keyv.table).toBe("keyv");
-	t.expect(keyv.keyLength).toBe(255);
-	t.expect(keyv.namespaceLength).toBe(255);
-	t.expect(keyv.iterationLimit).toBe(10);
-	t.expect(keyv.intervalExpiration).toBeUndefined();
-	t.expect(keyv.namespace).toBeUndefined();
-});
-
-it("properties are set correctly via constructor options", (t) => {
-	const keyv = new KeyvMysql({
-		uri,
-		table: "custom_table",
-		keyLength: 512,
-		namespaceLength: 128,
-		iterationLimit: 50,
+describe("createKeyv", () => {
+	test("returns a Keyv instance from a uri string", async () => {
+		const keyv = createKeyv(uri);
+		expect(keyv).toBeInstanceOf(Keyv);
+		const key = faker.string.alphanumeric(10);
+		const value = faker.string.alphanumeric(10);
+		await keyv.set(key, value);
+		expect(await keyv.get(key)).toBe(value);
 	});
-	t.expect(keyv.table).toBe("custom_table");
-	t.expect(keyv.keyLength).toBe(512);
-	t.expect(keyv.namespaceLength).toBe(128);
-	t.expect(keyv.iterationLimit).toBe(50);
-});
 
-it("property getters return configured values", (t) => {
-	const keyv = new KeyvMysql({ uri, table: "custom", keyLength: 512 });
-	t.expect(keyv.table).toBe("custom");
-	t.expect(keyv.keyLength).toBe(512);
-	t.expect(keyv.uri).toBe(uri);
-	t.expect(keyv.namespaceLength).toBe(255);
-	t.expect(keyv.iterationLimit).toBe(10);
-});
-
-it("individual property setters work", (t) => {
-	const keyv = new KeyvMysql(uri);
-	keyv.uri = "mysql://otherhost";
-	t.expect(keyv.uri).toBe("mysql://otherhost");
-	keyv.table = "updated_table";
-	t.expect(keyv.table).toBe("updated_table");
-	keyv.keyLength = 1024;
-	t.expect(keyv.keyLength).toBe(1024);
-	keyv.namespaceLength = 128;
-	t.expect(keyv.namespaceLength).toBe(128);
-	keyv.iterationLimit = 100;
-	t.expect(keyv.iterationLimit).toBe(100);
-	keyv.intervalExpiration = 30;
-	t.expect(keyv.intervalExpiration).toBe(30);
-	keyv.namespace = "test-ns";
-	t.expect(keyv.namespace).toBe("test-ns");
-});
-
-// Non-string value tests (covers getExpiresFromValue else branch)
-it("set() stores null expires when value is a number (non-string)", async (t) => {
-	const keyv = new KeyvMysql(uri);
-	const key = faker.string.alphanumeric(10);
-	await keyv.set(key, 42);
-	const rows = await keyv.query<mysql.RowDataPacket[]>(
-		`SELECT expires FROM \`keyv\` WHERE id = '${key}' AND namespace = ''`,
-	);
-	t.expect(rows[0].expires).toBeNull();
-});
-
-it("set() stores null expires when value is null (non-string)", async (t) => {
-	const keyv = new KeyvMysql(uri);
-	const key = faker.string.alphanumeric(10);
-	await keyv.set(key, null);
-	const rows = await keyv.query<mysql.RowDataPacket[]>(
-		`SELECT expires FROM \`keyv\` WHERE id = '${key}' AND namespace = ''`,
-	);
-	t.expect(rows[0].expires).toBeNull();
-});
-
-// createKeyv helper tests
-
-it("createKeyv with URI string returns a Keyv instance", async (t) => {
-	const keyv = createKeyv(uri);
-	t.expect(keyv).toBeInstanceOf(Keyv);
-	const key = faker.string.alphanumeric(10);
-	const value = faker.string.alphanumeric(10);
-	await keyv.set(key, value);
-	t.expect(await keyv.get(key)).toBe(value);
-});
-
-it("setMany returns false entries on query error", async (t) => {
-	const store = new KeyvMysql(uri);
-	let emittedError = false;
-	store.on("error", () => {
-		emittedError = true;
+	test("returns a Keyv instance from an options object", async () => {
+		const keyv = createKeyv({ uri, table: "keyv" });
+		expect(keyv).toBeInstanceOf(Keyv);
+		const key = faker.string.alphanumeric(10);
+		const value = faker.string.alphanumeric(10);
+		await keyv.set(key, value);
+		expect(await keyv.get(key)).toBe(value);
 	});
-	// Close the connection to force an error
-	await store.disconnect();
-	const result = await store.setMany([
-		{ key: "key1", value: "val1" },
-		{ key: "key2", value: "val2" },
-	]);
-	t.expect(result).toEqual([false, false]);
-	t.expect(emittedError).toBe(true);
-});
-
-it("has returns false and deletes expired key", async (t) => {
-	const keyv = new KeyvMysql(uri);
-	const key = faker.string.alphanumeric(10);
-	const expiredValue = JSON.stringify({ value: "old", expires: Date.now() - 1000 });
-	await keyv.set(key, expiredValue);
-	t.expect(await keyv.has(key)).toBe(false);
-	// Verify the key was deleted
-	t.expect(await keyv.get(key)).toBeUndefined();
-});
-
-it("hasMany returns false for expired keys and deletes them", async (t) => {
-	const keyv = new KeyvMysql(uri);
-	const expiredKey1 = faker.string.alphanumeric(10);
-	const expiredKey2 = faker.string.alphanumeric(10);
-	const validKey = faker.string.alphanumeric(10);
-	const expiredValue = JSON.stringify({ value: "old", expires: Date.now() - 1000 });
-	const validValue = JSON.stringify({ value: "fresh", expires: Date.now() + 60_000 });
-	await keyv.set(expiredKey1, expiredValue);
-	await keyv.set(expiredKey2, expiredValue);
-	await keyv.set(validKey, validValue);
-	const result = await keyv.hasMany([expiredKey1, expiredKey2, validKey]);
-	t.expect(result).toStrictEqual([false, false, true]);
-	// Verify expired keys were deleted
-	t.expect(await keyv.get(expiredKey1)).toBeUndefined();
-	t.expect(await keyv.get(expiredKey2)).toBeUndefined();
-});
-
-it("setMany with empty array returns empty array", async (t) => {
-	const keyv = new KeyvMysql(uri);
-	const result = await keyv.setMany([]);
-	t.expect(result).toEqual([]);
-});
-
-it("hasMany with empty array returns empty array", async (t) => {
-	const keyv = new KeyvMysql(uri);
-	const result = await keyv.hasMany([]);
-	t.expect(result).toEqual([]);
-});
-
-it("iterator on empty namespace yields nothing", async (t) => {
-	const ns = faker.string.alphanumeric(8);
-	const keyv = new KeyvMysql({ uri });
-	keyv.namespace = ns;
-	const collected: Array<[string, string]> = [];
-	for await (const entry of keyv.iterator()) {
-		collected.push(entry as [string, string]);
-	}
-
-	t.expect(collected.length).toBe(0);
-});
-
-it("createKeyv with options object returns a Keyv instance", async (t) => {
-	const keyv = createKeyv({ uri, table: "keyv" });
-	t.expect(keyv).toBeInstanceOf(Keyv);
-	const key = faker.string.alphanumeric(10);
-	const value = faker.string.alphanumeric(10);
-	await keyv.set(key, value);
-	t.expect(await keyv.get(key)).toBe(value);
 });


### PR DESCRIPTION
## Summary

Full code and test review of `@keyv/mysql` covering the requested checklist. Verified end-to-end against MySQL (regular + SSL) containers: **113 tests pass**, lint clean, coverage **99.55% stmts / 95.55% branch / 100% lines**.

## Source fixes

- **`get()` / `getMany()` return `undefined`, never `null`.** A SQL `NULL` value is now coerced to `undefined` so the adapter never leaks `null` to callers.
- **`getMany([])` no longer crashes.** With an empty key array the old code produced `... id IN () ...`, which is a MySQL syntax error. It now returns `[]` early, matching `hasMany()`. *(This was hidden because the test file disabled the shared `batch` suite — enabling it surfaced the bug.)*
- **No more unhandled rejection from the eager connection.** The constructor starts a background "connect + create table" promise. If an instance is constructed but never queried and the shared pool is closed by another instance, that promise rejected unhandled. A no-op `catch` is attached; real query failures still surface to callers because `query()` awaits the same promise.

## Tests (`test/test.ts`, `test/ssl.ts`)

- Rewritten with `describe` / `test` / `expect` grouped by method, matching the `mongo` / `memcache` adapters (previously `it` + `t.expect`). All `faker`-based, as before.
- Enabled the shared storage suite groups that were turned off (`batch`, `iterator`, `namespace`, `disconnect`), leaving only `ttl: false` — exactly as the postgres adapter does.
- **`iterator()` is now called without a namespace argument**; the namespace comes from the instance (the adapter never accepted an argument, and the old tests passed one that was silently ignored).
- Added explicit coverage proving `get()` / `getMany()` return `undefined` (not `null`) for null-valued keys.
- `ssl.ts` converted to the same style and updated to actually assert the no-SSL failure path.

## Docs (`README.md`)

- Fixed the **SSL example**, which used a non-existent two-argument constructor (`new KeyvMysql(uri, options)`). The constructor takes a single argument, so the example now uses `new KeyvMysql({ uri, ssl })` (and adds the missing `path` import).
- Removed the stale note about an `opts` getter "still existing for backward compatibility" — `opts` was removed in v6.

## Verification

```
Test Files  2 passed (2)
     Tests  113 passed (113)
% Coverage: 99.55 stmts | 95.55 branch | 100 lines
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCbyPSX6JPciuuPwKpcNjK

---
_Generated by [Claude Code](https://claude.ai/code/session_01XCbyPSX6JPciuuPwKpcNjK)_