### PR TITLE
postgres - refactor: code/test review for @keyv/postgres

### DIFF
--- a/storage/postgres/README.md
+++ b/storage/postgres/README.md
@@ -82,8 +82,7 @@ const keyv = createKeyv({ uri: 'postgresql://user:pass@localhost:5432/dbname', t
 
 ## Breaking changes
 
-
-The `opts` getter still exists for backward compatibility but should not be used for new code.
+v6 changes how namespaces are stored and which base class the adapter extends. Configuration is now exposed through dedicated [properties](#properties) (getters/setters) on the instance rather than a generic options bag. The sections below describe the changes and how to migrate existing data.
 
 ### Native namespace support
 
@@ -352,7 +351,7 @@ const results = await keyv.setMany([
 
 ## .get(key)
 
-Get a value by key. Returns `undefined` if the key does not exist.
+Get a value by key. Returns `undefined` if the key does not exist or has expired. A SQL `NULL` value is normalized to `undefined` (the adapter never returns `null`).
 
 ```js
 const value = await keyv.get('foo'); // 'bar'
@@ -360,7 +359,7 @@ const value = await keyv.get('foo'); // 'bar'
 
 ## .getMany(keys)
 
-Get multiple values at once. Returns an array of values in the same order as the keys, with `undefined` for missing keys.
+Get multiple values at once. Returns an array of values in the same order as the keys, with `undefined` for missing, expired, or `NULL` entries (never `null`).
 
 ```js
 const values = await keyv.getMany(['foo', 'baz']); // ['bar', 'qux']

--- a/storage/postgres/src/index.ts
+++ b/storage/postgres/src/index.ts
@@ -147,39 +147,6 @@ export class KeyvPostgres extends Hookified implements KeyvStorageAdapter {
 	}
 
 	/**
-	 * Initializes the database connection and ensures the table schema exists.
-	 * Called from the constructor; errors are emitted rather than thrown.
-	 */
-	private async init(
-		createTable: string,
-		migration: string,
-		migrationExpires: string,
-		dropOldPk: string,
-		createIndex: string,
-		createExpiresIndex: string,
-	): Promise<Query> {
-		const query = await this.connect();
-
-		try {
-			await query(createTable);
-			await query(migration);
-			await query(migrationExpires);
-			await query(dropOldPk);
-			await query(createIndex);
-			await query(createExpiresIndex);
-		} catch (error) {
-			// 23505 = unique_violation: safe to ignore when concurrent instances
-			// race to create the same index (the index already exists).
-			/* v8 ignore next -- @preserve */
-			if ((error as DatabaseError).code !== "23505") {
-				this.emit("error", error);
-			}
-		}
-
-		return query;
-	}
-
-	/**
 	 * Get the namespace for the adapter. If undefined, no namespace prefix is applied.
 	 */
 	public get namespace(): string | undefined {
@@ -632,6 +599,56 @@ export class KeyvPostgres extends Hookified implements KeyvStorageAdapter {
 	}
 
 	/**
+	 * Disconnects from the PostgreSQL database and releases the connection pool.
+	 * Also stops the automatic expired-entry cleanup interval if running.
+	 * @returns A promise that resolves once the pool has been closed.
+	 */
+	public async disconnect(): Promise<void> {
+		this.stopClearExpiredTimer();
+		await endPool(this._uri, { ...this._poolConfig, ssl: this._ssl });
+	}
+
+	/**
+	 * Initializes the database connection and ensures the table schema exists.
+	 * Called from the constructor; errors are emitted rather than thrown.
+	 * @param createTable - SQL statement that creates the storage table (and schema if needed).
+	 * @param migration - SQL statement that adds the `namespace` column to legacy tables.
+	 * @param migrationExpires - SQL statement that adds the `expires` column to legacy tables.
+	 * @param dropOldPk - SQL statement that drops the legacy single-column primary key.
+	 * @param createIndex - SQL statement that creates the unique `(key, namespace)` index.
+	 * @param createExpiresIndex - SQL statement that creates the partial index on `expires`.
+	 * @returns A promise resolving to the query function once initialization completes.
+	 */
+	private async init(
+		createTable: string,
+		migration: string,
+		migrationExpires: string,
+		dropOldPk: string,
+		createIndex: string,
+		createExpiresIndex: string,
+	): Promise<Query> {
+		const query = await this.connect();
+
+		try {
+			await query(createTable);
+			await query(migration);
+			await query(migrationExpires);
+			await query(dropOldPk);
+			await query(createIndex);
+			await query(createExpiresIndex);
+		} catch (error) {
+			// 23505 = unique_violation: safe to ignore when concurrent instances
+			// race to create the same index (the index already exists).
+			/* v8 ignore next -- @preserve */
+			if ((error as DatabaseError).code !== "23505") {
+				this.emit("error", error);
+			}
+		}
+
+		return query;
+	}
+
+	/**
 	 * Establishes a connection to the PostgreSQL database via the connection pool.
 	 * @returns A query function that executes SQL statements and returns result rows.
 	 */
@@ -642,16 +659,6 @@ export class KeyvPostgres extends Hookified implements KeyvStorageAdapter {
 			const data = await conn.query(sql, values);
 			return data.rows;
 		};
-	}
-
-	/**
-	 * Disconnects from the PostgreSQL database and releases the connection pool.
-	 * Also stops the automatic expired-entry cleanup interval if running.
-	 * @returns A promise that resolves once the pool has been closed.
-	 */
-	public async disconnect(): Promise<void> {
-		this.stopClearExpiredTimer();
-		await endPool(this._uri, { ...this._poolConfig, ssl: this._ssl });
 	}
 
 	/**

--- a/storage/postgres/src/index.ts
+++ b/storage/postgres/src/index.ts
@@ -1,6 +1,6 @@
 import type { ConnectionOptions } from "node:tls";
 import { Hookified } from "hookified";
-import Keyv, { type KeyvEntry, type KeyvStorageAdapter } from "keyv";
+import Keyv, { type KeyvEntry, type KeyvStorageAdapter, type KeyvStorageGetResult } from "keyv";
 import type { DatabaseError, PoolConfig } from "pg";
 import { endPool, pool } from "./pool.js";
 import type { KeyvPostgresOptions, Query } from "./types.js";
@@ -332,11 +332,13 @@ export class KeyvPostgres extends Hookified implements KeyvStorageAdapter {
 	}
 
 	/**
-	 * Gets a value by key.
+	 * Gets a value by key. Expired entries are deleted on read and reported as missing.
+	 * @template Value - The type of the stored value.
 	 * @param key - The key to retrieve.
-	 * @returns The value associated with the key, or `undefined` if not found.
+	 * @returns A promise resolving to the value associated with the key, or `undefined` if the
+	 * key does not exist or has expired. A SQL `NULL` value is normalized to `undefined`.
 	 */
-	public async get<Value>(key: string): Promise<Value | undefined> {
+	public async get<Value>(key: string): Promise<KeyvStorageGetResult<Value>> {
 		const strippedKey = this.removeKeyPrefix(key);
 		const ns = this.getNamespaceValue();
 		const now = Date.now();
@@ -353,28 +355,33 @@ export class KeyvPostgres extends Hookified implements KeyvStorageAdapter {
 			return undefined;
 		}
 
-		return row.value;
+		// Coerce a SQL NULL value to undefined so the adapter never returns null.
+		return (row.value ?? undefined) as KeyvStorageGetResult<Value>;
 	}
 
 	/**
-	 * Gets multiple values by their keys.
+	 * Gets multiple values by their keys. Expired entries are deleted on read and reported as missing.
+	 * @template Value - The type of the stored values.
 	 * @param keys - An array of keys to retrieve.
-	 * @returns An array of values in the same order as the keys, with `undefined` for missing keys.
+	 * @returns A promise resolving to an array of values in the same order as the keys, with
+	 * `undefined` for missing, expired, or SQL `NULL` entries.
 	 */
-	public async getMany<Value>(keys: string[]): Promise<Array<Value | undefined>> {
+	public async getMany<Value>(
+		keys: string[],
+	): Promise<Array<KeyvStorageGetResult<Value | undefined>>> {
 		const strippedKeys = keys.map((k) => this.removeKeyPrefix(k));
 		const ns = this.getNamespaceValue();
 		const now = Date.now();
 		const getMany = `SELECT * FROM ${escapeIdentifier(this._schema)}.${escapeIdentifier(this._table)} WHERE key = ANY($1) AND COALESCE(namespace, '') = COALESCE($2, '')`;
 		const rows = await this.query(getMany, [strippedKeys, ns]);
 
-		const validMap = new Map<string, Value>();
+		const validMap = new Map<string, KeyvStorageGetResult<Value>>();
 		const expiredKeys: string[] = [];
 		for (const row of rows) {
 			if (row.expires !== null && row.expires !== undefined && row.expires <= now) {
 				expiredKeys.push(row.key as string);
 			} else {
-				validMap.set(row.key as string, row.value as Value);
+				validMap.set(row.key as string, row.value as KeyvStorageGetResult<Value>);
 			}
 		}
 
@@ -383,13 +390,19 @@ export class KeyvPostgres extends Hookified implements KeyvStorageAdapter {
 			await this.query(del, [expiredKeys, ns]);
 		}
 
-		return strippedKeys.map((key) => validMap.get(key));
+		// Coerce missing keys and SQL NULL values to undefined so the adapter never returns null.
+		return strippedKeys.map(
+			(key) => (validMap.get(key) ?? undefined) as KeyvStorageGetResult<Value | undefined>,
+		);
 	}
 
 	/**
 	 * Sets a key-value pair. Uses an upsert operation via `ON CONFLICT` to insert or update.
+	 * Any TTL is read from the serialized value's `expires` field and stored in the `expires` column.
 	 * @param key - The key to set.
 	 * @param value - The value to store.
+	 * @returns A promise resolving to `true` on success, or `false` if an error occurred (an
+	 * `error` event is also emitted).
 	 */
 	// biome-ignore lint/suspicious/noExplicitAny: type format
 	public async set(key: string, value: any): Promise<boolean> {
@@ -411,8 +424,12 @@ export class KeyvPostgres extends Hookified implements KeyvStorageAdapter {
 	}
 
 	/**
-	 * Sets multiple key-value pairs at once using PostgreSQL `UNNEST` for efficient bulk operations.
+	 * Sets multiple key-value pairs at once using a single atomic PostgreSQL
+	 * `INSERT ... UNNEST ... ON CONFLICT` statement for efficient bulk upserts.
+	 * @template Value - The type of the stored values.
 	 * @param entries - An array of key-value entry objects.
+	 * @returns A promise resolving to an array of booleans (one per entry). Because the statement
+	 * is atomic, all entries succeed (`true`) or all fail (`false`); on failure an `error` event is emitted.
 	 */
 	public async setMany<Value>(entries: KeyvEntry<Value>[]): Promise<boolean[] | undefined> {
 		try {
@@ -460,7 +477,9 @@ export class KeyvPostgres extends Hookified implements KeyvStorageAdapter {
 	}
 
 	/**
-	 * Clears all keys in the current namespace. If no namespace is set, all keys are removed.
+	 * Clears all keys in the current namespace. If no namespace is set, only keys without a
+	 * namespace (the default namespace) are removed.
+	 * @returns A promise that resolves once the matching keys have been deleted.
 	 */
 	public async clear(): Promise<void> {
 		if (this._namespace) {
@@ -473,7 +492,9 @@ export class KeyvPostgres extends Hookified implements KeyvStorageAdapter {
 	}
 
 	/**
-	 * Utility helper method to delete all expired entries from the store where the `expires` column is less than the current timestamp.
+	 * Utility helper method to delete all expired entries from the store where the `expires`
+	 * column is set and less than the current timestamp. Useful for periodic cleanup.
+	 * @returns A promise that resolves once expired entries have been deleted.
 	 */
 	public async clearExpired(): Promise<void> {
 		const del = `DELETE FROM ${escapeIdentifier(this._schema)}.${escapeIdentifier(this._table)} WHERE expires IS NOT NULL AND expires < $1`;
@@ -481,9 +502,12 @@ export class KeyvPostgres extends Hookified implements KeyvStorageAdapter {
 	}
 
 	/**
-	 * Iterates over all key-value pairs, optionally filtered by namespace.
-	 * Uses cursor-based (keyset) pagination with batch size controlled by `iterationLimit`.
-	 * @yields A `[key, value]` tuple for each entry.
+	 * Iterates over all key-value pairs scoped to the namespace configured on the instance.
+	 * The namespace does not need to be passed in — it is read from the `namespace` property.
+	 * Uses cursor-based (keyset) pagination with batch size controlled by `iterationLimit`,
+	 * which handles concurrent deletions during iteration without skipping entries.
+	 * @yields A `[key, value]` tuple for each non-expired entry.
+	 * @returns An async generator of `[key, value]` tuples.
 	 */
 	public async *iterator(): AsyncGenerator<[string, string], void, unknown> {
 		const limit = Number.parseInt(String(this._iterationLimit), 10) || 10;
@@ -623,6 +647,7 @@ export class KeyvPostgres extends Hookified implements KeyvStorageAdapter {
 	/**
 	 * Disconnects from the PostgreSQL database and releases the connection pool.
 	 * Also stops the automatic expired-entry cleanup interval if running.
+	 * @returns A promise that resolves once the pool has been closed.
 	 */
 	public async disconnect(): Promise<void> {
 		this.stopClearExpiredTimer();
@@ -703,6 +728,11 @@ export class KeyvPostgres extends Hookified implements KeyvStorageAdapter {
 		}
 	}
 
+	/**
+	 * Applies a {@link KeyvPostgresOptions} object to the instance, assigning known adapter
+	 * options and forwarding any remaining properties to the underlying pg `PoolConfig`.
+	 * @param options - The options object to apply.
+	 */
 	private setOptions(options: KeyvPostgresOptions): void {
 		if (options.uri !== undefined) {
 			this._uri = options.uri;
@@ -759,11 +789,11 @@ export class KeyvPostgres extends Hookified implements KeyvStorageAdapter {
 
 /**
  * Helper function to create a Keyv instance with KeyvPostgres as the storage adapter.
- * @param options - Optional {@link KeyvPostgresOptions} configuration object.
+ * @param options - Optional {@link KeyvPostgresOptions} configuration object or a PostgreSQL connection URI string.
  * @returns A new Keyv instance backed by PostgreSQL.
  */
-export const createKeyv = (options?: KeyvPostgresOptions) =>
+export const createKeyv = (options?: KeyvPostgresOptions | string) =>
 	new Keyv({ store: new KeyvPostgres(options) });
 
 export default KeyvPostgres;
-export type { KeyvPostgresOptions } from "./types";
+export type { KeyvPostgresOptions } from "./types.js";

--- a/storage/postgres/test/test-ssl.ts
+++ b/storage/postgres/test/test-ssl.ts
@@ -1,5 +1,5 @@
 import { faker } from "@faker-js/faker";
-import { beforeEach, it } from "vitest";
+import { beforeEach, describe, expect, test } from "vitest";
 import KeyvPostgres from "../src/index.js";
 import { endAllPools } from "../src/pool.js";
 
@@ -14,61 +14,52 @@ beforeEach(async () => {
 	await keyv.clear();
 });
 
-it("throws if ssl is not used", async (t) => {
-	await endAllPools();
-	try {
-		const keyv = new KeyvPostgres({ uri: postgresUri });
-		const key = faker.string.alphanumeric(10);
-		await keyv.get(key);
-		t.expect.fail();
-	} catch {
-		t.expect(true).toBeTruthy();
-	} finally {
+describe("ssl", () => {
+	test("throws when ssl is not used", async () => {
 		await endAllPools();
-	}
-});
+		try {
+			const keyv = new KeyvPostgres({ uri: postgresUri });
+			await keyv.get(faker.string.alphanumeric(10));
+			expect.fail("expected the connection to fail without ssl");
+		} catch {
+			expect(true).toBeTruthy();
+		} finally {
+			await endAllPools();
+		}
+	});
 
-it("iterator with default namespace", async (t) => {
-	const keyv = new KeyvPostgres({ uri: postgresUri, ...options });
-	const key1 = faker.string.alphanumeric(10);
-	const value1 = faker.lorem.sentence();
-	const key2 = faker.string.alphanumeric(10);
-	const value2 = faker.lorem.sentence();
-	const key3 = faker.string.alphanumeric(10);
-	const value3 = faker.lorem.sentence();
-	await keyv.set(key1, value1);
-	await keyv.set(key2, value2);
-	await keyv.set(key3, value3);
+	test("iterates over the default namespace", async () => {
+		const keyv = new KeyvPostgres({ uri: postgresUri, ...options });
+		const key1 = faker.string.alphanumeric(10);
+		const value1 = faker.lorem.sentence();
+		const key2 = faker.string.alphanumeric(10);
+		const value2 = faker.lorem.sentence();
+		const key3 = faker.string.alphanumeric(10);
+		const value3 = faker.lorem.sentence();
+		await keyv.set(key1, value1);
+		await keyv.set(key2, value2);
+		await keyv.set(key3, value3);
 
-	const keys: string[] = [];
-	const values: string[] = [];
-	for await (const [key, value] of keyv.iterator()) {
-		keys.push(key);
-		values.push(value as string);
-	}
+		const collected = new Map<string, string>();
+		for await (const [key, value] of keyv.iterator()) {
+			collected.set(key, value);
+		}
 
-	t.expect(keys).toContain(key1);
-	t.expect(keys).toContain(key2);
-	t.expect(keys).toContain(key3);
-	t.expect(values).toContain(value1);
-	t.expect(values).toContain(value2);
-	t.expect(values).toContain(value3);
-});
+		expect(collected.get(key1)).toBe(value1);
+		expect(collected.get(key2)).toBe(value2);
+		expect(collected.get(key3)).toBe(value3);
+	});
 
-it(".clear() with undefined namespace", async (t) => {
-	const keyv = store();
-	t.expect(await keyv.clear()).toBeUndefined();
-});
+	test("clear returns undefined with the default namespace", async () => {
+		const keyv = store();
+		expect(await keyv.clear()).toBeUndefined();
+	});
 
-it("close connection successfully", async (t) => {
-	const keyv = store();
-	const key = faker.string.alphanumeric(10);
-	t.expect(await keyv.get(key)).toBeUndefined();
-	await keyv.disconnect();
-	try {
-		await keyv.get(key);
-		t.expect.fail();
-	} catch {
-		t.expect(true).toBeTruthy();
-	}
+	test("closes the connection on disconnect", async () => {
+		const keyv = store();
+		const key = faker.string.alphanumeric(10);
+		expect(await keyv.get(key)).toBeUndefined();
+		await keyv.disconnect();
+		await expect(keyv.get(key)).rejects.toBeDefined();
+	});
 });

--- a/storage/postgres/test/test.ts
+++ b/storage/postgres/test/test.ts
@@ -1,641 +1,831 @@
 import { faker } from "@faker-js/faker";
 import { keyvIteratorTests, keyvTestSuite, storageTestSuite } from "@keyv/test-suite";
 import Keyv from "keyv";
-import { beforeEach, it } from "vitest";
+import { beforeEach, describe, expect, test } from "vitest";
 import KeyvPostgres, { createKeyv } from "../src/index.js";
 
 const postgresUri = "postgresql://postgres:postgres@localhost:5432/keyv_test";
 
 const store = () => new KeyvPostgres({ uri: postgresUri, iterationLimit: 2 });
-keyvTestSuite(it, Keyv, store);
-keyvIteratorTests(it, Keyv, store);
-storageTestSuite(it, store, { ttl: false });
+
+keyvTestSuite(test, Keyv, store);
+keyvIteratorTests(test, Keyv, store);
+storageTestSuite(test, store, { ttl: false });
 
 beforeEach(async () => {
 	const keyv = store();
 	await keyv.clear();
 });
 
-it("should be able to pass in just uri as string", async (t) => {
-	const keyv = new KeyvPostgres(postgresUri);
-	const key = faker.string.alphanumeric(10);
-	const value = faker.lorem.sentence();
-	await keyv.set(key, value);
-	t.expect(await keyv.get(key)).toBe(value);
-});
-
-it("test schema as non public", async (t) => {
-	const keyv1 = new KeyvPostgres({
-		uri: "postgresql://postgres:postgres@localhost:5432/keyv_test",
-		schema: "keyvtest1",
-	});
-	const keyv2 = new KeyvPostgres({
-		uri: "postgresql://postgres:postgres@localhost:5432/keyv_test",
-		schema: "keyvtest2",
-	});
-	const key1 = faker.string.alphanumeric(10);
-	const value1 = faker.lorem.sentence();
-	const key2 = faker.string.alphanumeric(10);
-	const value2 = faker.lorem.sentence();
-	await keyv1.set(key1, value1);
-	await keyv2.set(key2, value2);
-	t.expect(await keyv1.get(key1)).toBe(value1);
-	t.expect(await keyv2.get(key2)).toBe(value2);
-});
-
-it("iterator with default namespace", async (t) => {
-	const keyv = new KeyvPostgres({ uri: postgresUri });
-	const key1 = faker.string.alphanumeric(10);
-	const value1 = faker.lorem.sentence();
-	const key2 = faker.string.alphanumeric(10);
-	const value2 = faker.lorem.sentence();
-	const key3 = faker.string.alphanumeric(10);
-	const value3 = faker.lorem.sentence();
-	await keyv.set(key1, value1);
-	await keyv.set(key2, value2);
-	await keyv.set(key3, value3);
-
-	const keys: string[] = [];
-	const values: string[] = [];
-	for await (const [key, value] of keyv.iterator()) {
-		keys.push(key);
-		values.push(value as string);
-	}
-
-	t.expect(keys).toContain(key1);
-	t.expect(keys).toContain(key2);
-	t.expect(keys).toContain(key3);
-	t.expect(values).toContain(value1);
-	t.expect(values).toContain(value2);
-	t.expect(values).toContain(value3);
-});
-
-it(".clear() with undefined namespace", async (t) => {
-	const keyv = store();
-	t.expect(await keyv.clear()).toBeUndefined();
-});
-
-it("close connection successfully", async (t) => {
-	const keyv = store();
-	const key = faker.string.alphanumeric(10);
-	t.expect(await keyv.get(key)).toBeUndefined();
-	await keyv.disconnect();
-	try {
-		await keyv.get(key);
-		t.expect.fail();
-	} catch {
-		t.expect(true).toBeTruthy();
-	}
-});
-
-it("create two instances and make sure they do not conflict", async (t) => {
-	const postgresUri = "postgresql://postgres:postgres@localhost:5432/keyv_test";
-	const postgresA = new KeyvPostgres({ uri: postgresUri });
-	const postgresB = new KeyvPostgres({ uri: postgresUri });
-	const keyvA = new Keyv({
-		store: postgresA,
-		namespace: "namespace-a",
-	});
-	const keyvB = new Keyv({
-		store: postgresB,
-		namespace: "namespace-b",
+describe("constructor", () => {
+	test("sets default property values", () => {
+		const keyv = new KeyvPostgres();
+		expect(keyv.uri).toBe("postgresql://localhost:5432");
+		expect(keyv.table).toBe("keyv");
+		expect(keyv.keyLength).toBe(255);
+		expect(keyv.namespaceLength).toBe(255);
+		expect(keyv.schema).toBe("public");
+		expect(keyv.iterationLimit).toBe(10);
+		expect(keyv.useUnloggedTable).toBe(false);
+		expect(keyv.clearExpiredInterval).toBe(0);
+		expect(keyv.ssl).toBeUndefined();
+		expect(keyv.namespace).toBeUndefined();
 	});
 
-	const key = faker.string.alphanumeric(10);
-	const valueA = faker.lorem.sentence();
-	const valueB = faker.lorem.sentence();
-
-	t.expect(await keyvA.set(key, valueA)).toBe(true);
-	t.expect(await keyvA.get(key)).toBe(valueA);
-	t.expect(await keyvB.set(key, valueB)).toBe(true);
-	t.expect(await keyvB.get(key)).toBe(valueB);
-});
-
-it("helper to create Keyv instance with postgres", async (t) => {
-	const keyv = createKeyv({ uri: postgresUri });
-	const key = faker.string.alphanumeric(10);
-	const value = faker.lorem.sentence();
-	t.expect(await keyv.set(key, value)).toBe(true);
-	t.expect(await keyv.get(key)).toBe(value);
-});
-
-it("test unlogged table", async (t) => {
-	const keyv = createKeyv({ uri: postgresUri, useUnloggedTable: true });
-	const key = faker.string.alphanumeric(10);
-	const value = faker.lorem.sentence();
-	t.expect(await keyv.set(key, value)).toBe(true);
-	t.expect(await keyv.get(key)).toBe(value);
-});
-
-it(".setMany support", async (t) => {
-	const keyv = new KeyvPostgres(postgresUri);
-	const key1 = faker.string.alphanumeric(10);
-	const value1 = faker.lorem.sentence();
-	const key2 = faker.string.alphanumeric(10);
-	const value2 = faker.lorem.sentence();
-	const key3 = faker.string.alphanumeric(10);
-	const value3 = faker.lorem.sentence();
-	await keyv.set(key1, value1);
-	await keyv.setMany([
-		{ key: key1, value: value1 },
-		{ key: key2, value: value2 },
-		{ key: key3, value: value3 },
-	]);
-	t.expect(await keyv.getMany([key1, key2, key3])).toStrictEqual([value1, value2, value3]);
-});
-
-it(".hasMany() returns correct booleans for existing and non-existing keys", async (t) => {
-	const keyv = new KeyvPostgres(postgresUri);
-	const key1 = faker.string.alphanumeric(10);
-	const value1 = faker.lorem.sentence();
-	const key2 = faker.string.alphanumeric(10);
-	const value2 = faker.lorem.sentence();
-	const key3 = faker.string.alphanumeric(10);
-	await keyv.set(key1, value1);
-	await keyv.set(key2, value2);
-	const result = await keyv.hasMany([key1, key2, key3]);
-	t.expect(result).toStrictEqual([true, true, false]);
-});
-
-it(".hasMany() with all non-existent keys returns all false", async (t) => {
-	const keyv = new KeyvPostgres(postgresUri);
-	const result = await keyv.hasMany(["nonexistent1", "nonexistent2", "nonexistent3"]);
-	t.expect(result).toStrictEqual([false, false, false]);
-});
-
-it("should have correct default property values", (t) => {
-	const keyv = new KeyvPostgres();
-	t.expect(keyv.uri).toBe("postgresql://localhost:5432");
-	t.expect(keyv.table).toBe("keyv");
-	t.expect(keyv.keyLength).toBe(255);
-	t.expect(keyv.namespaceLength).toBe(255);
-	t.expect(keyv.schema).toBe("public");
-	t.expect(keyv.iterationLimit).toBe(10);
-	t.expect(keyv.useUnloggedTable).toBe(false);
-	t.expect(keyv.ssl).toBeUndefined();
-	t.expect(keyv.namespace).toBeUndefined();
-});
-
-it("should set properties from constructor options", (t) => {
-	const keyv = new KeyvPostgres({
-		uri: postgresUri,
-		table: "custom_table",
-		keyLength: 512,
-		namespaceLength: 512,
-		schema: "custom_schema",
-		iterationLimit: 50,
-		useUnloggedTable: true,
-		ssl: { rejectUnauthorized: false },
-	});
-	t.expect(keyv.uri).toBe(postgresUri);
-	t.expect(keyv.table).toBe("custom_table");
-	t.expect(keyv.keyLength).toBe(512);
-	t.expect(keyv.namespaceLength).toBe(512);
-	t.expect(keyv.schema).toBe("custom_schema");
-	t.expect(keyv.iterationLimit).toBe(50);
-	t.expect(keyv.useUnloggedTable).toBe(true);
-	t.expect(keyv.ssl).toEqual({ rejectUnauthorized: false });
-});
-
-it("should set uri when string is passed to constructor", (t) => {
-	const keyv = new KeyvPostgres(postgresUri);
-	t.expect(keyv.uri).toBe(postgresUri);
-	t.expect(keyv.table).toBe("keyv");
-	t.expect(keyv.schema).toBe("public");
-});
-
-it("should be able to get and set individual properties", (t) => {
-	const keyv = new KeyvPostgres({ uri: postgresUri });
-	keyv.table = "new_table";
-	t.expect(keyv.table).toBe("new_table");
-	keyv.schema = "new_schema";
-	t.expect(keyv.schema).toBe("new_schema");
-	keyv.keyLength = 512;
-	t.expect(keyv.keyLength).toBe(512);
-	keyv.namespaceLength = 512;
-	t.expect(keyv.namespaceLength).toBe(512);
-	keyv.iterationLimit = 25;
-	t.expect(keyv.iterationLimit).toBe(25);
-	keyv.useUnloggedTable = true;
-	t.expect(keyv.useUnloggedTable).toBe(true);
-	keyv.ssl = { rejectUnauthorized: false };
-	t.expect(keyv.ssl).toEqual({ rejectUnauthorized: false });
-	keyv.uri = "postgresql://localhost:5433";
-	t.expect(keyv.uri).toBe("postgresql://localhost:5433");
-	keyv.namespace = "test-ns";
-	t.expect(keyv.namespace).toBe("test-ns");
-	keyv.namespace = undefined;
-	t.expect(keyv.namespace).toBeUndefined();
-});
-
-it("property getters should return correct values", (t) => {
-	const keyv = new KeyvPostgres({
-		uri: postgresUri,
-		table: "opts_table",
-		iterationLimit: 99,
-	});
-	t.expect(keyv.table).toBe("opts_table");
-	t.expect(keyv.iterationLimit).toBe(99);
-	t.expect(keyv.uri).toBe(postgresUri);
-	t.expect(keyv.schema).toBe("public");
-	t.expect(keyv.keyLength).toBe(255);
-	t.expect(keyv.useUnloggedTable).toBe(false);
-});
-
-it("property setters should update individual properties", (t) => {
-	const keyv = new KeyvPostgres({ uri: postgresUri });
-	keyv.table = "updated_table";
-	keyv.schema = "updated_schema";
-	keyv.keyLength = 1024;
-	t.expect(keyv.table).toBe("updated_table");
-	t.expect(keyv.schema).toBe("updated_schema");
-	t.expect(keyv.keyLength).toBe(1024);
-	t.expect(keyv.uri).toBe(postgresUri);
-});
-
-it("emits error when connection fails", async (t) => {
-	const keyv = new KeyvPostgres({
-		uri: "postgresql://invalid:invalid@localhost:9999/nonexistent",
+	test("sets properties from constructor options", () => {
+		const keyv = new KeyvPostgres({
+			uri: postgresUri,
+			table: "custom_table",
+			keyLength: 512,
+			namespaceLength: 512,
+			schema: "custom_schema",
+			iterationLimit: 50,
+			useUnloggedTable: true,
+			clearExpiredInterval: 5000,
+			ssl: { rejectUnauthorized: false },
+		});
+		expect(keyv.uri).toBe(postgresUri);
+		expect(keyv.table).toBe("custom_table");
+		expect(keyv.keyLength).toBe(512);
+		expect(keyv.namespaceLength).toBe(512);
+		expect(keyv.schema).toBe("custom_schema");
+		expect(keyv.iterationLimit).toBe(50);
+		expect(keyv.useUnloggedTable).toBe(true);
+		expect(keyv.clearExpiredInterval).toBe(5000);
+		expect(keyv.ssl).toEqual({ rejectUnauthorized: false });
+		keyv.clearExpiredInterval = 0;
 	});
 
-	const error = await new Promise((resolve) => {
-		keyv.on("error", (error: unknown) => resolve(error));
+	test("sets the uri when a string is passed", () => {
+		const keyv = new KeyvPostgres(postgresUri);
+		expect(keyv.uri).toBe(postgresUri);
+		expect(keyv.table).toBe("keyv");
+		expect(keyv.schema).toBe("public");
 	});
 
-	t.expect(error).toBeInstanceOf(Error);
-});
-
-it("native namespace: same key in different namespaces stored independently", async (t) => {
-	const postgres1 = new KeyvPostgres({ uri: postgresUri });
-	postgres1.namespace = "ns1";
-	const postgres2 = new KeyvPostgres({ uri: postgresUri });
-	postgres2.namespace = "ns2";
-
-	await postgres1.set("ns1:testkey", "value1");
-	await postgres2.set("ns2:testkey", "value2");
-
-	t.expect(await postgres1.get("ns1:testkey")).toBe("value1");
-	t.expect(await postgres2.get("ns2:testkey")).toBe("value2");
-});
-
-it("native namespace: null namespace stores and retrieves correctly", async (t) => {
-	const postgres = new KeyvPostgres({ uri: postgresUri });
-	await postgres.set("testkey", "testvalue");
-	t.expect(await postgres.get("testkey")).toBe("testvalue");
-});
-
-it("native namespace: clear only clears the specified namespace", async (t) => {
-	const postgres1 = new KeyvPostgres({ uri: postgresUri });
-	postgres1.namespace = "ns1";
-	const postgres2 = new KeyvPostgres({ uri: postgresUri });
-	postgres2.namespace = "ns2";
-
-	await postgres1.set("ns1:key1", "value1");
-	await postgres2.set("ns2:key1", "value2");
-
-	await postgres1.clear();
-
-	t.expect(await postgres1.get("ns1:key1")).toBeUndefined();
-	t.expect(await postgres2.get("ns2:key1")).toBe("value2");
-});
-
-it("native namespace: iterator falls back to default limit when iterationLimit is 0", async (t) => {
-	const postgres = new KeyvPostgres({ uri: postgresUri, iterationLimit: 0 });
-	postgres.namespace = "nslimit";
-
-	await postgres.set("a", "v1");
-
-	const keys: string[] = [];
-	for await (const [key] of postgres.iterator()) {
-		keys.push(key);
-	}
-
-	t.expect(keys).toContain("a");
-});
-
-it("native namespace: iterator with null namespace paginates correctly", async (t) => {
-	const postgres = new KeyvPostgres({ uri: postgresUri, iterationLimit: 2 });
-
-	await postgres.set("a", "v1");
-	await postgres.set("b", "v2");
-	await postgres.set("c", "v3");
-
-	const keys: string[] = [];
-	for await (const [key] of postgres.iterator()) {
-		keys.push(key);
-	}
-
-	t.expect(keys.length).toBe(3);
-	t.expect(keys).toContain("a");
-	t.expect(keys).toContain("b");
-	t.expect(keys).toContain("c");
-});
-
-it("native namespace: iterator only returns keys from correct namespace", async (t) => {
-	const postgres1 = new KeyvPostgres({ uri: postgresUri });
-	postgres1.namespace = "ns1";
-	const postgres2 = new KeyvPostgres({ uri: postgresUri });
-	postgres2.namespace = "ns2";
-
-	await postgres1.set("key1", "val1");
-	await postgres1.set("key2", "val2");
-	await postgres2.set("key3", "val3");
-
-	const keys: string[] = [];
-	for await (const [key] of postgres1.iterator()) {
-		keys.push(key);
-	}
-
-	t.expect(keys.length).toBe(2);
-	t.expect(keys).toContain("key1");
-	t.expect(keys).toContain("key2");
-});
-
-it("set() extracts and stores expires in the expires column", async (t) => {
-	const keyv = new KeyvPostgres({ uri: postgresUri });
-	const expiresTimestamp = Date.now() + 60_000;
-	const serializedValue = JSON.stringify({
-		value: "test-value",
-		expires: expiresTimestamp,
+	test("updates properties via setters", () => {
+		const keyv = new KeyvPostgres({ uri: postgresUri });
+		keyv.uri = "postgresql://localhost:5433";
+		expect(keyv.uri).toBe("postgresql://localhost:5433");
+		keyv.table = "new_table";
+		expect(keyv.table).toBe("new_table");
+		keyv.schema = "new_schema";
+		expect(keyv.schema).toBe("new_schema");
+		keyv.keyLength = 512;
+		expect(keyv.keyLength).toBe(512);
+		keyv.namespaceLength = 1024;
+		expect(keyv.namespaceLength).toBe(1024);
+		keyv.iterationLimit = 25;
+		expect(keyv.iterationLimit).toBe(25);
+		keyv.useUnloggedTable = true;
+		expect(keyv.useUnloggedTable).toBe(true);
+		keyv.ssl = { rejectUnauthorized: false };
+		expect(keyv.ssl).toEqual({ rejectUnauthorized: false });
+		keyv.namespace = "test-ns";
+		expect(keyv.namespace).toBe("test-ns");
+		keyv.namespace = undefined;
+		expect(keyv.namespace).toBeUndefined();
 	});
-	await keyv.set("expires-test-key", serializedValue);
-	t.expect(await keyv.get("expires-test-key")).toBe(serializedValue);
 });
 
-it("set() stores null expires when value has no expires field", async (t) => {
-	const keyv = new KeyvPostgres({ uri: postgresUri });
-	const serializedValue = JSON.stringify({ value: "no-ttl-value" });
-	await keyv.set("no-expires-key", serializedValue);
-	t.expect(await keyv.get("no-expires-key")).toBe(serializedValue);
-});
-
-it("set() gracefully handles non-JSON string values", async (t) => {
-	const keyv = new KeyvPostgres({ uri: postgresUri });
-	await keyv.set("plain-text-key", "not-json-at-all");
-	t.expect(await keyv.get("plain-text-key")).toBe("not-json-at-all");
-});
-
-it("set() updates expires column on upsert", async (t) => {
-	const keyv = new KeyvPostgres({ uri: postgresUri });
-	const expires1 = Date.now() + 60_000;
-	const expires2 = Date.now() + 120_000;
-	await keyv.set("upsert-exp-key", JSON.stringify({ value: "v1", expires: expires1 }));
-	await keyv.set("upsert-exp-key", JSON.stringify({ value: "v2", expires: expires2 }));
-	t.expect(await keyv.get("upsert-exp-key")).toBe(
-		JSON.stringify({ value: "v2", expires: expires2 }),
-	);
-});
-
-it("setMany() extracts and stores expires for each entry", async (t) => {
-	const keyv = new KeyvPostgres({ uri: postgresUri });
-	const expires1 = Date.now() + 60_000;
-	const expires2 = Date.now() + 120_000;
-	await keyv.setMany([
-		{
-			key: "many-exp-1",
-			value: JSON.stringify({ value: "v1", expires: expires1 }),
-		},
-		{
-			key: "many-exp-2",
-			value: JSON.stringify({ value: "v2", expires: expires2 }),
-		},
-		{ key: "many-exp-3", value: JSON.stringify({ value: "v3" }) },
-	]);
-	t.expect(await keyv.get("many-exp-1")).toBe(JSON.stringify({ value: "v1", expires: expires1 }));
-	t.expect(await keyv.get("many-exp-2")).toBe(JSON.stringify({ value: "v2", expires: expires2 }));
-	t.expect(await keyv.get("many-exp-3")).toBe(JSON.stringify({ value: "v3" }));
-});
-
-it("expires column is populated when using Keyv core with TTL", async (t) => {
-	const keyv = new Keyv({
-		store: new KeyvPostgres({ uri: postgresUri }),
-		ttl: 60_000,
-	});
-	const key = faker.string.alphanumeric(10);
-	await keyv.set(key, "ttl-value");
-	t.expect(await keyv.get(key)).toBe("ttl-value");
-});
-
-it("set() handles object value with expires (serialization disabled)", async (t) => {
-	const keyv = new KeyvPostgres({ uri: postgresUri });
-	const expiresTimestamp = Date.now() + 60_000;
-	const objectValue = { value: "obj-test", expires: expiresTimestamp };
-	// biome-ignore lint/suspicious/noExplicitAny: testing non-string value path
-	await keyv.set("obj-expires-key", objectValue as any);
-	const result = await keyv.get("obj-expires-key");
-	t.expect(result).toBeDefined();
-});
-
-it("set() handles object value without expires", async (t) => {
-	const keyv = new KeyvPostgres({ uri: postgresUri });
-	const objectValue = { value: "no-exp-obj" };
-	// biome-ignore lint/suspicious/noExplicitAny: testing non-string value path
-	await keyv.set("obj-no-expires-key", objectValue as any);
-	const result = await keyv.get("obj-no-expires-key");
-	t.expect(result).toBeDefined();
-});
-
-it("set() handles null value for expires extraction", async (t) => {
-	const keyv = new KeyvPostgres({ uri: postgresUri });
-	// biome-ignore lint/suspicious/noExplicitAny: testing null value path
-	await keyv.set("null-val-key", null as any);
-	const result = await keyv.get("null-val-key");
-	t.expect(result).toBeNull();
-});
-
-it("set() handles numeric value for expires extraction", async (t) => {
-	const keyv = new KeyvPostgres({ uri: postgresUri });
-	// biome-ignore lint/suspicious/noExplicitAny: testing numeric value path
-	await keyv.set("num-val-key", 12345 as any);
-	const result = await keyv.get("num-val-key");
-	t.expect(result).toBe("12345");
-});
-
-it("clearExpired() removes expired entries and keeps valid ones", async (t) => {
-	const keyv = new KeyvPostgres({ uri: postgresUri });
-	const pastExpires = Date.now() - 60_000;
-	const futureExpires = Date.now() + 60_000;
-	await keyv.set("expired-key", JSON.stringify({ value: "old", expires: pastExpires }));
-	await keyv.set("valid-key", JSON.stringify({ value: "fresh", expires: futureExpires }));
-	await keyv.set("no-ttl-key", JSON.stringify({ value: "forever" }));
-
-	await keyv.clearExpired();
-
-	t.expect(await keyv.get("expired-key")).toBeUndefined();
-	t.expect(await keyv.get("valid-key")).toBe(
-		JSON.stringify({ value: "fresh", expires: futureExpires }),
-	);
-	t.expect(await keyv.get("no-ttl-key")).toBe(JSON.stringify({ value: "forever" }));
-});
-
-it("clearExpired() is a no-op when no entries are expired", async (t) => {
-	const keyv = new KeyvPostgres({ uri: postgresUri });
-	const futureExpires = Date.now() + 60_000;
-	await keyv.set("still-valid", JSON.stringify({ value: "ok", expires: futureExpires }));
-
-	await keyv.clearExpired();
-
-	t.expect(await keyv.get("still-valid")).toBe(
-		JSON.stringify({ value: "ok", expires: futureExpires }),
-	);
-});
-
-it("clearExpiredInterval defaults to 0 (disabled)", (t) => {
-	const keyv = new KeyvPostgres({ uri: postgresUri });
-	t.expect(keyv.clearExpiredInterval).toBe(0);
-});
-
-it("clearExpiredInterval can be set via constructor options", (t) => {
-	const keyv = new KeyvPostgres({
-		uri: postgresUri,
-		clearExpiredInterval: 5000,
-	});
-	t.expect(keyv.clearExpiredInterval).toBe(5000);
-	keyv.clearExpiredInterval = 0;
-});
-
-it("clearExpiredInterval getter and setter work", (t) => {
-	const keyv = new KeyvPostgres({ uri: postgresUri });
-	t.expect(keyv.clearExpiredInterval).toBe(0);
-	keyv.clearExpiredInterval = 3000;
-	t.expect(keyv.clearExpiredInterval).toBe(3000);
-	keyv.clearExpiredInterval = 0;
-});
-
-it("clearExpiredInterval is accessible via property getter", (t) => {
-	const keyv = new KeyvPostgres({
-		uri: postgresUri,
-		clearExpiredInterval: 10_000,
-	});
-	t.expect(keyv.clearExpiredInterval).toBe(10_000);
-	keyv.clearExpiredInterval = 0;
-});
-
-it("clearExpiredInterval automatically clears expired entries", async (t) => {
-	const keyv = new KeyvPostgres({
-		uri: postgresUri,
-		clearExpiredInterval: 100,
-	});
-	const pastExpires = Date.now() - 60_000;
-	const futureExpires = Date.now() + 60_000;
-	await keyv.set("interval-expired", JSON.stringify({ value: "old", expires: pastExpires }));
-	await keyv.set("interval-valid", JSON.stringify({ value: "fresh", expires: futureExpires }));
-
-	// Wait for the interval to fire
-	await new Promise((resolve) => {
-		setTimeout(resolve, 300);
+describe("get", () => {
+	test("returns undefined for a missing key", async () => {
+		const keyv = new KeyvPostgres({ uri: postgresUri });
+		expect(await keyv.get(faker.string.alphanumeric(10))).toBeUndefined();
 	});
 
-	t.expect(await keyv.get("interval-expired")).toBeUndefined();
-	t.expect(await keyv.get("interval-valid")).toBe(
-		JSON.stringify({ value: "fresh", expires: futureExpires }),
-	);
-	keyv.clearExpiredInterval = 0;
-});
-
-it("disconnect stops the clearExpiredInterval timer", async (t) => {
-	const keyv = new KeyvPostgres({
-		uri: postgresUri,
-		clearExpiredInterval: 100,
+	test("returns a previously set value", async () => {
+		const keyv = new KeyvPostgres({ uri: postgresUri });
+		const key = faker.string.alphanumeric(10);
+		const value = faker.lorem.sentence();
+		await keyv.set(key, value);
+		expect(await keyv.get(key)).toBe(value);
 	});
-	t.expect(keyv.clearExpiredInterval).toBe(100);
-	await keyv.disconnect();
-	// After disconnect, the timer should be stopped. We just verify no errors are thrown.
-	t.expect(keyv.clearExpiredInterval).toBe(100);
-});
 
-it("setMany returns false entries on query error", async (t) => {
-	const store = new KeyvPostgres({ uri: postgresUri });
-	let emittedError = false;
-	store.on("error", () => {
-		emittedError = true;
+	test("returns undefined (not null) for a key stored with a null value", async () => {
+		const keyv = new KeyvPostgres({ uri: postgresUri });
+		const key = faker.string.alphanumeric(10);
+		// biome-ignore lint/suspicious/noExplicitAny: testing null value path
+		await keyv.set(key, null as any);
+		const result = await keyv.get(key);
+		expect(result).toBeUndefined();
+		expect(result).not.toBeNull();
 	});
-	// Close the connection to force an error
-	await store.disconnect();
-	const result = await store.setMany([
-		{ key: "key1", value: "val1" },
-		{ key: "key2", value: "val2" },
-	]);
-	t.expect(result).toEqual([false, false]);
-	t.expect(emittedError).toBe(true);
-});
 
-it("has() returns true for an existing key", async (t) => {
-	const keyv = new KeyvPostgres({ uri: postgresUri });
-	const key = faker.string.alphanumeric(10);
-	await keyv.set(key, "value");
-	t.expect(await keyv.has(key)).toBe(true);
-});
-
-it("has() returns false for a non-existing key", async (t) => {
-	const keyv = new KeyvPostgres({ uri: postgresUri });
-	t.expect(await keyv.has("nonexistent-key")).toBe(false);
-});
-
-it("has() returns correct result with namespace", async (t) => {
-	const keyv1 = new KeyvPostgres({ uri: postgresUri });
-	keyv1.namespace = "has-ns1";
-	const keyv2 = new KeyvPostgres({ uri: postgresUri });
-	keyv2.namespace = "has-ns2";
-
-	const key = faker.string.alphanumeric(10);
-	await keyv1.set(key, "value1");
-
-	t.expect(await keyv1.has(key)).toBe(true);
-	t.expect(await keyv2.has(key)).toBe(false);
-});
-
-it("has() returns true after set and false after delete", async (t) => {
-	const keyv = new KeyvPostgres({ uri: postgresUri });
-	const key = faker.string.alphanumeric(10);
-	await keyv.set(key, "value");
-	t.expect(await keyv.has(key)).toBe(true);
-	await keyv.delete(key);
-	t.expect(await keyv.has(key)).toBe(false);
-});
-
-it("has() returns false after clear", async (t) => {
-	const keyv = new KeyvPostgres({ uri: postgresUri });
-	const key = faker.string.alphanumeric(10);
-	await keyv.set(key, "value");
-	t.expect(await keyv.has(key)).toBe(true);
-	await keyv.clear();
-	t.expect(await keyv.has(key)).toBe(false);
-});
-
-it("has returns false and deletes expired key", async (t) => {
-	const keyv = new KeyvPostgres({ uri: postgresUri });
-	const key = faker.string.alphanumeric(10);
-	const expiredValue = JSON.stringify({ value: "old", expires: Date.now() - 1000 });
-	await keyv.set(key, expiredValue);
-	t.expect(await keyv.has(key)).toBe(false);
-	// Verify the key was deleted
-	t.expect(await keyv.get(key)).toBeUndefined();
-});
-
-it("hasMany returns false for expired keys and deletes them", async (t) => {
-	const keyv = new KeyvPostgres({ uri: postgresUri });
-	const expiredKey1 = faker.string.alphanumeric(10);
-	const expiredKey2 = faker.string.alphanumeric(10);
-	const validKey = faker.string.alphanumeric(10);
-	const expiredValue = JSON.stringify({ value: "old", expires: Date.now() - 1000 });
-	const validValue = JSON.stringify({ value: "fresh", expires: Date.now() + 60_000 });
-	await keyv.set(expiredKey1, expiredValue);
-	await keyv.set(expiredKey2, expiredValue);
-	await keyv.set(validKey, validValue);
-	const result = await keyv.hasMany([expiredKey1, expiredKey2, validKey]);
-	t.expect(result).toStrictEqual([false, false, true]);
-	// Verify expired keys were deleted
-	t.expect(await keyv.get(expiredKey1)).toBeUndefined();
-	t.expect(await keyv.get(expiredKey2)).toBeUndefined();
-});
-
-it("setting clearExpiredInterval to 0 stops an active timer", (t) => {
-	const keyv = new KeyvPostgres({
-		uri: postgresUri,
-		clearExpiredInterval: 1000,
+	test("stores a numeric value as its string representation", async () => {
+		const keyv = new KeyvPostgres({ uri: postgresUri });
+		const key = faker.string.alphanumeric(10);
+		// biome-ignore lint/suspicious/noExplicitAny: testing numeric value path
+		await keyv.set(key, 12_345 as any);
+		expect(await keyv.get(key)).toBe("12345");
 	});
-	t.expect(keyv.clearExpiredInterval).toBe(1000);
-	keyv.clearExpiredInterval = 0;
-	t.expect(keyv.clearExpiredInterval).toBe(0);
+
+	test("handles object values with an expires field without serialization", async () => {
+		const keyv = new KeyvPostgres({ uri: postgresUri });
+		const key = faker.string.alphanumeric(10);
+		const objectValue = { value: faker.lorem.word(), expires: Date.now() + 60_000 };
+		// biome-ignore lint/suspicious/noExplicitAny: testing non-string value path
+		await keyv.set(key, objectValue as any);
+		expect(await keyv.get(key)).toBeDefined();
+	});
+
+	test("handles object values without an expires field", async () => {
+		const keyv = new KeyvPostgres({ uri: postgresUri });
+		const key = faker.string.alphanumeric(10);
+		const objectValue = { value: faker.lorem.word() };
+		// biome-ignore lint/suspicious/noExplicitAny: testing non-string value path
+		await keyv.set(key, objectValue as any);
+		expect(await keyv.get(key)).toBeDefined();
+	});
+});
+
+describe("getMany", () => {
+	test("returns values in order with undefined for missing keys", async () => {
+		const keyv = new KeyvPostgres({ uri: postgresUri });
+		const key1 = faker.string.alphanumeric(10);
+		const value1 = faker.lorem.sentence();
+		const key2 = faker.string.alphanumeric(10);
+		const value2 = faker.lorem.sentence();
+		await keyv.set(key1, value1);
+		await keyv.set(key2, value2);
+		expect(await keyv.getMany([key1, faker.string.alphanumeric(10), key2])).toStrictEqual([
+			value1,
+			undefined,
+			value2,
+		]);
+	});
+
+	test("returns undefined (not null) for keys stored with a null value", async () => {
+		const keyv = new KeyvPostgres({ uri: postgresUri });
+		const key = faker.string.alphanumeric(10);
+		// biome-ignore lint/suspicious/noExplicitAny: testing null value path
+		await keyv.set(key, null as any);
+		const results = await keyv.getMany([key, faker.string.alphanumeric(10)]);
+		expect(results).toEqual([undefined, undefined]);
+		expect(results[0]).not.toBeNull();
+	});
+});
+
+describe("set and setMany", () => {
+	test("stores and retrieves when constructed with a uri string", async () => {
+		const keyv = new KeyvPostgres(postgresUri);
+		const key = faker.string.alphanumeric(10);
+		const value = faker.lorem.sentence();
+		await keyv.set(key, value);
+		expect(await keyv.get(key)).toBe(value);
+	});
+
+	test("setMany inserts multiple entries", async () => {
+		const keyv = new KeyvPostgres(postgresUri);
+		const key1 = faker.string.alphanumeric(10);
+		const value1 = faker.lorem.sentence();
+		const key2 = faker.string.alphanumeric(10);
+		const value2 = faker.lorem.sentence();
+		const key3 = faker.string.alphanumeric(10);
+		const value3 = faker.lorem.sentence();
+		await keyv.setMany([
+			{ key: key1, value: value1 },
+			{ key: key2, value: value2 },
+			{ key: key3, value: value3 },
+		]);
+		expect(await keyv.getMany([key1, key2, key3])).toStrictEqual([value1, value2, value3]);
+	});
+
+	test("setMany updates existing keys", async () => {
+		const keyv = new KeyvPostgres(postgresUri);
+		const key = faker.string.alphanumeric(10);
+		await keyv.set(key, "original");
+		await keyv.setMany([{ key, value: "updated" }]);
+		expect(await keyv.get(key)).toBe("updated");
+	});
+
+	test("gracefully handles non-JSON string values", async () => {
+		const keyv = new KeyvPostgres({ uri: postgresUri });
+		const key = faker.string.alphanumeric(10);
+		await keyv.set(key, "not-json-at-all");
+		expect(await keyv.get(key)).toBe("not-json-at-all");
+	});
+
+	test("setMany emits an error and returns false entries on query error", async () => {
+		const keyv = new KeyvPostgres({ uri: postgresUri });
+		let emittedError = false;
+		keyv.on("error", () => {
+			emittedError = true;
+		});
+		// Close the connection to force an error.
+		await keyv.disconnect();
+		const result = await keyv.setMany([
+			{ key: "key1", value: "val1" },
+			{ key: "key2", value: "val2" },
+		]);
+		expect(result).toEqual([false, false]);
+		expect(emittedError).toBe(true);
+	});
+});
+
+describe("has and hasMany", () => {
+	test("has returns true for an existing key", async () => {
+		const keyv = new KeyvPostgres({ uri: postgresUri });
+		const key = faker.string.alphanumeric(10);
+		await keyv.set(key, faker.lorem.word());
+		expect(await keyv.has(key)).toBe(true);
+	});
+
+	test("has returns false for a non-existing key", async () => {
+		const keyv = new KeyvPostgres({ uri: postgresUri });
+		expect(await keyv.has(faker.string.alphanumeric(10))).toBe(false);
+	});
+
+	test("has returns true after set and false after delete", async () => {
+		const keyv = new KeyvPostgres({ uri: postgresUri });
+		const key = faker.string.alphanumeric(10);
+		await keyv.set(key, faker.lorem.word());
+		expect(await keyv.has(key)).toBe(true);
+		await keyv.delete(key);
+		expect(await keyv.has(key)).toBe(false);
+	});
+
+	test("has returns false after clear", async () => {
+		const keyv = new KeyvPostgres({ uri: postgresUri });
+		const key = faker.string.alphanumeric(10);
+		await keyv.set(key, faker.lorem.word());
+		expect(await keyv.has(key)).toBe(true);
+		await keyv.clear();
+		expect(await keyv.has(key)).toBe(false);
+	});
+
+	test("has returns false and deletes an expired key", async () => {
+		const keyv = new KeyvPostgres({ uri: postgresUri });
+		const key = faker.string.alphanumeric(10);
+		const expiredValue = JSON.stringify({ value: "old", expires: Date.now() - 1000 });
+		await keyv.set(key, expiredValue);
+		expect(await keyv.has(key)).toBe(false);
+		// The expired key should have been deleted.
+		expect(await keyv.get(key)).toBeUndefined();
+	});
+
+	test("hasMany returns correct booleans for existing and non-existing keys", async () => {
+		const keyv = new KeyvPostgres(postgresUri);
+		const key1 = faker.string.alphanumeric(10);
+		const key2 = faker.string.alphanumeric(10);
+		const key3 = faker.string.alphanumeric(10);
+		await keyv.set(key1, faker.lorem.word());
+		await keyv.set(key2, faker.lorem.word());
+		expect(await keyv.hasMany([key1, key2, key3])).toStrictEqual([true, true, false]);
+	});
+
+	test("hasMany with all non-existent keys returns all false", async () => {
+		const keyv = new KeyvPostgres(postgresUri);
+		const result = await keyv.hasMany([
+			faker.string.alphanumeric(10),
+			faker.string.alphanumeric(10),
+			faker.string.alphanumeric(10),
+		]);
+		expect(result).toStrictEqual([false, false, false]);
+	});
+
+	test("hasMany returns false for expired keys and deletes them", async () => {
+		const keyv = new KeyvPostgres({ uri: postgresUri });
+		const expiredKey1 = faker.string.alphanumeric(10);
+		const expiredKey2 = faker.string.alphanumeric(10);
+		const validKey = faker.string.alphanumeric(10);
+		const expiredValue = JSON.stringify({ value: "old", expires: Date.now() - 1000 });
+		const validValue = JSON.stringify({ value: "fresh", expires: Date.now() + 60_000 });
+		await keyv.set(expiredKey1, expiredValue);
+		await keyv.set(expiredKey2, expiredValue);
+		await keyv.set(validKey, validValue);
+		const result = await keyv.hasMany([expiredKey1, expiredKey2, validKey]);
+		expect(result).toStrictEqual([false, false, true]);
+		// The expired keys should have been deleted.
+		expect(await keyv.get(expiredKey1)).toBeUndefined();
+		expect(await keyv.get(expiredKey2)).toBeUndefined();
+	});
+});
+
+describe("clear", () => {
+	test("returns undefined with the default namespace", async () => {
+		const keyv = store();
+		expect(await keyv.clear()).toBeUndefined();
+	});
+});
+
+describe("clearExpired", () => {
+	test("removes expired entries and keeps valid ones", async () => {
+		const keyv = new KeyvPostgres({ uri: postgresUri });
+		const expiredKey = faker.string.alphanumeric(10);
+		const validKey = faker.string.alphanumeric(10);
+		const noExpiryKey = faker.string.alphanumeric(10);
+		const pastExpires = Date.now() - 60_000;
+		const futureExpires = Date.now() + 60_000;
+		const validValue = JSON.stringify({ value: "fresh", expires: futureExpires });
+		const noExpiryValue = JSON.stringify({ value: "forever" });
+		await keyv.set(expiredKey, JSON.stringify({ value: "old", expires: pastExpires }));
+		await keyv.set(validKey, validValue);
+		await keyv.set(noExpiryKey, noExpiryValue);
+
+		await keyv.clearExpired();
+
+		expect(await keyv.get(expiredKey)).toBeUndefined();
+		expect(await keyv.get(validKey)).toBe(validValue);
+		expect(await keyv.get(noExpiryKey)).toBe(noExpiryValue);
+	});
+
+	test("is a no-op when no entries are expired", async () => {
+		const keyv = new KeyvPostgres({ uri: postgresUri });
+		const key = faker.string.alphanumeric(10);
+		const value = JSON.stringify({ value: "ok", expires: Date.now() + 60_000 });
+		await keyv.set(key, value);
+
+		await keyv.clearExpired();
+
+		expect(await keyv.get(key)).toBe(value);
+	});
+});
+
+describe("expires column", () => {
+	test("set extracts and stores expires from the value", async () => {
+		const keyv = new KeyvPostgres({ uri: postgresUri });
+		const key = faker.string.alphanumeric(10);
+		const value = JSON.stringify({ value: "test-value", expires: Date.now() + 60_000 });
+		await keyv.set(key, value);
+		expect(await keyv.get(key)).toBe(value);
+	});
+
+	test("set stores null expires when the value has no expires field", async () => {
+		const keyv = new KeyvPostgres({ uri: postgresUri });
+		const key = faker.string.alphanumeric(10);
+		const value = JSON.stringify({ value: "no-ttl-value" });
+		await keyv.set(key, value);
+		expect(await keyv.get(key)).toBe(value);
+	});
+
+	test("set updates the expires column on upsert", async () => {
+		const keyv = new KeyvPostgres({ uri: postgresUri });
+		const key = faker.string.alphanumeric(10);
+		const value2 = JSON.stringify({ value: "v2", expires: Date.now() + 120_000 });
+		await keyv.set(key, JSON.stringify({ value: "v1", expires: Date.now() + 60_000 }));
+		await keyv.set(key, value2);
+		expect(await keyv.get(key)).toBe(value2);
+	});
+
+	test("setMany extracts and stores expires for each entry", async () => {
+		const keyv = new KeyvPostgres({ uri: postgresUri });
+		const key1 = faker.string.alphanumeric(10);
+		const key2 = faker.string.alphanumeric(10);
+		const key3 = faker.string.alphanumeric(10);
+		const value1 = JSON.stringify({ value: "v1", expires: Date.now() + 60_000 });
+		const value2 = JSON.stringify({ value: "v2", expires: Date.now() + 120_000 });
+		const value3 = JSON.stringify({ value: "v3" });
+		await keyv.setMany([
+			{ key: key1, value: value1 },
+			{ key: key2, value: value2 },
+			{ key: key3, value: value3 },
+		]);
+		expect(await keyv.get(key1)).toBe(value1);
+		expect(await keyv.get(key2)).toBe(value2);
+		expect(await keyv.get(key3)).toBe(value3);
+	});
+
+	test("is populated when using Keyv core with a TTL", async () => {
+		const keyv = new Keyv({ store: new KeyvPostgres({ uri: postgresUri }), ttl: 60_000 });
+		const key = faker.string.alphanumeric(10);
+		const value = faker.lorem.sentence();
+		await keyv.set(key, value);
+		expect(await keyv.get(key)).toBe(value);
+	});
+});
+
+describe("clearExpiredInterval", () => {
+	test("defaults to 0 (disabled)", () => {
+		const keyv = new KeyvPostgres({ uri: postgresUri });
+		expect(keyv.clearExpiredInterval).toBe(0);
+	});
+
+	test("can be set via constructor options", () => {
+		const keyv = new KeyvPostgres({ uri: postgresUri, clearExpiredInterval: 5000 });
+		expect(keyv.clearExpiredInterval).toBe(5000);
+		keyv.clearExpiredInterval = 0;
+	});
+
+	test("getter and setter work", () => {
+		const keyv = new KeyvPostgres({ uri: postgresUri });
+		expect(keyv.clearExpiredInterval).toBe(0);
+		keyv.clearExpiredInterval = 3000;
+		expect(keyv.clearExpiredInterval).toBe(3000);
+		keyv.clearExpiredInterval = 0;
+	});
+
+	test("setting to 0 stops an active timer", () => {
+		const keyv = new KeyvPostgres({ uri: postgresUri, clearExpiredInterval: 1000 });
+		expect(keyv.clearExpiredInterval).toBe(1000);
+		keyv.clearExpiredInterval = 0;
+		expect(keyv.clearExpiredInterval).toBe(0);
+	});
+
+	test("automatically clears expired entries on the configured schedule", async () => {
+		const keyv = new KeyvPostgres({ uri: postgresUri, clearExpiredInterval: 100 });
+		const expiredKey = faker.string.alphanumeric(10);
+		const validKey = faker.string.alphanumeric(10);
+		const validValue = JSON.stringify({ value: "fresh", expires: Date.now() + 60_000 });
+		await keyv.set(expiredKey, JSON.stringify({ value: "old", expires: Date.now() - 60_000 }));
+		await keyv.set(validKey, validValue);
+
+		// Wait for the interval to fire.
+		await new Promise((resolve) => {
+			setTimeout(resolve, 300);
+		});
+
+		expect(await keyv.get(expiredKey)).toBeUndefined();
+		expect(await keyv.get(validKey)).toBe(validValue);
+		keyv.clearExpiredInterval = 0;
+	});
+
+	test("is stopped on disconnect", async () => {
+		const keyv = new KeyvPostgres({ uri: postgresUri, clearExpiredInterval: 100 });
+		expect(keyv.clearExpiredInterval).toBe(100);
+		// After disconnect the timer is stopped; verify no errors are thrown.
+		await keyv.disconnect();
+		expect(keyv.clearExpiredInterval).toBe(100);
+	});
+});
+
+describe("namespace", () => {
+	test("stores the same key independently across namespaces", async () => {
+		const ns1 = faker.string.alphanumeric(8);
+		const ns2 = faker.string.alphanumeric(8);
+		const postgres1 = new KeyvPostgres({ uri: postgresUri });
+		postgres1.namespace = ns1;
+		const postgres2 = new KeyvPostgres({ uri: postgresUri });
+		postgres2.namespace = ns2;
+
+		const key = faker.string.alphanumeric(10);
+		const val1 = faker.lorem.sentence();
+		const val2 = faker.lorem.sentence();
+		await postgres1.set(`${ns1}:${key}`, val1);
+		await postgres2.set(`${ns2}:${key}`, val2);
+
+		expect(await postgres1.get(`${ns1}:${key}`)).toBe(val1);
+		expect(await postgres2.get(`${ns2}:${key}`)).toBe(val2);
+	});
+
+	test("stores and retrieves with the default namespace", async () => {
+		const keyv = new KeyvPostgres({ uri: postgresUri });
+		const key = faker.string.alphanumeric(10);
+		const value = faker.lorem.sentence();
+		await keyv.set(key, value);
+		expect(await keyv.get(key)).toBe(value);
+	});
+
+	test("clear only affects the configured namespace", async () => {
+		const ns1 = faker.string.alphanumeric(8);
+		const ns2 = faker.string.alphanumeric(8);
+		const postgres1 = new KeyvPostgres({ uri: postgresUri });
+		postgres1.namespace = ns1;
+		const postgres2 = new KeyvPostgres({ uri: postgresUri });
+		postgres2.namespace = ns2;
+
+		const key = faker.string.alphanumeric(10);
+		const val2 = faker.lorem.sentence();
+		await postgres1.set(`${ns1}:${key}`, faker.lorem.sentence());
+		await postgres2.set(`${ns2}:${key}`, val2);
+
+		await postgres1.clear();
+
+		expect(await postgres1.get(`${ns1}:${key}`)).toBeUndefined();
+		expect(await postgres2.get(`${ns2}:${key}`)).toBe(val2);
+	});
+
+	test("delete is scoped to the namespace", async () => {
+		const ns1 = faker.string.alphanumeric(8);
+		const ns2 = faker.string.alphanumeric(8);
+		const postgres1 = new KeyvPostgres({ uri: postgresUri });
+		postgres1.namespace = ns1;
+		const postgres2 = new KeyvPostgres({ uri: postgresUri });
+		postgres2.namespace = ns2;
+
+		const key = faker.string.alphanumeric(10);
+		const val2 = faker.lorem.sentence();
+		await postgres1.set(`${ns1}:${key}`, faker.lorem.sentence());
+		await postgres2.set(`${ns2}:${key}`, val2);
+
+		expect(await postgres1.delete(`${ns1}:${key}`)).toBe(true);
+		expect(await postgres1.get(`${ns1}:${key}`)).toBeUndefined();
+		expect(await postgres2.get(`${ns2}:${key}`)).toBe(val2);
+	});
+
+	test("deleteMany is scoped to the namespace", async () => {
+		const ns1 = faker.string.alphanumeric(8);
+		const ns2 = faker.string.alphanumeric(8);
+		const postgres1 = new KeyvPostgres({ uri: postgresUri });
+		postgres1.namespace = ns1;
+		const postgres2 = new KeyvPostgres({ uri: postgresUri });
+		postgres2.namespace = ns2;
+
+		const key = faker.string.alphanumeric(10);
+		const val2 = faker.lorem.sentence();
+		await postgres1.set(`${ns1}:${key}`, faker.lorem.sentence());
+		await postgres2.set(`${ns2}:${key}`, val2);
+
+		expect(await postgres1.deleteMany([`${ns1}:${key}`])).toEqual([true]);
+		expect(await postgres1.get(`${ns1}:${key}`)).toBeUndefined();
+		expect(await postgres2.get(`${ns2}:${key}`)).toBe(val2);
+	});
+
+	test("has is scoped to the namespace", async () => {
+		const ns1 = faker.string.alphanumeric(8);
+		const ns2 = faker.string.alphanumeric(8);
+		const postgres1 = new KeyvPostgres({ uri: postgresUri });
+		postgres1.namespace = ns1;
+		const postgres2 = new KeyvPostgres({ uri: postgresUri });
+		postgres2.namespace = ns2;
+
+		const key = faker.string.alphanumeric(10);
+		await postgres1.set(`${ns1}:${key}`, faker.lorem.sentence());
+
+		expect(await postgres1.has(`${ns1}:${key}`)).toBe(true);
+		// ns2 should not see ns1's key.
+		expect(await postgres2.has(`${ns2}:${key}`)).toBe(false);
+	});
+
+	test("hasMany is scoped to the namespace", async () => {
+		const ns1 = faker.string.alphanumeric(8);
+		const ns2 = faker.string.alphanumeric(8);
+		const postgres1 = new KeyvPostgres({ uri: postgresUri });
+		postgres1.namespace = ns1;
+		const postgres2 = new KeyvPostgres({ uri: postgresUri });
+		postgres2.namespace = ns2;
+
+		const key = faker.string.alphanumeric(10);
+		await postgres1.set(`${ns1}:${key}`, faker.lorem.sentence());
+		await postgres2.set(`${ns2}:${key}`, faker.lorem.sentence());
+
+		expect(await postgres1.hasMany([`${ns1}:${key}`])).toEqual([true]);
+		expect(await postgres1.hasMany([`${ns2}:${key}`])).toEqual([false]);
+	});
+
+	test("getMany is scoped to the namespace", async () => {
+		const ns1 = faker.string.alphanumeric(8);
+		const ns2 = faker.string.alphanumeric(8);
+		const postgres1 = new KeyvPostgres({ uri: postgresUri });
+		postgres1.namespace = ns1;
+		const postgres2 = new KeyvPostgres({ uri: postgresUri });
+		postgres2.namespace = ns2;
+
+		const key = faker.string.alphanumeric(10);
+		const val1 = faker.lorem.sentence();
+		await postgres1.set(`${ns1}:${key}`, val1);
+		await postgres2.set(`${ns2}:${key}`, faker.lorem.sentence());
+
+		expect(await postgres1.getMany([`${ns1}:${key}`])).toEqual([val1]);
+		expect(await postgres1.getMany([`${ns2}:${key}`])).toEqual([undefined]);
+	});
+
+	test("setMany is scoped to the namespace", async () => {
+		const ns1 = faker.string.alphanumeric(8);
+		const ns2 = faker.string.alphanumeric(8);
+		const postgres1 = new KeyvPostgres({ uri: postgresUri });
+		postgres1.namespace = ns1;
+		const postgres2 = new KeyvPostgres({ uri: postgresUri });
+		postgres2.namespace = ns2;
+
+		const key1 = faker.string.alphanumeric(10);
+		const key2 = faker.string.alphanumeric(10);
+		const val1 = faker.lorem.sentence();
+		const val2 = faker.lorem.sentence();
+		await postgres1.setMany([
+			{ key: `${ns1}:${key1}`, value: val1 },
+			{ key: `${ns1}:${key2}`, value: val2 },
+		]);
+
+		expect(await postgres1.get(`${ns1}:${key1}`)).toBe(val1);
+		expect(await postgres1.get(`${ns1}:${key2}`)).toBe(val2);
+		// ns2 should not see ns1's keys.
+		expect(await postgres2.get(`${ns2}:${key1}`)).toBeUndefined();
+	});
+
+	test("two Keyv instances with different namespaces do not conflict", async () => {
+		const nsA = faker.string.alphanumeric(8);
+		const nsB = faker.string.alphanumeric(8);
+		const keyvA = new Keyv({ store: new KeyvPostgres({ uri: postgresUri }), namespace: nsA });
+		const keyvB = new Keyv({ store: new KeyvPostgres({ uri: postgresUri }), namespace: nsB });
+
+		const key = faker.string.alphanumeric(10);
+		const valA = faker.lorem.sentence();
+		const valB = faker.lorem.sentence();
+		expect(await keyvA.set(key, valA)).toBe(true);
+		expect(await keyvA.get(key)).toBe(valA);
+		expect(await keyvB.set(key, valB)).toBe(true);
+		expect(await keyvB.get(key)).toBe(valB);
+		// Ensure they didn't overwrite each other.
+		expect(await keyvA.get(key)).toBe(valA);
+	});
+});
+
+describe("iterator", () => {
+	test("iterates over the default namespace", async () => {
+		const keyv = new KeyvPostgres({ uri: postgresUri });
+		const key1 = faker.string.alphanumeric(10);
+		const val1 = faker.lorem.sentence();
+		const key2 = faker.string.alphanumeric(10);
+		const val2 = faker.lorem.sentence();
+		const key3 = faker.string.alphanumeric(10);
+		const val3 = faker.lorem.sentence();
+		await keyv.set(key1, val1);
+		await keyv.set(key2, val2);
+		await keyv.set(key3, val3);
+
+		const collected = new Map<string, string>();
+		for await (const [key, value] of keyv.iterator()) {
+			collected.set(key, value);
+		}
+
+		expect(collected.get(key1)).toBe(val1);
+		expect(collected.get(key2)).toBe(val2);
+		expect(collected.get(key3)).toBe(val3);
+	});
+
+	test("iterates over a configured namespace without passing it to iterator()", async () => {
+		const ns = faker.string.alphanumeric(8);
+		const keyv = new KeyvPostgres({ uri: postgresUri });
+		keyv.namespace = ns;
+		const key1 = faker.string.alphanumeric(10);
+		const val1 = faker.lorem.sentence();
+		const key2 = faker.string.alphanumeric(10);
+		const val2 = faker.lorem.sentence();
+		await keyv.set(key1, val1);
+		await keyv.set(key2, val2);
+
+		const collected = new Map<string, string>();
+		for await (const [key, value] of keyv.iterator()) {
+			collected.set(key, value);
+		}
+
+		expect(collected.size).toBe(2);
+		expect(collected.get(key1)).toBe(val1);
+		expect(collected.get(key2)).toBe(val2);
+	});
+
+	test("only yields keys from the configured namespace", async () => {
+		const ns1 = faker.string.alphanumeric(8);
+		const ns2 = faker.string.alphanumeric(8);
+		const postgres1 = new KeyvPostgres({ uri: postgresUri });
+		postgres1.namespace = ns1;
+		const postgres2 = new KeyvPostgres({ uri: postgresUri });
+		postgres2.namespace = ns2;
+
+		const key1 = faker.string.alphanumeric(10);
+		const key2 = faker.string.alphanumeric(10);
+		const key3 = faker.string.alphanumeric(10);
+		await postgres1.set(key1, faker.lorem.word());
+		await postgres1.set(key2, faker.lorem.word());
+		await postgres2.set(key3, faker.lorem.word());
+
+		const keys: string[] = [];
+		for await (const [key] of postgres1.iterator()) {
+			keys.push(key);
+		}
+
+		expect(keys.length).toBe(2);
+		expect(keys).toContain(key1);
+		expect(keys).toContain(key2);
+	});
+
+	test("paginates correctly with the default namespace", async () => {
+		const keyv = new KeyvPostgres({ uri: postgresUri, iterationLimit: 2 });
+		const keysToSet = [
+			faker.string.alphanumeric(10),
+			faker.string.alphanumeric(10),
+			faker.string.alphanumeric(10),
+		];
+		for (const key of keysToSet) {
+			await keyv.set(key, faker.lorem.word());
+		}
+
+		const keys: string[] = [];
+		for await (const [key] of keyv.iterator()) {
+			keys.push(key);
+		}
+
+		expect(keys.length).toBe(3);
+		for (const key of keysToSet) {
+			expect(keys).toContain(key);
+		}
+	});
+
+	test("falls back to the default limit when iterationLimit is 0", async () => {
+		const ns = faker.string.alphanumeric(8);
+		const keyv = new KeyvPostgres({ uri: postgresUri, iterationLimit: 0 });
+		keyv.namespace = ns;
+		const key = faker.string.alphanumeric(10);
+		await keyv.set(key, faker.lorem.word());
+
+		const keys: string[] = [];
+		for await (const [k] of keyv.iterator()) {
+			keys.push(k);
+		}
+
+		expect(keys).toContain(key);
+	});
+});
+
+describe("schema", () => {
+	test("stores keys independently across non-public schemas", async () => {
+		const keyv1 = new KeyvPostgres({ uri: postgresUri, schema: "keyvtest1" });
+		const keyv2 = new KeyvPostgres({ uri: postgresUri, schema: "keyvtest2" });
+		const key1 = faker.string.alphanumeric(10);
+		const value1 = faker.lorem.sentence();
+		const key2 = faker.string.alphanumeric(10);
+		const value2 = faker.lorem.sentence();
+		await keyv1.set(key1, value1);
+		await keyv2.set(key2, value2);
+		expect(await keyv1.get(key1)).toBe(value1);
+		expect(await keyv2.get(key2)).toBe(value2);
+	});
+});
+
+describe("unlogged table", () => {
+	test("stores and retrieves values", async () => {
+		const keyv = createKeyv({ uri: postgresUri, useUnloggedTable: true });
+		const key = faker.string.alphanumeric(10);
+		const value = faker.lorem.sentence();
+		expect(await keyv.set(key, value)).toBe(true);
+		expect(await keyv.get(key)).toBe(value);
+	});
+});
+
+describe("SQL injection prevention", () => {
+	test("has prevents a DROP TABLE injection", async () => {
+		const keyv = new KeyvPostgres({ uri: postgresUri });
+		const safeKey = faker.string.alphanumeric(10);
+		await keyv.set(safeKey, "value");
+		expect(await keyv.has("'; DROP TABLE keyv; --")).toBe(false);
+		// The table and the safe key should still be intact.
+		expect(await keyv.has(safeKey)).toBe(true);
+	});
+
+	test("handles keys with single quotes", async () => {
+		const keyv = new KeyvPostgres({ uri: postgresUri });
+		const keyWithQuote = "key'with'quotes";
+		await keyv.set(keyWithQuote, "value");
+		expect(await keyv.has(keyWithQuote)).toBe(true);
+		expect(await keyv.get(keyWithQuote)).toBe("value");
+	});
+
+	test("handles keys with special SQL characters", async () => {
+		const keyv = new KeyvPostgres({ uri: postgresUri });
+		const specialKeys = [
+			"key;with;semicolon",
+			"key--with--dashes",
+			"key/*comment*/",
+			"key\\with\\backslash",
+		];
+		for (const key of specialKeys) {
+			await keyv.set(key, "value");
+			expect(await keyv.has(key)).toBe(true);
+		}
+
+		expect(await keyv.has("nonexistent;key")).toBe(false);
+	});
+});
+
+describe("connection", () => {
+	test("closes the connection on disconnect", async () => {
+		const keyv = store();
+		const key = faker.string.alphanumeric(10);
+		expect(await keyv.get(key)).toBeUndefined();
+		await keyv.disconnect();
+		await expect(keyv.get(key)).rejects.toBeDefined();
+	});
+
+	test("emits an error when the connection fails", async () => {
+		const keyv = new KeyvPostgres({
+			uri: "postgresql://invalid:invalid@localhost:9999/nonexistent",
+		});
+
+		const error = await new Promise((resolve) => {
+			keyv.on("error", (error: unknown) => resolve(error));
+		});
+
+		expect(error).toBeInstanceOf(Error);
+	});
+});
+
+describe("createKeyv", () => {
+	test("returns a Keyv instance from a uri string", async () => {
+		const keyv = createKeyv(postgresUri);
+		expect(keyv).toBeInstanceOf(Keyv);
+		const key = faker.string.alphanumeric(10);
+		const value = faker.lorem.sentence();
+		expect(await keyv.set(key, value)).toBe(true);
+		expect(await keyv.get(key)).toBe(value);
+	});
+
+	test("returns a Keyv instance from an options object", async () => {
+		const keyv = createKeyv({ uri: postgresUri });
+		expect(keyv).toBeInstanceOf(Keyv);
+		const key = faker.string.alphanumeric(10);
+		const value = faker.lorem.sentence();
+		expect(await keyv.set(key, value)).toBe(true);
+		expect(await keyv.get(key)).toBe(value);
+	});
 });


### PR DESCRIPTION
## Summary

A full code and test review of `@keyv/postgres` addressing the requested items.

### Source (`src/index.ts`)
- **Never return `null`:** `get()` and `getMany()` now coerce a SQL `NULL` value to `undefined` (`row.value ?? undefined`). Previously a key explicitly stored with a `NULL` value would surface as `null`.
- **Return types:** `get()` / `getMany()` now use `KeyvStorageGetResult<Value>` to exactly match the `KeyvStorageAdapter` interface from keyv core (consistent with `@keyv/mysql`).
- **Robust jsDocs:** added `@param` / `@returns` / `@template` to `get`, `getMany`, `set`, `setMany`, `clear`, `clearExpired`, `disconnect`, `iterator`, `setOptions`, and `createKeyv`. Corrected the `clear()` doc (it removes only the default/`NULL` namespace when no namespace is set, not "all keys") and clarified that `iterator()` reads the namespace from the instance and does not require it to be passed.
- `createKeyv()` now also accepts a connection URI string (matching `@keyv/mysql`).
- Fixed the `KeyvPostgresOptions` type re-export to use the `.js` extension.

### Tests (`test/test.ts`, `test/test-ssl.ts`)
- Restructured from flat `it(...)` / `t.expect` into uniform `describe` / `test` / `expect` blocks, mirroring the other storage adapters (notably `@keyv/mysql`).
- Use **faker** for all keys and values throughout.
- Added native-namespace scoping coverage: `get`, `set`, `delete`, `deleteMany`, `has`, `hasMany`, `getMany`, `setMany`, `clear`, and `iterator` are all verified to be isolated per namespace.
- Added explicit "returns `undefined` (not `null`)" tests for `get` and `getMany`.
- Added a `SQL injection prevention` block validating parameterized queries.
- Added an iterator test confirming a configured namespace is honored **without** passing it to `iterator()`.

### README
- Removed the incorrect "the `opts` getter still exists" migration note (no such getter exists) and clarified the *Breaking changes* section.
- Documented that `get` / `getMany` normalize `NULL` to `undefined`.

## Validation
- `biome check --error-on-warnings` ✅
- `pnpm build` (tsdown CJS + ESM + d.ts) ✅
- `tsc --noEmit` on `src` ✅

> Note: the DB-backed Vitest suites require a running PostgreSQL instance (`pnpm test:services:start`) and were not executed in this environment, which has no Docker/Postgres available. Lint, build, and typecheck all pass.

## Verifying the requested checklist
- ✅ API documented correctly in the README
- ✅ Tests use faker and match the other storage modules
- ✅ Tests cleaned up to be uniform with `describe`/`test`
- ✅ Namespace is fully supported natively (dedicated `namespace` column)
- ✅ Iterator does not require a namespace argument
- ✅ `get`/`getMany` return `undefined` instead of `null`
- ✅ Events use Hookified and are wired up correctly
- ✅ jsDocs are robust with params and return values

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MqkNpok85EHwEBfB7mdynb

---
_Generated by [Claude Code](https://claude.ai/code/session_01MqkNpok85EHwEBfB7mdynb)_