### PR TITLE
redis - chore: full code and test review cleanup

### DIFF
--- a/storage/redis/README.md
+++ b/storage/redis/README.md
@@ -159,7 +159,7 @@ export type KeyvRedisOptions = {
 	/**
 	 * Timeout in milliseconds for the connection. Default is undefined, which uses the default timeout of the Redis client.
 	 * If set, it will throw an error if the connection does not succeed within the specified time.
-   * @default undefined
+	 * @default undefined
 	 */
 	connectionTimeout?: number;
 };
@@ -481,79 +481,38 @@ const tlsOptions = {
 const keyv = new Keyv({ store: new KeyvRedis(tlsOptions) });
 ```
 
-# Keyv Redis Options
-
-Here are all the options that you can set on the constructor
-
-```ts
-export type KeyvRedisOptions = {
-	/**
-	 * Namespace for the current instance.
-	 */
-	namespace?: string;
-	/**
-	 * Separator to use between namespace and key.
-	 */
-	keyPrefixSeparator?: string;
-	/**
-	 * Number of keys to delete in a single batch.
-	 */
-	clearBatchSize?: number;
-	/**
-	 * Enable Unlink instead of using Del for clearing keys. This is more performant but may not be supported by all Redis versions.
-	 */
-	useUnlink?: boolean;
-
-	/**
-	 * Whether to allow clearing all keys when no namespace is set.
-	 * If set to true and no namespace is set, iterate() will return all keys.
-	 * Defaults to `false`.
-	 */
-	noNamespaceAffectsAll?: boolean;
-
-	/**
-	 * This is used to throw an error if the client is not connected when trying to connect. By default, this is
-	 * set to true so that it throws an error when trying to connect to the Redis server fails.
-	 */
-	throwOnConnectError?: boolean;
-
-	/**
-	 * This is used to throw an error if at any point there is a failure. Use this if you want to
-	 * ensure that all operations are successful and you want to handle errors. By default, this is
-	 * set to false so that it does not throw an error on every operation and instead emits an error event
-	 * and returns no-op responses.
-	 * @default false
-	 */
-	throwOnErrors?: boolean;
-
-	/**
-	 * Timeout in milliseconds for the connection. Default is undefined, which uses the default timeout of the Redis client.
-	 * If set, it will throw an error if the connection does not succeed within the specified time.
-	 * @default undefined
-	 */
-	connectionTimeout?: number;
-};
-```
-
 # API
-* **constructor([connection], [options])**
-* **namespace** - The namespace to use for the keys.
-* **client** - The Redis client instance.
-* **keyPrefixSeparator** - The separator to use between the namespace and key. It can be set to a blank string.
+
+## Properties
+* **client** - The Redis client, cluster, or sentinel connection instance.
+* **namespace** - The namespace to use for the keys. If `undefined` no namespace prefixing is applied. Default is `undefined`.
+* **keyPrefixSeparator** - The separator to use between the namespace and key. It can be set to a blank string. Default is `::`.
 * **clearBatchSize** - The number of keys to delete in a single batch. Has to be greater than 0. Default is `1000`.
-* **useUnlink** - Use the `UNLINK` command for deleting keys isntead of `DEL`.
-* **noNamespaceAffectsAll**: Whether to allow clearing all keys when no namespace is set (default is `false`).
-* **set** - Set a key.
-* **setMany** - Set multiple keys using `KeyvEntry<Value>` objects (`{ key: string, value: Value, ttl?: number }`) via `MULTI/EXEC` transactions. Returns `boolean[]` with per-entry success tracking by inspecting each command's result. In cluster mode, entries are grouped by hash slot with results mapped back to the original order.
-* **get** - Get a key.
-* **getMany** - Get multiple keys.
-* **has** - Check if a key exists.
-* **hasMany** - Check if multiple keys exist.
-* **delete** - Delete a key.
-* **deleteMany** - Delete multiple keys. Returns `boolean[]`.
-* **clear** - Clear all keys in the namespace. If the namespace is not set it will clear all keys that are not prefixed with a namespace unless `noNamespaceAffectsAll` is set to `true`.
-* **disconnect** - Disconnect from the Redis server using `Quit` command. If you set `force` to `true` it will force the disconnect.
-* **iterator** - Create a new iterator for the keys. The iterator uses the namespace configured on the instance. If no namespace is set it will iterate over all keys that are not prefixed with a namespace unless `noNamespaceAffectsAll` is set to `true`.
+* **useUnlink** - Use the `UNLINK` command for deleting keys instead of `DEL`. Default is `true`.
+* **noNamespaceAffectsAll** - Whether to allow clearing and iterating all keys when no namespace is set. Default is `false`.
+* **throwOnConnectError** - Whether to throw an error if the client fails to connect. Default is `true`.
+* **throwOnErrors** - Whether to throw an error if any operation fails instead of emitting an error event and returning a no-op response. Default is `false`.
+* **connectionTimeout** - The connection timeout in milliseconds. Default is `undefined` which uses the Redis client default.
+
+## Methods
+* **constructor([connection], [options])** - Create a new `KeyvRedis` instance. See [Keyv Redis Options](#keyv-redis-options).
+* **getClient()** - Get the connected Redis client. Connects first if the client is not already connected.
+* **set(key, value, [ttl])** - Set a key. `ttl` is in milliseconds. Returns `boolean`.
+* **setMany(entries)** - Set multiple keys using `KeyvEntry<Value>` objects (`{ key: string, value: Value, ttl?: number }`) via `MULTI/EXEC` transactions. Returns `boolean[]` with per-entry success tracking by inspecting each command's result. In cluster mode, entries are grouped by hash slot with results mapped back to the original order.
+* **get(key)** - Get a key. Returns the value or `undefined` if the key does not exist.
+* **getMany(keys)** - Get multiple keys. Returns an array of values where each entry is the value or `undefined` if the key does not exist.
+* **has(key)** - Check if a key exists. Returns `boolean`.
+* **hasMany(keys)** - Check if multiple keys exist. Returns `boolean[]`.
+* **delete(key)** - Delete a key. Returns `boolean`.
+* **deleteMany(keys)** - Delete multiple keys. Returns `boolean[]`.
+* **clear()** - Clear all keys in the namespace. If the namespace is not set it will clear all keys that are not prefixed with a namespace unless `noNamespaceAffectsAll` is set to `true`.
+* **disconnect([force])** - Disconnect from the Redis server using the `Quit` command. If you set `force` to `true` it will force the disconnect.
+* **iterator()** - Create a new async iterator for the keys and values. The iterator uses the namespace configured on the instance and does not take a namespace parameter. If no namespace is set it will iterate over all keys that are not prefixed with a namespace unless `noNamespaceAffectsAll` is set to `true`.
+* **createKeyPrefix(key, [namespace])** - Helper that returns the key with the namespace prefix applied such as `namespace::key`.
+* **getKeyWithoutPrefix(key, [namespace])** - Helper that returns the key with the namespace prefix removed.
+* **isCluster()** - Returns `true` if the client is a Redis cluster.
+* **isSentinel()** - Returns `true` if the client is a Redis sentinel.
+* **getMasterNodes()** - Get the master node clients in the cluster. If the client is not a cluster it returns the single client.
 
 # Using Custom Redis Client Events
 

--- a/storage/redis/src/create.ts
+++ b/storage/redis/src/create.ts
@@ -5,9 +5,10 @@ import KeyvRedis from "./index.js";
 import type { KeyvRedisOptions } from "./types.js";
 
 /**
- * Will create a Keyv instance with the Redis adapter. This will also set the namespace.
- * @param connect - How to connect to the Redis server. If string pass in the url, if object pass in the options, if RedisClient pass in the client. If nothing is passed in, it will default to 'redis://localhost:6379'.
- * @param {KeyvRedisOptions} options - Options for the adapter such as namespace, keyPrefixSeparator, and clearBatchSize.
+ * Will create a Keyv instance with the Redis adapter. This will also set the namespace and disable the Keyv
+ * key prefix to avoid double prefixing of keys.
+ * @param {string | RedisClientOptions | RedisClientType} [connect] - How to connect to the Redis server. If string pass in the url, if object pass in the options, if RedisClient pass in the client. If nothing is passed in, it will default to 'redis://localhost:6379'.
+ * @param {KeyvRedisOptions} [options] - Options for the adapter such as namespace, keyPrefixSeparator, and clearBatchSize.
  * @returns {Keyv} - Keyv instance with the Redis adapter
  */
 export function createKeyv(
@@ -52,6 +53,14 @@ export function createKeyv(
 	return keyv;
 }
 
+/**
+ * Will create a non-blocking Keyv instance with the Redis adapter. This does everything `createKeyv` does but also
+ * disables throwing errors, removes the offline queue, and disables the reconnect strategy so that when used as a
+ * secondary cache (such as with cacheable) it does not block the primary cache on connection errors or timeouts.
+ * @param {string | RedisClientOptions | RedisClientType} [connect] - How to connect to the Redis server. If string pass in the url, if object pass in the options, if RedisClient pass in the client. If nothing is passed in, it will default to 'redis://localhost:6379'.
+ * @param {KeyvRedisOptions} [options] - Options for the adapter such as namespace, keyPrefixSeparator, and clearBatchSize.
+ * @returns {Keyv} - non-blocking Keyv instance with the Redis adapter
+ */
 export function createKeyvNonBlocking(
 	connect?: string | RedisClientOptions | RedisClientType,
 	options?: KeyvRedisOptions,

--- a/storage/redis/src/index.ts
+++ b/storage/redis/src/index.ts
@@ -43,15 +43,55 @@ export {
 };
 
 export default class KeyvRedis<T> extends Hookified implements KeyvStorageAdapter {
+	/**
+	 * The underlying Redis client, cluster, or sentinel connection used for all storage operations.
+	 */
 	private _client!: RedisClientConnectionType;
+	/**
+	 * Namespace used to prefix keys. When undefined, no namespace prefixing is applied.
+	 * @default undefined
+	 */
 	private _namespace: string | undefined;
+	/**
+	 * Separator placed between the namespace and the key such as 'namespace::key'.
+	 * @default "::"
+	 */
 	private _keyPrefixSeparator = "::";
+	/**
+	 * Number of keys to delete in a single batch when clearing.
+	 * @default 1000
+	 */
 	private _clearBatchSize = 1000;
+	/**
+	 * Whether to use the UNLINK command instead of DEL when removing keys.
+	 * @default true
+	 */
 	private _useUnlink = true;
+	/**
+	 * Whether operations with no namespace set affect all keys in the database.
+	 * @default false
+	 */
 	private _noNamespaceAffectsAll = false;
+	/**
+	 * Whether to throw an error when the client fails to connect.
+	 * @default true
+	 */
 	private _throwOnConnectError = true;
+	/**
+	 * Whether to throw an error when any operation fails instead of emitting an error event.
+	 * @default false
+	 */
 	private _throwOnErrors = false;
+	/**
+	 * Connection timeout in milliseconds. When undefined, the Redis client default is used.
+	 * @default undefined
+	 */
 	private _connectionTimeout: number | undefined;
+	/**
+	 * Tracks the client instance whose events have already been wired up so that
+	 * repeated initialization does not attach duplicate listeners.
+	 */
+	private _eventsWiredClient: RedisClientConnectionType | undefined;
 
 	/**
 	 * KeyvRedis constructor.
@@ -107,14 +147,16 @@ export default class KeyvRedis<T> extends Hookified implements KeyvStorageAdapte
 	}
 
 	/**
-	 * Get the Redis client.
+	 * Get the Redis client, cluster, or sentinel connection.
+	 * @returns {RedisClientConnectionType} The current Redis client connection.
 	 */
 	public get client(): RedisClientConnectionType {
 		return this._client;
 	}
 
 	/**
-	 * Set the Redis client.
+	 * Set the Redis client, cluster, or sentinel connection. This will re-wire the event listeners.
+	 * @param {RedisClientConnectionType} value - The Redis client connection to use.
 	 */
 	public set client(value: RedisClientConnectionType) {
 		this._client = value;
@@ -123,6 +165,7 @@ export default class KeyvRedis<T> extends Hookified implements KeyvStorageAdapte
 
 	/**
 	 * Get the namespace for the adapter. If undefined, it will not use a namespace including keyPrefixing.
+	 * @returns {string | undefined} The current namespace, or undefined if no namespace is set.
 	 * @default undefined
 	 */
 	public get namespace(): string | undefined {
@@ -131,6 +174,7 @@ export default class KeyvRedis<T> extends Hookified implements KeyvStorageAdapte
 
 	/**
 	 * Set the namespace for the adapter. If undefined, it will not use a namespace including keyPrefixing.
+	 * @param {string | undefined} value - The namespace to use, or undefined to disable namespacing.
 	 */
 	public set namespace(value: string | undefined) {
 		this._namespace = value;
@@ -138,6 +182,7 @@ export default class KeyvRedis<T> extends Hookified implements KeyvStorageAdapte
 
 	/**
 	 * Get the separator between the namespace and key.
+	 * @returns {string} The separator placed between the namespace and key.
 	 * @default '::'
 	 */
 	public get keyPrefixSeparator(): string {
@@ -146,6 +191,7 @@ export default class KeyvRedis<T> extends Hookified implements KeyvStorageAdapte
 
 	/**
 	 * Set the separator between the namespace and key.
+	 * @param {string} value - The separator to place between the namespace and key.
 	 */
 	public set keyPrefixSeparator(value: string) {
 		this._keyPrefixSeparator = value;
@@ -153,6 +199,7 @@ export default class KeyvRedis<T> extends Hookified implements KeyvStorageAdapte
 
 	/**
 	 * Get the number of keys to delete in a single batch.
+	 * @returns {number} The number of keys to delete in a single batch.
 	 * @default 1000
 	 */
 	public get clearBatchSize(): number {
@@ -160,7 +207,8 @@ export default class KeyvRedis<T> extends Hookified implements KeyvStorageAdapte
 	}
 
 	/**
-	 * Set the number of keys to delete in a single batch.
+	 * Set the number of keys to delete in a single batch. Must be greater than 0 otherwise an error event is emitted.
+	 * @param {number} value - The number of keys to delete in a single batch.
 	 */
 	public set clearBatchSize(value: number) {
 		if (value > 0) {
@@ -172,6 +220,7 @@ export default class KeyvRedis<T> extends Hookified implements KeyvStorageAdapte
 
 	/**
 	 * Get if Unlink is used instead of Del for clearing keys. This is more performant but may not be supported by all Redis versions.
+	 * @returns {boolean} True if the UNLINK command is used instead of DEL.
 	 * @default true
 	 */
 	public get useUnlink(): boolean {
@@ -180,6 +229,7 @@ export default class KeyvRedis<T> extends Hookified implements KeyvStorageAdapte
 
 	/**
 	 * Set if Unlink is used instead of Del for clearing keys. This is more performant but may not be supported by all Redis versions.
+	 * @param {boolean} value - True to use the UNLINK command instead of DEL.
 	 */
 	public set useUnlink(value: boolean) {
 		this._useUnlink = value;
@@ -189,6 +239,7 @@ export default class KeyvRedis<T> extends Hookified implements KeyvStorageAdapte
 	 * Get if no namespace affects all keys.
 	 * Whether to allow clearing all keys when no namespace is set.
 	 * If set to true and no namespace is set, iterate() will return all keys.
+	 * @returns {boolean} True if operations with no namespace affect all keys.
 	 * @default false
 	 */
 	public get noNamespaceAffectsAll(): boolean {
@@ -196,7 +247,8 @@ export default class KeyvRedis<T> extends Hookified implements KeyvStorageAdapte
 	}
 
 	/**
-	 * Set if not namespace affects all keys.
+	 * Set if no namespace affects all keys.
+	 * @param {boolean} value - True to allow operations with no namespace to affect all keys.
 	 */
 	public set noNamespaceAffectsAll(value: boolean) {
 		this._noNamespaceAffectsAll = value;
@@ -206,6 +258,7 @@ export default class KeyvRedis<T> extends Hookified implements KeyvStorageAdapte
 	 * Get if throwOnConnectError is set to true.
 	 * This is used to throw an error if the client is not connected when trying to connect. By default, this is
 	 * set to true so that it throws an error when trying to connect to the Redis server fails.
+	 * @returns {boolean} True if an error is thrown when the client fails to connect.
 	 * @default true
 	 */
 	public get throwOnConnectError(): boolean {
@@ -216,6 +269,7 @@ export default class KeyvRedis<T> extends Hookified implements KeyvStorageAdapte
 	 * Set if throwOnConnectError is set to true.
 	 * This is used to throw an error if the client is not connected when trying to connect. By default, this is
 	 * set to true so that it throws an error when trying to connect to the Redis server fails.
+	 * @param {boolean} value - True to throw an error when the client fails to connect.
 	 */
 	public set throwOnConnectError(value: boolean) {
 		this._throwOnConnectError = value;
@@ -227,6 +281,7 @@ export default class KeyvRedis<T> extends Hookified implements KeyvStorageAdapte
 	 * ensure that all operations are successful and you want to handle errors. By default, this is
 	 * set to false so that it does not throw an error on every operation and instead emits an error event
 	 * and returns no-op responses.
+	 * @returns {boolean} True if an error is thrown when any operation fails.
 	 * @default false
 	 */
 	public get throwOnErrors(): boolean {
@@ -239,6 +294,7 @@ export default class KeyvRedis<T> extends Hookified implements KeyvStorageAdapte
 	 * ensure that all operations are successful and you want to handle errors. By default, this is
 	 * set to false so that it does not throw an error on every operation and instead emits an error event
 	 * and returns no-op responses.
+	 * @param {boolean} value - True to throw an error when any operation fails.
 	 */
 	public set throwOnErrors(value: boolean) {
 		this._throwOnErrors = value;
@@ -246,6 +302,7 @@ export default class KeyvRedis<T> extends Hookified implements KeyvStorageAdapte
 
 	/**
 	 * Get the connection timeout in milliseconds such as 5000 (5 seconds). Default is undefined. If undefined, it will use the default.
+	 * @returns {number | undefined} The connection timeout in milliseconds, or undefined to use the default.
 	 * @default undefined
 	 */
 	public get connectionTimeout(): number | undefined {
@@ -254,6 +311,7 @@ export default class KeyvRedis<T> extends Hookified implements KeyvStorageAdapte
 
 	/**
 	 * Set the connection timeout in milliseconds such as 5000 (5 seconds). Default is undefined. If undefined, it will use the default.
+	 * @param {number | undefined} value - The connection timeout in milliseconds, or undefined to use the default.
 	 * @default undefined
 	 */
 	public set connectionTimeout(value: number | undefined) {
@@ -261,7 +319,10 @@ export default class KeyvRedis<T> extends Hookified implements KeyvStorageAdapte
 	}
 
 	/**
-	 * Get the Redis URL used to connect to the server. This is used to get a connected client.
+	 * Get the connected Redis client. If the client is not already connected it will connect first, respecting
+	 * the connectionTimeout. If the connection fails it will emit an error event and, when throwOnConnectError
+	 * is true, throw an error.
+	 * @returns {Promise<RedisClientConnectionType>} The connected Redis client.
 	 */
 	public async getClient(): Promise<RedisClientConnectionType> {
 		if (this._client.isOpen) {
@@ -297,6 +358,7 @@ export default class KeyvRedis<T> extends Hookified implements KeyvStorageAdapte
 	 * @param {string} key - the key to set
 	 * @param {string} value - the value to set
 	 * @param {number} [ttl] - the time to live in milliseconds
+	 * @returns {Promise<boolean>} - true if the value was set, false if an error occurred and throwOnErrors is false
 	 */
 	public async set(key: string, value: string, ttl?: number): Promise<boolean> {
 		const client = await this.getClient();
@@ -325,6 +387,7 @@ export default class KeyvRedis<T> extends Hookified implements KeyvStorageAdapte
 	/**
 	 * Will set many key value pairs in the store. TTL is in milliseconds. This will be done as a single transaction.
 	 * @param {KeyvEntry[]} entries - the key value pairs to set with optional ttl
+	 * @returns {Promise<boolean[] | undefined>} - array of booleans indicating whether each entry was successfully set
 	 */
 	public async setMany<Value>(entries: KeyvEntry<Value>[]): Promise<boolean[] | undefined> {
 		try {
@@ -709,8 +772,10 @@ export default class KeyvRedis<T> extends Hookified implements KeyvStorageAdapte
 	}
 
 	/**
-	 * Get an async iterator for the keys and values in the store. It will only iterate over keys with the current namespace.
-	 * @returns {AsyncGenerator<[string, T | undefined], void, unknown>} - async iterator with key value pairs
+	 * Get an async iterator for the keys and values in the store. The namespace is not passed in and instead
+	 * uses the namespace configured on the instance. It will only iterate over keys with the current namespace.
+	 * If no namespace is set it will iterate over keys with no namespace prefix unless noNamespaceAffectsAll is true.
+	 * @returns {AsyncGenerator<[string, U | undefined], void, unknown>} - async iterator with key value pairs
 	 */
 	public async *iterator<U = T>(): AsyncGenerator<[string, U | undefined], void, unknown> {
 		// When instance is not a cluster, it will only have one client
@@ -892,14 +957,28 @@ export default class KeyvRedis<T> extends Hookified implements KeyvStorageAdapte
 		return slotMap;
 	}
 
+	/**
+	 * Check if the provided client is a cluster client.
+	 * @param {RedisClientConnectionType} client - the client to check
+	 * @returns {boolean} - true if the client is a cluster client, false if not
+	 */
 	private isClientCluster(client: RedisClientConnectionType): boolean {
 		return (client as any).slots !== undefined;
 	}
 
+	/**
+	 * Check if the provided client is a sentinel client.
+	 * @param {RedisClientConnectionType} client - the client to check
+	 * @returns {boolean} - true if the client is a sentinel client, false if not
+	 */
 	private isClientSentinel(client: RedisClientConnectionType): boolean {
 		return (client as any).getSentinelNode !== undefined;
 	}
 
+	/**
+	 * Apply the provided options to the instance. Only defined options are applied.
+	 * @param {KeyvRedisOptions} [options] - the options to apply
+	 */
 	private setOptions(options?: KeyvRedisOptions): void {
 		if (!options) {
 			return;
@@ -938,7 +1017,19 @@ export default class KeyvRedis<T> extends Hookified implements KeyvStorageAdapte
 		}
 	}
 
+	/**
+	 * Wire up the client events (error, connect, disconnect, reconnecting) to be re-emitted on this instance.
+	 * Listeners are only attached once per client instance to avoid duplicates.
+	 */
 	private initClient(): void {
+		// Only wire up listeners once per client instance so that repeated calls
+		// (for example on reconnect via getClient) do not accumulate duplicate listeners.
+		if (this._eventsWiredClient === this._client) {
+			return;
+		}
+
+		this._eventsWiredClient = this._client;
+
 		this._client.on("error", (error) => {
 			this.emit("error", error);
 		});
@@ -958,6 +1049,11 @@ export default class KeyvRedis<T> extends Hookified implements KeyvStorageAdapte
 		});
 	}
 
+	/**
+	 * Create a promise that rejects after the provided timeout. Used to race against the connection.
+	 * @param {number} timeoutMs - the timeout in milliseconds before the promise rejects
+	 * @returns {Promise<never>} - a promise that always rejects once the timeout elapses
+	 */
 	private async createTimeoutPromise(timeoutMs: number): Promise<never> {
 		return new Promise<never>((_, reject) =>
 			setTimeout(() => {

--- a/storage/redis/src/types.ts
+++ b/storage/redis/src/types.ts
@@ -12,20 +12,23 @@ import type {
 
 export type KeyvRedisOptions = {
 	/**
-	 * Namespace for the current instance.
-	 * Defaults to `keyv`
+	 * Namespace for the current instance. When undefined, no namespace prefixing is applied.
+	 * @default undefined
 	 */
 	namespace?: string;
 	/**
 	 * Separator to use between namespace and key.
+	 * @default "::"
 	 */
 	keyPrefixSeparator?: string;
 	/**
 	 * Number of keys to delete in a single batch.
+	 * @default 1000
 	 */
 	clearBatchSize?: number;
 	/**
 	 * Enable Unlink instead of using Del for clearing keys. This is more performant but may not be supported by all Redis versions.
+	 * @default true
 	 */
 	useUnlink?: boolean;
 

--- a/storage/redis/test/cluster.test.ts
+++ b/storage/redis/test/cluster.test.ts
@@ -257,16 +257,16 @@ describe("KeyvRedis Cluster", () => {
 	});
 
 	describe("KeyvRedis Iterators", () => {
-		test("should no throw an error on iterator", async () => {
+		test("should not throw an error on iterator", async () => {
 			const cluster = createCluster(defaultClusterOptions);
 			const keyvRedis = new KeyvRedis(cluster);
+			keyvRedis.namespace = faker.string.uuid();
 
-			const iteratorNamespace = faker.string.uuid();
 			let errorThrown = false;
 			try {
 				const keys = [];
 				const values = [];
-				for await (const [key, value] of keyvRedis.iterator(iteratorNamespace)) {
+				for await (const [key, value] of keyvRedis.iterator()) {
 					keys.push(key);
 					values.push(value);
 				}
@@ -327,7 +327,7 @@ describe("KeyvRedis Cluster", () => {
 			await keyvRedis.set(nsKey3, nsVal3);
 			const keys = [];
 			const values = [];
-			for await (const [key, value] of keyvRedis.iterator(namespace)) {
+			for await (const [key, value] of keyvRedis.iterator()) {
 				keys.push(key);
 				values.push(value);
 			}

--- a/storage/redis/test/delete.test.ts
+++ b/storage/redis/test/delete.test.ts
@@ -144,7 +144,7 @@ describe("delete", () => {
 		expect(didError).toBe(false);
 	});
 
-	test("should throw on getMany an error when throwOnErrors is true and an error occurs", async () => {
+	test("should throw on deleteMany when throwOnErrors is true and an error occurs", async () => {
 		const keyvRedis = new KeyvRedis(redisUri, { throwOnErrors: true });
 
 		const data = {

--- a/storage/redis/test/events.test.ts
+++ b/storage/redis/test/events.test.ts
@@ -1,0 +1,80 @@
+import process from "node:process";
+import { faker } from "@faker-js/faker";
+import { describe, expect, test } from "vitest";
+import KeyvRedis, { createClient, type RedisClientType } from "../src/index.js";
+
+const redisUri = process.env.REDIS_URI ?? "redis://localhost:6379";
+
+describe("events", () => {
+	test("should expose hookified event methods", () => {
+		const keyvRedis = new KeyvRedis(redisUri);
+		expect(typeof keyvRedis.on).toBe("function");
+		expect(typeof keyvRedis.once).toBe("function");
+		expect(typeof keyvRedis.emit).toBe("function");
+	});
+
+	test("should re-emit the client error event on the adapter", async () => {
+		const keyvRedis = new KeyvRedis(redisUri);
+		const error = new Error(faker.lorem.sentence());
+		let received: Error | undefined;
+		keyvRedis.on("error", (emitted) => {
+			received = emitted as Error;
+		});
+
+		keyvRedis.client.emit("error", error);
+
+		expect(received).toBe(error);
+		await keyvRedis.disconnect();
+	});
+
+	test("should emit a connect event when the client connects", async () => {
+		const keyvRedis = new KeyvRedis(redisUri);
+		let connected = false;
+		keyvRedis.on("connect", () => {
+			connected = true;
+		});
+
+		await keyvRedis.getClient();
+
+		expect(connected).toBe(true);
+		await keyvRedis.disconnect();
+	});
+
+	test("should not attach duplicate listeners when connecting", async () => {
+		const keyvRedis = new KeyvRedis(redisUri);
+		// The constructor wires up a single listener per event.
+		expect(keyvRedis.client.listenerCount("error")).toBe(1);
+		expect(keyvRedis.client.listenerCount("connect")).toBe(1);
+
+		// Connecting (and re-initializing the client) must not add duplicates.
+		await keyvRedis.getClient();
+		await keyvRedis.getClient();
+
+		expect(keyvRedis.client.listenerCount("error")).toBe(1);
+		expect(keyvRedis.client.listenerCount("connect")).toBe(1);
+		await keyvRedis.disconnect();
+	});
+
+	test("should re-wire listeners when the client is replaced", () => {
+		const keyvRedis = new KeyvRedis(redisUri);
+		const newClient = createClient({ url: redisUri }) as RedisClientType;
+
+		keyvRedis.client = newClient;
+
+		expect(keyvRedis.client).toBe(newClient);
+		expect(keyvRedis.client.listenerCount("error")).toBe(1);
+		expect(keyvRedis.client.listenerCount("connect")).toBe(1);
+	});
+
+	test("should emit an error event when clearBatchSize is set to an invalid value", () => {
+		const keyvRedis = new KeyvRedis(redisUri);
+		let received = "";
+		keyvRedis.on("error", (message) => {
+			received = message as string;
+		});
+
+		keyvRedis.clearBatchSize = -1;
+
+		expect(received).toBe("clearBatchSize must be greater than 0");
+	});
+});

--- a/storage/redis/test/get-client.test.ts
+++ b/storage/redis/test/get-client.test.ts
@@ -43,7 +43,7 @@ describe("getClient", () => {
 		expect(didError).toBe(true);
 	});
 
-	test("should throw an error if not connected with Keyv", async () => {
+	test("should throw an error if not connected with Keyv when throwOnErrors is true", async () => {
 		const keyv = createKeyv(redisBadUri, {
 			throwOnErrors: true,
 			connectionTimeout: 500,
@@ -58,7 +58,7 @@ describe("getClient", () => {
 		expect(didError).toBe(true);
 	});
 
-	test("should throw an error if not connected with Keyv", async () => {
+	test("should throw an error if not connected with Keyv when throwOnConnectError is true", async () => {
 		const keyv = createKeyv(redisBadUri, {
 			throwOnConnectError: true,
 			connectionTimeout: 500,

--- a/storage/redis/test/get.test.ts
+++ b/storage/redis/test/get.test.ts
@@ -89,7 +89,7 @@ describe("get", () => {
 		vi.spyOn(keyvRedis.client, "get").mockRestore();
 	});
 
-	test("should throw and error on getMany client error", async () => {
+	test("should throw an error on getMany client error", async () => {
 		const keyvRedis = new KeyvRedis(redisUri, { throwOnErrors: true });
 
 		const data = {
@@ -112,7 +112,7 @@ describe("get", () => {
 		vi.spyOn(keyvRedis.client, "mGet").mockRestore();
 	});
 
-	test("should not throw and error on getMany client error", async () => {
+	test("should not throw an error on getMany client error", async () => {
 		const keyvRedis = new KeyvRedis(redisUri, { throwOnErrors: false });
 
 		const data = {

--- a/storage/redis/test/main.test.ts
+++ b/storage/redis/test/main.test.ts
@@ -77,7 +77,7 @@ describe("KeyvRedis", () => {
 		expect(keyvRedis.namespace).toBe("test");
 	});
 
-	test("should be able to pass in the url and options to constructor", () => {
+	test("should be able to pass in the url and all options to constructor", () => {
 		const uri = "redis://localhost:6379";
 		const options = {
 			namespace: "test",

--- a/storage/redis/test/sentinel.test.ts
+++ b/storage/redis/test/sentinel.test.ts
@@ -234,16 +234,16 @@ describe("KeyvRedis Sentinel", () => {
 	});
 
 	describe("KeyvRedis Iterators", () => {
-		test("should no throw an error on iterator", async () => {
+		test("should not throw an error on iterator", async () => {
 			const sentinel = createSentinel(defaultSentinelOptions);
 			const keyvRedis = new KeyvRedis(sentinel);
-			const iteratorNamespace = faker.string.uuid();
+			keyvRedis.namespace = faker.string.uuid();
 
 			let errorThrown = false;
 			try {
 				const keys = [];
 				const values = [];
-				for await (const [key, value] of keyvRedis.iterator(iteratorNamespace)) {
+				for await (const [key, value] of keyvRedis.iterator()) {
 					keys.push(key);
 					values.push(value);
 				}
@@ -304,7 +304,7 @@ describe("KeyvRedis Sentinel", () => {
 			await keyvRedis.set(nsKey3, nsVal3);
 			const keys = [];
 			const values = [];
-			for await (const [key, value] of keyvRedis.iterator(namespace)) {
+			for await (const [key, value] of keyvRedis.iterator()) {
 				keys.push(key);
 				values.push(value);
 			}

--- a/storage/redis/test/set.test.ts
+++ b/storage/redis/test/set.test.ts
@@ -22,7 +22,7 @@ describe("set", () => {
 		expect(result).toBe(data.value);
 	});
 
-	test("should throw error on bad uri", async () => {
+	test("should throw on connection error with a bad uri", async () => {
 		const keyvRedis = new KeyvRedis(redisBadUri, { connectionTimeout: 500 });
 		keyvRedis.on("error", () => {}); // Silence expected connection errors
 
@@ -42,7 +42,7 @@ describe("set", () => {
 		expect(didError).toBe(true);
 	});
 
-	test("should throw error on bad uri", async () => {
+	test("should throw on set client error when throwOnErrors is true", async () => {
 		const keyvRedis = new KeyvRedis(redisBadUri, {
 			throwOnConnectError: false,
 			throwOnErrors: true,
@@ -90,27 +90,7 @@ describe("set", () => {
 		expect(expiredResult).toBeUndefined();
 	});
 
-	test("should set a value with ttl", async () => {
-		const keyvRedis = new KeyvRedis(redisUri);
-		const data = {
-			key: faker.string.alphanumeric(10),
-			value: faker.lorem.sentence(),
-			ttl: 100, // 100 milliseconds
-		};
-
-		await keyvRedis.set(data.key, data.value, data.ttl);
-
-		const result = await keyvRedis.get(data.key);
-
-		expect(result).toBe(data.value);
-
-		await delay(300); // Wait for ttl to expire
-
-		const expiredResult = await keyvRedis.get(data.key);
-		expect(expiredResult).toBeUndefined();
-	});
-
-	test("show throw on redis client set and get error", async () => {
+	test("should throw on redis client set error when throwOnErrors is true", async () => {
 		const keyvRedis = new KeyvRedis(redisUri, { throwOnErrors: true });
 
 		const data = {
@@ -134,7 +114,7 @@ describe("set", () => {
 		vi.spyOn(keyvRedis.client, "set").mockRestore();
 	});
 
-	test("show throw on redis client setMany and get error", async () => {
+	test("should throw on redis client setMany error when throwOnErrors is true", async () => {
 		const keyvRedis = new KeyvRedis(redisUri, { throwOnErrors: true });
 
 		const data = {
@@ -158,7 +138,7 @@ describe("set", () => {
 		vi.spyOn(keyvRedis.client, "multi").mockRestore();
 	});
 
-	test("setMany should return false entries on error when throwOnErrors is false", async () => {
+	test("should return false entries on setMany error when throwOnErrors is false", async () => {
 		const keyvRedis = new KeyvRedis(redisUri);
 		keyvRedis.on("error", () => {}); // Silence expected errors
 


### PR DESCRIPTION
## Summary

A full code and test review of `@keyv/redis`, addressing the review checklist. Changes are docs, tests, and one behavioral fix.

### Source (`src/`)
- **jsDocs**: Added robust `@param`/`@returns` to every getter/setter, to `set`/`setMany`, to `getClient`, and to the previously undocumented private helpers (`isClientCluster`, `isClientSentinel`, `setOptions`, `initClient`, `createTimeoutPromise`). Documented the private backing fields with `@default`.
- **fix — duplicate event listeners**: `initClient()` re-wired the client's `error`/`connect`/`disconnect`/`reconnecting` listeners on every `getClient()` (re)connect, so listener counts grew (1 → 2 → …) and events double-emitted on reconnect. `initClient()` now wires each client instance only once. Verified: counts stay `1 → 1 → 1`.
- **correctness in docs**: `getClient` jsDoc no longer claims it "Get[s] the Redis URL" (it returns the connected client). `types.ts` namespace default corrected from `keyv` to `undefined`, with `@default` annotations added.
- **iterator**: jsDoc clarifies it takes **no** namespace parameter and uses the instance namespace.
- `create.ts`: documented `createKeyvNonBlocking` and typed the `createKeyv` params.

### README
- Completed the **API** section — added the undocumented public surface: `throwOnConnectError`, `throwOnErrors`, `connectionTimeout`, `getClient`, `createKeyPrefix`, `getKeyWithoutPrefix`, `isCluster`, `isSentinel`, `getMasterNodes`.
- Reorganized into **Properties** / **Methods**, fixed an `isntead` typo, and removed the duplicated *Keyv Redis Options* block.

### Tests
- Added `events.test.ts` validating the Hookified wiring (`on`/`once`/`emit`), error re-emission, the `connect` event, and the duplicate-listener fix.
- Removed an exact-duplicate `should set a value with ttl` test.
- Fixed duplicate/typo'd descriptions (`show throw` → `should throw`, `throw and error` → `throw an error`, `should no throw` → `should not throw`, a `deleteMany` test mislabeled `getMany`, and several non-unique names).
- Stopped passing a namespace argument to `iterator()` in the cluster and sentinel suites (the method uses the instance namespace) — behavior-preserving.

### Review checklist outcome
- ✅ API documented correctly in README
- ✅ Tests use faker, consistent with sibling adapters, using `test()` + uniform descriptions
- ✅ Namespace supported natively (`createKeyPrefix`/`getKeyWithoutPrefix`)
- ✅ `iterator()` requires no namespace argument
- ✅ Reads return `undefined`, never `null`
- ✅ Events use Hookified and are wired correctly (duplicate-listener bug fixed)
- ✅ Robust jsDocs on public functions and properties
- ✅ Private functions below public functions; properties above functions and under the constructor

### Verification
- `biome check` — clean (17 files)
- Standalone suites (a local Redis instance) — 162 tests passing
- Build (`tsdown`) and test-file typecheck — green
- Cluster/sentinel suites can't run in this environment (need multi-node infra) but collect cleanly and the edits are behavior-preserving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUqq6NSZbnumZh8ajot2En

---
_Generated by [Claude Code](https://claude.ai/code/session_01WUqq6NSZbnumZh8ajot2En)_