### PR TITLE
keyv - docs: fix README API accuracy and strengthen code/test review

### DIFF
--- a/core/keyv/README.md
+++ b/core/keyv/README.md
@@ -46,17 +46,17 @@ There are a few existing modules similar to Keyv, however Keyv is different beca
   - [.ttl](#ttl)
   - [.store](#store)
   - [.serialization](#serialization-1)
-  - [.compression](#compression)
-  - [.useKeyPrefix](#usekeyprefix)
-  - [.emitErrors](#emiterrors)
+  - [.compression](#compression-1)
+  - [.encryption](#encryption-1)
   - [.throwOnErrors](#throwonerrors)
+  - [.checkExpired](#checkexpired)
   - [.stats](#stats)
   - [.sanitize](#sanitize)
   - [Keyv Instance](#keyv-instance)
 	- [.set(key, value, [ttl])](#setkey-value-ttl)
 	- [.setMany(entries)](#setmanyentries)
-	- [.get(key, [options])](#getkey-options)
-	- [.getMany(keys, [options])](#getmanykeys-options)
+	- [.get(key)](#getkey)
+	- [.getMany(keys)](#getmanykeys)
   - [.getRaw(key)](#getrawkey)
   - [.getManyRaw(keys)](#getmanyrawkeys)
   - [.setRaw(key, value)](#setrawkey-value)
@@ -193,12 +193,11 @@ await cache.get('foo'); // 'cache'
 
 # Events
 
-Keyv is a custom `EventEmitter` and will emit an `'error'` event if there is an error.
-If there is no listener for the `'error'` event, an uncaught exception will be thrown.
-To disable the `'error'` event, pass `emitErrors: false` in the constructor options.
+Keyv is an `EventEmitter` (built on [hookified](https://github.com/jaredwray/hookified)) and will emit an `'error'` event if there is an error. By default an error is only thrown if there are no listeners attached to the `'error'` event. To always throw on errors regardless of listeners, enable the [`throwOnErrors`](#throwonerrors) option.
 
 ```js
-const keyv = new Keyv({ emitErrors: false });
+const keyv = new Keyv();
+keyv.on('error', err => console.log('Connection Error', err));
 ```
 
 In addition it will emit `clear` and `disconnect` events when the corresponding methods are called.
@@ -216,41 +215,46 @@ keyv.on('disconnect', handleDisconnect);
 
 # Hooks
 
-Keyv supports hooks for `get`, `set`, and `delete` methods. Hooks are useful for logging, debugging, and other custom functionality. Here is a list of all the hooks:
+Keyv supports hooks for all of its operations. Hooks are useful for logging, debugging, and other custom functionality. Each operation fires a `BEFORE_*` hook before it runs and an `AFTER_*` hook after it completes. Here is the list of all the hooks:
 
 ```
-PRE_GET
-POST_GET
-PRE_GET_RAW
-POST_GET_RAW
-PRE_GET_MANY
-POST_GET_MANY
-PRE_GET_MANY_RAW
-POST_GET_MANY_RAW
-PRE_SET
-POST_SET
-PRE_SET_RAW
-POST_SET_RAW
-PRE_SET_MANY_RAW
-POST_SET_MANY_RAW
-PRE_DELETE
-POST_DELETE
+BEFORE_GET            / AFTER_GET
+BEFORE_GET_MANY       / AFTER_GET_MANY
+BEFORE_GET_RAW        / AFTER_GET_RAW
+BEFORE_GET_MANY_RAW   / AFTER_GET_MANY_RAW
+BEFORE_SET            / AFTER_SET
+BEFORE_SET_RAW        / AFTER_SET_RAW
+BEFORE_SET_MANY       / AFTER_SET_MANY
+BEFORE_SET_MANY_RAW   / AFTER_SET_MANY_RAW
+BEFORE_DELETE         / AFTER_DELETE
+BEFORE_DELETE_MANY    / AFTER_DELETE_MANY
+BEFORE_HAS            / AFTER_HAS
+BEFORE_HAS_MANY       / AFTER_HAS_MANY
+BEFORE_CLEAR          / AFTER_CLEAR
+BEFORE_DISCONNECT     / AFTER_DISCONNECT
 ```
 
-You can access this by importing `KeyvHooks` from the main Keyv package.
+> The older `PRE_*` / `POST_*` hook names (e.g. `PRE_GET`, `POST_SET`) are deprecated aliases that still fire for backward compatibility. Prefer the `BEFORE_*` / `AFTER_*` names going forward.
+
+You can access these by importing `KeyvHooks` from the main Keyv package and registering a handler with `onHook()`:
 
 ```js
 import Keyv, { KeyvHooks } from 'keyv';
+
+const keyv = new Keyv();
+keyv.onHook(KeyvHooks.BEFORE_SET, (data) => {
+  console.log(`Setting key ${data.key} to ${data.value}`);
+});
 ```
 
 ## Get Hooks
 
-The `POST_GET` and `POST_GET_RAW` hooks fire on both cache hits and misses. When a cache miss occurs (key doesn't exist or is expired), the hooks receive `undefined` as the value.
+The `AFTER_GET` and `AFTER_GET_RAW` hooks fire on both cache hits and misses. When a cache miss occurs (key doesn't exist or is expired), the hook receives `undefined` as the value.
 
 ```js
-// POST_GET hook - fires on both hits and misses
+// AFTER_GET hook - fires on both hits and misses
 const keyv = new Keyv();
-keyv.hooks.addHandler(KeyvHooks.POST_GET, (data) => {
+keyv.onHook(KeyvHooks.AFTER_GET, (data) => {
   if (data.value === undefined) {
     console.log(`Cache miss for key: ${data.key}`);
   } else {
@@ -263,9 +267,9 @@ await keyv.get('missing-key');  // Logs cache miss with undefined
 ```
 
 ```js
-// POST_GET_RAW hook - same behavior as POST_GET
+// AFTER_GET_RAW hook - same behavior as AFTER_GET
 const keyv = new Keyv();
-keyv.hooks.addHandler(KeyvHooks.POST_GET_RAW, (data) => {
+keyv.onHook(KeyvHooks.AFTER_GET_RAW, (data) => {
   console.log(`Key: ${data.key}, Value:`, data.value);
 });
 
@@ -275,31 +279,31 @@ await keyv.getRaw('foo'); // Logs with value or undefined
 ## Set Hooks
 
 ```js
-//PRE_SET hook
+// BEFORE_SET hook
 const keyv = new Keyv();
-keyv.hooks.addHandler(KeyvHooks.PRE_SET, (data) => console.log(`Setting key ${data.key} to ${data.value}`));
+keyv.onHook(KeyvHooks.BEFORE_SET, (data) => console.log(`Setting key ${data.key} to ${data.value}`));
 
-//POST_SET hook
+// AFTER_SET hook
 const keyv = new Keyv();
-keyv.hooks.addHandler(KeyvHooks.POST_SET, ({key, value}) => console.log(`Set key ${key} to ${value}`));
+keyv.onHook(KeyvHooks.AFTER_SET, ({ key, value }) => console.log(`Set key ${key} to ${value}`));
 ```
 
-In these examples you can also manipulate the value before it is set. For example, you could add a prefix to all keys.
+In the `BEFORE_SET` hook you can also manipulate the value before it is set. For example, you could add a prefix to all keys.
 
 ```js
 const keyv = new Keyv();
-keyv.hooks.addHandler(KeyvHooks.PRE_SET, (data) => {
+keyv.onHook(KeyvHooks.BEFORE_SET, (data) => {
   console.log(`Manipulating key ${data.key} and ${data.value}`);
   data.key = `prefix-${data.key}`;
   data.value = `prefix-${data.value}`;
 });
 ```
 
-Now this key will have prefix- added to it before it is set.
+Now this key will have `prefix-` added to it before it is set.
 
 ## Delete Hooks
 
-In `PRE_DELETE` and `POST_DELETE` hooks, the value could be a single item or an `Array`. This is based on the fact that `delete` can accept a single key or an `Array` of keys.
+In the `BEFORE_DELETE` and `AFTER_DELETE` hooks, the value could be a single item or an `Array`. This is based on the fact that `delete` can accept a single key or an `Array` of keys.
 
 
 # Serialization
@@ -353,13 +357,13 @@ const keyv = new Keyv({ serialization: false });
 
 ## Pipeline
 
-When serialization and/or compression are configured, Keyv applies them in this order:
+When serialization, compression, and/or encryption are configured, Keyv applies them in this order:
 
-**On set:** serialize (optional) → compress (optional) → store
+**On set:** serialize → compress (optional) → encrypt (optional) → store
 
-**On get:** store → decompress (optional) → parse (optional) → value
+**On get:** store → decrypt (optional) → decompress (optional) → parse → value
 
-If compression is configured without a serializer, Keyv will use `JSON.stringify`/`JSON.parse` as a minimum fallback since compression adapters require string input.
+Compression and encryption operate on the serialized string, so they only run when a serializer is configured. The built-in `KeyvJsonSerializer` is enabled by default, so this works out of the box. If you disable serialization with `serialization: false`, values are passed through to the store as-is and compression/encryption are skipped.
 
 # Official Storage Adapters
 
@@ -518,7 +522,7 @@ keyvCompressionTests(test, new KeyvGzip());
 
 # Encryption
 
-Keyv provides a `KeyvEncryptionAdapter` interface for encryption support. This interface is available for custom implementations but is not yet wired into the core pipeline.
+Keyv supports pluggable encryption of stored values via the `KeyvEncryptionAdapter` interface. Pass an adapter with `encrypt` and `decrypt` methods using the `encryption` option (or set the [`.encryption`](#encryption-1) property). Encryption runs on the serialized (and optionally compressed) value, so it requires a serializer — the built-in `KeyvJsonSerializer` is enabled by default.
 
 ```typescript
 interface KeyvEncryptionAdapter {
@@ -527,9 +531,22 @@ interface KeyvEncryptionAdapter {
 }
 ```
 
+```js
+import Keyv from 'keyv';
+
+const encryption = {
+  encrypt: async (data) => Buffer.from(data).toString('base64'),
+  decrypt: async (data) => Buffer.from(data, 'base64').toString('utf8'),
+};
+
+const keyv = new Keyv({ encryption });
+await keyv.set('foo', 'bar'); // value is encrypted at rest
+await keyv.get('foo'); // 'bar'
+```
+
 # Capability Detection
 
-Keyv exports helper functions to check whether an object implements the expected interface for a Keyv instance, storage adapter, compression adapter, serialization adapter, or encryption adapter. Each function returns an object with boolean flags for every capability, plus a top-level boolean indicating whether the object fully satisfies the interface.
+Keyv exports helper functions to check whether an object implements the expected interface for a Keyv instance, storage adapter, compression adapter, serialization adapter, or encryption adapter. Each function returns an object with a top-level `compatible` boolean (whether the object fully satisfies the interface) plus a `methods` record describing every method it looked for.
 
 ```ts
 import {
@@ -538,43 +555,47 @@ import {
   detectKeyvCompression,
   detectKeyvSerialization,
   detectKeyvEncryption,
-  detectCapabilities,
 } from 'keyv';
 ```
 
+Every entry in the `methods` record has the shape `{ exists: boolean, methodType: "sync" | "async" | "none" }`.
+
 ## detectKeyv(obj)
 
-Returns a `KeyvCapability` with a boolean for each Keyv method/property. The `keyv` flag is `true` only when **all** capabilities are present.
+Returns a `KeyvCapability`: `{ compatible, methods, properties }`. `compatible` is `true` only when **all** Keyv methods and properties are present.
 
 ```ts
 import Keyv, { detectKeyv } from 'keyv';
 
-detectKeyv(new Keyv());
-// { keyv: true, get: true, set: true, delete: true, clear: true, has: true,
-//   getMany: true, setMany: true, deleteMany: true, hasMany: true,
-//   disconnect: true, getRaw: true, getManyRaw: true, setRaw: true,
-//   setManyRaw: true, hooks: true, stats: true, iterator: true }
+const result = detectKeyv(new Keyv());
+result.compatible;              // true — all capabilities present
+result.methods.get.exists;      // true
+result.methods.get.methodType;  // "async"
+result.properties.hooks;        // true
+result.properties.stats;        // true
 
-detectKeyv(new Map());
-// { keyv: false, get: true, set: true, ... }
+const partial = detectKeyv(new Map());
+partial.compatible;             // false — missing getMany, setMany, hooks, stats, etc.
+partial.methods.get.exists;     // true
 ```
 
 ## detectKeyvStorage(obj)
 
-Returns a `KeyvStorageCapability`. The `keyvStorage` flag is `true` when the object has `get`, `set`, `delete`, `clear`, `has`, `setMany`, `deleteMany`, and `hasMany`.
+Returns a `KeyvStorageCapability`: `{ compatible, store, methods }`. `compatible` is `true` when the object is a usable storage adapter, and `store` reports the detected kind:
 
-The result also includes:
-- **`mapLike`** — `true` when the object has synchronous `get`, `set`, `delete`, `has`, `entries`, and `keys` methods (i.e. it behaves like a `Map`)
-- **`methodTypes`** — a record mapping each method name to `"sync"`, `"async"`, or `"none"` (not present)
+- **`"keyvStorage"`** — implements the full async storage adapter interface (`get`, `set`, `delete`, `clear`, `has`, `setMany`, `deleteMany`, `hasMany`, all async)
+- **`"mapLike"`** — has synchronous `get`, `set`, `delete`, and `has` (i.e. it behaves like a `Map`)
+- **`"asyncMap"`** — has at least async `get`, `set`, `delete`, and `clear`
+- **`"none"`** — not a usable store
 
 ```ts
 import { detectKeyvStorage } from 'keyv';
 
 // Map-like object
-const result = detectKeyvStorage(new Map());
-result.mapLike; // true
-result.methodTypes.get; // "sync"
-result.methodTypes.set; // "sync"
+const map = detectKeyvStorage(new Map());
+map.compatible;              // true
+map.store;                   // "mapLike"
+map.methods.get.methodType;  // "sync"
 
 // Async storage adapter
 const adapter = {
@@ -583,58 +604,48 @@ const adapter = {
   deleteMany: async () => {}, hasMany: async () => {},
 };
 const adapterResult = detectKeyvStorage(adapter);
-adapterResult.keyvStorage; // true
-adapterResult.mapLike; // false
-adapterResult.methodTypes.get; // "async"
+adapterResult.compatible;             // true
+adapterResult.store;                  // "keyvStorage"
+adapterResult.methods.get.methodType; // "async"
 ```
 
 ## detectKeyvCompression(obj)
 
-Returns a `KeyvCompressionCapability`. The `keyvCompression` flag is `true` when both `compress` and `decompress` methods are present.
+Returns a `KeyvCompressionCapability`: `{ compatible, methods }`. `compatible` is `true` when both `compress` and `decompress` methods are present.
 
 ```ts
 import { detectKeyvCompression } from 'keyv';
 
-detectKeyvCompression({ compress: (d) => d, decompress: (d) => d });
-// { keyvCompression: true, compress: true, decompress: true }
+const result = detectKeyvCompression({ compress: (d) => d, decompress: (d) => d });
+result.compatible;                // true
+result.methods.compress.exists;   // true
+result.methods.decompress.exists; // true
 ```
 
 ## detectKeyvSerialization(obj)
 
-Returns a `KeyvSerializationCapability`. The `keyvSerialization` flag is `true` when both `stringify` and `parse` methods are present.
+Returns a `KeyvSerializationCapability`: `{ compatible, methods }`. `compatible` is `true` when both `stringify` and `parse` methods are present.
 
 ```ts
 import { detectKeyvSerialization } from 'keyv';
 
-detectKeyvSerialization(JSON);
-// { keyvSerialization: true, stringify: true, parse: true }
+const result = detectKeyvSerialization(JSON);
+result.compatible;               // true
+result.methods.stringify.exists; // true
+result.methods.parse.exists;     // true
 ```
 
 ## detectKeyvEncryption(obj)
 
-Returns a `KeyvEncryptionCapability`. The `keyvEncryption` flag is `true` when both `encrypt` and `decrypt` methods are present.
+Returns a `KeyvEncryptionCapability`: `{ compatible, methods }`. `compatible` is `true` when both `encrypt` and `decrypt` methods are present.
 
 ```ts
 import { detectKeyvEncryption } from 'keyv';
 
-detectKeyvEncryption({ encrypt: (d) => d, decrypt: (d) => d });
-// { keyvEncryption: true, encrypt: true, decrypt: true }
-```
-
-## detectCapabilities(obj, spec)
-
-A generic helper for building your own capability checks. Accepts a `CapabilitySpec` describing which methods and properties to look for, which are required, and the name of the composite boolean key.
-
-```ts
-import { detectCapabilities } from 'keyv';
-
-const result = detectCapabilities(myObject, {
-  methods: ['read', 'write'],
-  properties: ['name'],
-  requiredKeys: ['read', 'write', 'name'],
-  compositeKey: 'isValid',
-});
-// { isValid: true/false, read: true/false, write: true/false, name: true/false }
+const result = detectKeyvEncryption({ encrypt: (d) => d, decrypt: (d) => d });
+result.compatible;              // true
+result.methods.encrypt.exists;  // true
+result.methods.decrypt.exists;  // true
 ```
 
 # API
@@ -700,6 +711,41 @@ Default: `new Map()`
 
 The storage adapter instance to be used by Keyv.
 
+## options.stats
+
+Type: `Boolean`<br />
+Default: `false`
+
+Enable statistics tracking (hits, misses, sets, deletes, errors). See [.stats](#stats) for details.
+
+## options.throwOnErrors
+
+Type: `Boolean`<br />
+Default: `false`
+
+Throw on all errors instead of only when there are no `'error'` listeners. See [.throwOnErrors](#throwonerrors) for details.
+
+## options.sanitize
+
+Type: `KeyvSanitizeOptions`<br />
+Default: `undefined`
+
+Enable sanitization of keys and namespaces by stripping dangerous patterns. See [.sanitize](#sanitize) for details.
+
+## options.encryption
+
+Type: `KeyvEncryptionAdapter`<br />
+Default: `undefined`
+
+Encryption adapter used to encrypt and decrypt stored values. See [Encryption](#encryption) for details.
+
+## options.checkExpired
+
+Type: `Boolean`<br />
+Default: `false`
+
+When `true`, Keyv checks expiry at its own layer on `get`/`getMany`/`has`/`hasMany` instead of trusting the storage adapter. See [.checkExpired](#checkexpired) for details.
+
 # Keyv Instance
 
 Keys must always be strings. Values can be of any type.
@@ -716,13 +762,13 @@ Returns a promise which resolves to `true`.
 
 Set multiple values using `KeyvEntry<Value>` objects (`{ key: string, value: Value, ttl?: number }`). The `Value` type is inferred from the entries provided.
 
-## .get(key, [options])
+## .get(key)
 
-Returns a promise which resolves to the retrieved value.
+Returns a promise which resolves to the retrieved value, or `undefined` if the key does not exist or is expired. If an array of keys is passed it delegates to `.getMany()` and resolves to an array of values.
 
-## .getMany(keys, [options])
+## .getMany(keys)
 
-Returns a promise which resolves to an array of retrieved values.
+Returns a promise which resolves to an array of retrieved values, with `undefined` for keys that do not exist or are expired.
 
 ## .getRaw(key)
 
@@ -833,7 +879,7 @@ for await (const [key, value] of keyv.iterator()) {
 The iterator works with any storage backend:
 - **Map stores**: iterates using the built-in `Symbol.iterator`
 - **Storage adapters**: delegates to the adapter's `iterator()` method (e.g., Redis SCAN, SQL cursor)
-- **Unsupported stores**: emits an `error` event if the store does not support iteration
+- **Unsupported stores**: yields nothing if the store does not support iteration
 
 # API - Properties
 
@@ -916,48 +962,33 @@ keyv.compression = new KeyvGzip();
 console.log(keyv.compression); // KeyvGzip
 ```
 
-## .useKeyPrefix
+## .encryption
 
-Type: `Boolean`<br />
-Default: `true`
+Type: `KeyvEncryptionAdapter`<br />
+Default: `undefined`
 
-If set to `true` Keyv will prefix all keys with the namespace. This is useful if you want to avoid collisions with other data in your storage.
+The encryption adapter used to encrypt and decrypt stored values. If `undefined` (default) values are not encrypted. See [Encryption](#encryption) for more details.
 
 ```js
-const keyv = new Keyv({ useKeyPrefix: false });
-console.log(keyv.useKeyPrefix); // false
-keyv.useKeyPrefix = true;
-console.log(keyv.useKeyPrefix); // true
+const keyv = new Keyv();
+console.log(keyv.encryption); // undefined
+keyv.encryption = {
+  encrypt: async (data) => Buffer.from(data).toString('base64'),
+  decrypt: async (data) => Buffer.from(data, 'base64').toString('utf8'),
+};
+console.log(keyv.encryption); // the encryption adapter
 ```
 
-With many of the storage adapters you will also need to set the `namespace` option to `undefined` to have it work correctly. This is because in `v5` we started the transition to having the storage adapter handle the namespacing and `Keyv` will no longer handle it internally via KeyPrefixing. Here is an example of doing ith with `KeyvSqlite`:
-
-```js
-import Keyv from 'keyv';
-import KeyvSqlite from '@keyv/sqlite';
-
-const store = new KeyvSqlite('sqlite://path/to/database.sqlite');
-const keyv = new Keyv({ store });
-keyv.useKeyPrefix = false; // disable key prefixing
-store.namespace = undefined; // disable namespacing in the storage adapter
-
-await keyv.set('foo', 'bar'); // true
-await keyv.get('foo'); // 'bar'
-await keyv.clear();
-```
-
-## .emitErrors
+## .checkExpired
 
 Type: `Boolean`<br />
-Default: `true`
+Default: `false`
 
-If set to `true`, Keyv will emit an `'error'` event when an error occurs. Set to `false` to suppress error events.
+A read-only property (configured via the `checkExpired` constructor option). When `true`, Keyv checks expiry at its own layer on `get`, `getMany`, `has`, and `hasMany`, deleting any expired entries it encounters. When `false` (default) it trusts the storage adapter to handle expiry.
 
 ```js
-const keyv = new Keyv({ emitErrors: false });
-console.log(keyv.emitErrors); // false
-keyv.emitErrors = true;
-console.log(keyv.emitErrors); // true
+const keyv = new Keyv({ checkExpired: true });
+console.log(keyv.checkExpired); // true
 ```
 
 ## .throwOnErrors
@@ -1060,10 +1091,12 @@ const stats = new KeyvStats({ enabled: true, maxEntries: 500, emitter: keyv });
 ```
 
 ## .sanitize
-Type: `boolean | KeyvSanitizeOptions`<br />
-Default: `false`
+Type: `KeyvSanitize` (configured via the `sanitize` option: `KeyvSanitizeOptions`)<br />
+Default: disabled
 
-Detects and strips dangerous patterns from keys and namespaces to protect against SQL injection, MongoDB operator injection, path traversal, and control character attacks. Harmless characters like quotes, slashes, and dollar signs pass through unchanged — only dangerous *patterns* are stripped.
+The `.sanitize` property is a `KeyvSanitize` adapter. It is configured through the `sanitize` constructor option (`true`, or a `KeyvSanitizeOptions` object) and disabled by default.
+
+It detects and strips dangerous patterns from keys and namespaces to protect against SQL injection, MongoDB operator injection, path traversal, and control character attacks. Harmless characters like quotes, slashes, and dollar signs pass through unchanged — only dangerous *patterns* are stripped.
 
 Results are cached in an LRU cache (10,000 entries) for fast repeated lookups.
 
@@ -1118,11 +1151,16 @@ const keyv = new Keyv({
 });
 ```
 
-Change at runtime:
+Change at runtime by updating the options on the existing adapter, or by replacing it:
 ```js
-keyv.sanitize = false; // disable
-keyv.sanitize = true;  // enable all
-keyv.sanitize = { keys: { sql: true, mongo: false } }; // granular
+import { KeyvSanitize } from 'keyv';
+
+// Update options on the existing adapter
+keyv.sanitize.updateOptions({ keys: true, namespace: true });   // enable all
+keyv.sanitize.updateOptions({ keys: { sql: true, mongo: false } }); // granular
+
+// Or replace the adapter entirely
+keyv.sanitize = new KeyvSanitize({ keys: true, namespace: true });
 ```
 
 Sanitization is applied to all key-accepting methods: `get`, `set`, `delete`, `has`, `getMany`, `setMany`, `deleteMany`, `hasMany`, `getRaw`, `getManyRaw`, `setRaw`, and `setManyRaw`. Namespace sanitization is applied at construction and when the `namespace` setter is used.

--- a/core/keyv/src/keyv.ts
+++ b/core/keyv/src/keyv.ts
@@ -35,6 +35,52 @@ import {
 // biome-ignore lint/suspicious/noExplicitAny: type format
 export class Keyv<GenericValue = any> extends Hookified {
 	/**
+	 * Keyv Constructor
+	 * @param {KeyvStorageAdapter | KeyvOptions | Map<any, any> | any} store  to be provided or just the options
+	 * @param {Omit<KeyvOptions, 'store'>} [options] if you provide the store you can then provide the Keyv Options
+	 */
+	constructor(
+		store?: KeyvStorageAdapter | KeyvOptions | KeyvMapAny,
+		options?: Omit<KeyvOptions, "store">,
+	);
+	/**
+	 * Keyv Constructor
+	 * @param {KeyvOptions} options to be provided
+	 */
+	constructor(options?: KeyvOptions);
+	/**
+	 * Keyv Constructor
+	 * @param {KeyvStorageAdapter | KeyvOptions} store
+	 * @param {Omit<KeyvOptions, 'store'>} [options] if you provide the store you can then provide the Keyv Options
+	 */
+	constructor(store?: KeyvStorageAdapter | KeyvOptions, options?: Omit<KeyvOptions, "store">) {
+		const mergedOptions = Keyv.resolveOptions(store, options);
+
+		super({
+			throwOnHookError: false,
+			throwOnEmptyListeners: true,
+			throwOnEmitError: mergedOptions.throwOnErrors ?? false,
+		});
+
+		this.deprecatedHooks = buildDeprecatedHooks();
+		this._compression = mergedOptions.compression;
+		this._encryption = mergedOptions.encryption;
+		this.initSerialization(mergedOptions);
+		this.initSanitize(mergedOptions);
+		this.initNamespace(mergedOptions.namespace);
+		this.initStats(mergedOptions);
+
+		if (mergedOptions.store) {
+			this.setStore(mergedOptions.store);
+		}
+
+		this.setTtl(mergedOptions.ttl);
+		this._checkExpired = mergedOptions.checkExpired ?? false;
+	}
+
+	// --- Properties ---
+
+	/**
 	 * Stats manager for tracking cache operation metrics (hits, misses, sets, deletes, errors).
 	 * @default this is disabled.
 	 */
@@ -80,50 +126,6 @@ export class Keyv<GenericValue = any> extends Hookified {
 	 * When true, Keyv checks expiry at its layer on get/getMany/has/hasMany.
 	 */
 	private _checkExpired = false;
-
-	/**
-	 * Keyv Constructor
-	 * @param {KeyvStorageAdapter | KeyvOptions | Map<any, any> | any} store  to be provided or just the options
-	 * @param {Omit<KeyvOptions, 'store'>} [options] if you provide the store you can then provide the Keyv Options
-	 */
-	constructor(
-		store?: KeyvStorageAdapter | KeyvOptions | KeyvMapAny,
-		options?: Omit<KeyvOptions, "store">,
-	);
-	/**
-	 * Keyv Constructor
-	 * @param {KeyvOptions} options to be provided
-	 */
-	constructor(options?: KeyvOptions);
-	/**
-	 * Keyv Constructor
-	 * @param {KeyvStorageAdapter | KeyvOptions} store
-	 * @param {Omit<KeyvOptions, 'store'>} [options] if you provide the store you can then provide the Keyv Options
-	 */
-	constructor(store?: KeyvStorageAdapter | KeyvOptions, options?: Omit<KeyvOptions, "store">) {
-		const mergedOptions = Keyv.resolveOptions(store, options);
-
-		super({
-			throwOnHookError: false,
-			throwOnEmptyListeners: true,
-			throwOnEmitError: mergedOptions.throwOnErrors ?? false,
-		});
-
-		this.deprecatedHooks = buildDeprecatedHooks();
-		this._compression = mergedOptions.compression;
-		this._encryption = mergedOptions.encryption;
-		this.initSerialization(mergedOptions);
-		this.initSanitize(mergedOptions);
-		this.initNamespace(mergedOptions.namespace);
-		this.initStats(mergedOptions);
-
-		if (mergedOptions.store) {
-			this.setStore(mergedOptions.store);
-		}
-
-		this.setTtl(mergedOptions.ttl);
-		this._checkExpired = mergedOptions.checkExpired ?? false;
-	}
 
 	/**
 	 * Get the current storage adapter.
@@ -274,14 +276,6 @@ export class Keyv<GenericValue = any> extends Hookified {
 	}
 
 	/**
-	 * When true, Keyv checks expiry at its layer on get/getMany/has/hasMany.
-	 * When false (default), trusts the storage adapter.
-	 */
-	public get checkExpired(): boolean {
-		return this._checkExpired;
-	}
-
-	/**
 	 * Set the stats. When setting a new instance it will unsubscribe the old listeners
 	 * and subscribe the new instance.
 	 * @param {KeyvStats} stats The stats instance to set.
@@ -290,6 +284,15 @@ export class Keyv<GenericValue = any> extends Hookified {
 		this._stats.unsubscribe();
 		this._stats = stats;
 		this._stats.subscribe(this);
+	}
+
+	/**
+	 * Get whether Keyv checks expiry at its own layer on get/getMany/has/hasMany.
+	 * When false (default), it trusts the storage adapter to handle expiry.
+	 * @returns {boolean} `true` if Keyv checks expiry at its layer.
+	 */
+	public get checkExpired(): boolean {
+		return this._checkExpired;
 	}
 
 	/**
@@ -357,8 +360,12 @@ export class Keyv<GenericValue = any> extends Hookified {
 	}
 
 	/**
-	 * Get the Value of a Key
+	 * Get the value of a key. If an array of keys is passed in it will return an array of values
+	 * delegating to {@link getMany}.
 	 * @param {string | string[]} key passing in a single key or multiple as an array
+	 * @returns {Promise<Value | undefined | Array<Value | undefined>>} the value of the key, or
+	 * `undefined` if the key does not exist or is expired. When an array of keys is passed in it
+	 * returns an array of values in the same order (with `undefined` for missing keys).
 	 */
 	public async get<Value = GenericValue>(key: string): Promise<Value | undefined>;
 	public async get<Value = GenericValue>(key: string[]): Promise<Array<Value | undefined>>;
@@ -416,8 +423,10 @@ export class Keyv<GenericValue = any> extends Hookified {
 	}
 
 	/**
-	 * Get many values of keys
-	 * @param {string[]} keys passing in a single key or multiple as an array
+	 * Get many values for an array of keys.
+	 * @param {string[]} keys the keys to get
+	 * @returns {Promise<Array<Value | undefined>>} an array of values in the same order as the
+	 * keys, with `undefined` for keys that do not exist or are expired.
 	 */
 	public async getMany<Value = GenericValue>(keys: string[]): Promise<Array<Value | undefined>> {
 		keys = this._sanitize.enabled ? this._sanitize.cleanKeys(keys) : keys;
@@ -566,10 +575,10 @@ export class Keyv<GenericValue = any> extends Hookified {
 
 	/**
 	 * Set an item to the store
-	 * @param {string | Array<KeyvEntry<Value>>} key the key to use. If you pass in an array of KeyvEntry it will set many items
+	 * @param {string} key the key to use
 	 * @param {Value} value the value of the key
-	 * @param {number} [ttl] time to live in milliseconds
-	 * @returns {boolean} if it sets then it will return a true. On failure will return false.
+	 * @param {number} [ttl] time to live in milliseconds. Overrides the instance-level `ttl`.
+	 * @returns {Promise<boolean>} `true` if it was set successfully, `false` on failure.
 	 */
 	public async set<Value = GenericValue>(
 		key: string,
@@ -624,7 +633,7 @@ export class Keyv<GenericValue = any> extends Hookified {
 	/**
 	 * Set many items to the store
 	 * @param {Array<KeyvEntry<Value>>} entries the entries to set
-	 * @returns {boolean[]} will return an array of booleans if it sets then it will return a true. On failure will return false.
+	 * @returns {Promise<boolean[]>} an array of booleans, one per entry: `true` if set successfully, `false` on failure.
 	 */
 	public async setMany<Value = GenericValue>(entries: KeyvEntry<Value>[]): Promise<boolean[]> {
 		entries = entries.map((e) => ({
@@ -688,7 +697,7 @@ export class Keyv<GenericValue = any> extends Hookified {
 	 * The store-level TTL is derived automatically from `value.expires`.
 	 * @param {string} key the key to set
 	 * @param {KeyvValue<Value>} value the raw value envelope to store
-	 * @returns {boolean} if it sets then it will return a true. On failure will return false.
+	 * @returns {Promise<boolean>} `true` if it was set successfully, `false` on failure.
 	 */
 	public async setRaw<Value = GenericValue>(
 		key: string,
@@ -737,7 +746,7 @@ export class Keyv<GenericValue = any> extends Hookified {
 	 * Each entry's value should be a KeyvValue object with { value, expires? }. If you need TTL-based expiration,
 	 * set `expires` on each value directly. The store-level TTL is derived automatically from `value.expires`.
 	 * @param {KeyvEntry<KeyvValue<Value>>[]} entries the raw entries to set
-	 * @returns {boolean[]} will return an array of booleans if it sets then it will return a true. On failure will return false.
+	 * @returns {Promise<boolean[]>} an array of booleans, one per entry: `true` if set successfully, `false` on failure.
 	 */
 	public async setManyRaw<Value = GenericValue>(
 		entries: KeyvEntry<KeyvValue<Value>>[],
@@ -784,15 +793,16 @@ export class Keyv<GenericValue = any> extends Hookified {
 	}
 
 	/**
-	 * Delete an Entry
+	 * Delete an entry. If an array of keys is passed in it will delete many entries
+	 * delegating to {@link deleteMany}.
 	 * @param {string} key the key to be deleted
-	 * @returns {boolean} will return true if item is deleted. false if there is an error
+	 * @returns {Promise<boolean>} `true` if the item was deleted, `false` if there was an error.
 	 */
 	public async delete(key: string): Promise<boolean>;
 	/**
-	 * Delete multiple Entries
+	 * Delete multiple entries
 	 * @param {string[]} keys the keys to be deleted
-	 * @returns {boolean[]} will return array of booleans for each key
+	 * @returns {Promise<boolean[]>} an array of booleans indicating success for each key.
 	 */
 	public async delete(keys: string[]): Promise<boolean[]>;
 	public async delete(key: string | string[]): Promise<boolean | boolean[]> {
@@ -829,7 +839,7 @@ export class Keyv<GenericValue = any> extends Hookified {
 	/**
 	 * Delete many items from the store
 	 * @param {string[]} keys the keys to be deleted
-	 * @returns {boolean[]} array of booleans indicating success for each key
+	 * @returns {Promise<boolean[]>} an array of booleans indicating success for each key.
 	 */
 	public async deleteMany(keys: string[]): Promise<boolean[]> {
 		/* v8 ignore next -- @preserve */
@@ -861,9 +871,11 @@ export class Keyv<GenericValue = any> extends Hookified {
 	}
 
 	/**
-	 * Has a key.
-	 * @param {string} key the key to check
-	 * @returns {boolean} will return true if the key exists
+	 * Check if a key exists. If an array of keys is passed in it will check many keys
+	 * delegating to {@link hasMany}.
+	 * @param {string | string[]} key the key (or keys) to check
+	 * @returns {Promise<boolean | boolean[]>} `true` if the key exists, `false` if not. When an
+	 * array of keys is passed in it returns an array of booleans in the same order.
 	 */
 	public async has(key: string[]): Promise<boolean[]>;
 	public async has(key: string): Promise<boolean>;
@@ -902,7 +914,7 @@ export class Keyv<GenericValue = any> extends Hookified {
 	/**
 	 * Check if many keys exist
 	 * @param {string[]} keys the keys to check
-	 * @returns {boolean[]} will return an array of booleans if the keys exist
+	 * @returns {Promise<boolean[]>} an array of booleans in the same order as the keys, `true` if the key exists.
 	 */
 	public async hasMany(keys: string[]): Promise<boolean[]> {
 		keys = this._sanitize.enabled ? this._sanitize.cleanKeys(keys) : keys;
@@ -929,8 +941,9 @@ export class Keyv<GenericValue = any> extends Hookified {
 	}
 
 	/**
-	 * Clear the store
-	 * @returns {void}
+	 * Clear the store. If a namespace is set only entries in that namespace are removed.
+	 * Emits a `clear` event.
+	 * @returns {Promise<void>} resolves once the entries have been cleared.
 	 */
 	public async clear(): Promise<void> {
 		this.emit("clear");

--- a/core/keyv/test/get.test.ts
+++ b/core/keyv/test/get.test.ts
@@ -1,5 +1,4 @@
 import { faker } from "@faker-js/faker";
-import * as testRunner from "vitest";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import Keyv, { KeyvMemoryAdapter, type KeyvStorageAdapter } from "../src/index.js";
 import { createStore, delay } from "./test-utils.js";
@@ -85,109 +84,110 @@ describe("Keyv", async () => {
 	});
 });
 
-testRunner.it(".getRaw(key) returns the raw object instead of the value", async (t) => {
-	const keyv = new Keyv();
-	await keyv.set("foo", "bar");
-	const value = await keyv.get("foo");
-	const rawObject = await keyv.getRaw("foo");
-	t.expect(value).toBe("bar");
-	t.expect(rawObject?.value).toBe("bar");
+describe("getRaw", () => {
+	test(".getRaw(key) returns the raw object instead of the value", async () => {
+		const keyv = new Keyv();
+		await keyv.set("foo", "bar");
+		const value = await keyv.get("foo");
+		const rawObject = await keyv.getRaw("foo");
+		expect(value).toBe("bar");
+		expect(rawObject?.value).toBe("bar");
+	});
 });
 
-testRunner.it("Keyv should wait for the expired get", async (t) => {
-	t.expect.assertions(4);
-	const _store = new Map();
-	const store = {
-		get: async (key: string) => _store.get(key),
-		// biome-ignore lint/suspicious/noExplicitAny: type format
-		set(key: string, value: any) {
-			_store.set(key, value);
-		},
-		clear() {
-			_store.clear();
-		},
-		async delete(key: string) {
-			await new Promise<void>((resolve) => {
-				setTimeout(() => {
-					// Simulate database latency
-					resolve();
-				}, 20);
-			});
-			return _store.delete(key);
-		},
-	} as KeyvStorageAdapter;
+describe("get", () => {
+	test("Keyv should wait for the expired get", async () => {
+		expect.assertions(4);
+		const _store = new Map();
+		const store = {
+			get: async (key: string) => _store.get(key),
+			// biome-ignore lint/suspicious/noExplicitAny: type format
+			set(key: string, value: any) {
+				_store.set(key, value);
+			},
+			clear() {
+				_store.clear();
+			},
+			async delete(key: string) {
+				await new Promise<void>((resolve) => {
+					setTimeout(() => {
+						// Simulate database latency
+						resolve();
+					}, 20);
+				});
+				return _store.delete(key);
+			},
+		} as KeyvStorageAdapter;
 
-	const keyv = new Keyv({ store, checkExpired: true });
+		const keyv = new Keyv({ store, checkExpired: true });
 
-	// Round 1
-	const v1 = await keyv.get("foo");
-	t.expect(v1).toBeUndefined();
+		// Round 1
+		const v1 = await keyv.get("foo");
+		expect(v1).toBeUndefined();
 
-	await keyv.set("foo", "bar", 1000);
-	const v2 = await keyv.get("foo");
-	t.expect(v2).toBe("bar");
+		await keyv.set("foo", "bar", 1000);
+		const v2 = await keyv.get("foo");
+		expect(v2).toBe("bar");
 
-	await new Promise<void>((resolve) => {
-		setTimeout(() => {
-			// Wait for expired
-			resolve();
-		}, 1100);
+		await new Promise<void>((resolve) => {
+			setTimeout(() => {
+				// Wait for expired
+				resolve();
+			}, 1100);
+		});
+
+		// Round 2
+		const v3 = await keyv.get("foo");
+		expect(v3).toBeUndefined();
+
+		await keyv.set("foo", "bar", 1000);
+		await new Promise<void>((resolve) => {
+			setTimeout(() => {
+				// Simulate database latency
+				resolve();
+			}, 30);
+		});
+		const v4 = await keyv.get("foo");
+		expect(v4).toBe("bar");
 	});
 
-	// Round 2
-	const v3 = await keyv.get("foo");
-	t.expect(v3).toBeUndefined();
+	test("keyv.get([keys]) should return array values", async () => {
+		const keyv = new Keyv({ store: new Map() });
+		await keyv.set("foo", "bar");
+		await keyv.set("foo1", "bar1");
+		await keyv.set("foo2", "bar2");
+		const values = (await keyv.get<string>(["foo", "foo1", "foo2"])) as string[];
+		expect(Array.isArray(values)).toBeTruthy();
+		expect(values[0]).toBe("bar");
+		expect(values[1]).toBe("bar1");
+		expect(values[2]).toBe("bar2");
 
-	await keyv.set("foo", "bar", 1000);
-	await new Promise<void>((resolve) => {
-		setTimeout(() => {
-			// Simulate database latency
-			resolve();
-		}, 30);
+		const rawValues = await keyv.getManyRaw<string>(["foo", "foo1", "foo2"]);
+		expect(Array.isArray(rawValues)).toBeTruthy();
+		expect(rawValues[0]).toEqual({ value: "bar" });
+		expect(rawValues[1]).toEqual({ value: "bar1" });
+		expect(rawValues[2]).toEqual({ value: "bar2" });
 	});
-	const v4 = await keyv.get("foo");
-	t.expect(v4).toBe("bar");
-});
 
-testRunner.it("keyv.get([keys]) should return array values", async (t) => {
-	const keyv = new Keyv({ store: new Map() });
-	await keyv.set("foo", "bar");
-	await keyv.set("foo1", "bar1");
-	await keyv.set("foo2", "bar2");
-	const values = (await keyv.get<string>(["foo", "foo1", "foo2"])) as string[];
-	t.expect(Array.isArray(values)).toBeTruthy();
-	t.expect(values[0]).toBe("bar");
-	t.expect(values[1]).toBe("bar1");
-	t.expect(values[2]).toBe("bar2");
-
-	const rawValues = await keyv.getManyRaw<string>(["foo", "foo1", "foo2"]);
-	t.expect(Array.isArray(rawValues)).toBeTruthy();
-	t.expect(rawValues[0]).toEqual({ value: "bar" });
-	t.expect(rawValues[1]).toEqual({ value: "bar1" });
-	t.expect(rawValues[2]).toEqual({ value: "bar2" });
-});
-
-testRunner.it("keyv.get([keys]) should return array value undefined when expires", async (t) => {
-	const keyv = new Keyv({ store: new Map() });
-	await keyv.set("foo", "bar");
-	await keyv.set("foo1", "bar1", 1);
-	await keyv.set("foo2", "bar2");
-	await new Promise<void>((resolve) => {
-		setTimeout(() => {
-			// Simulate database latency
-			resolve();
-		}, 30);
+	test("keyv.get([keys]) should return array value undefined when expires", async () => {
+		const keyv = new Keyv({ store: new Map() });
+		await keyv.set("foo", "bar");
+		await keyv.set("foo1", "bar1", 1);
+		await keyv.set("foo2", "bar2");
+		await new Promise<void>((resolve) => {
+			setTimeout(() => {
+				// Simulate database latency
+				resolve();
+			}, 30);
+		});
+		const values = await keyv.get<string>(["foo", "foo1", "foo2"]);
+		expect(Array.isArray(values)).toBeTruthy();
+		expect(values[0]).toBe("bar");
+		expect(values[1]).toBeUndefined();
+		expect(values[2]).toBe("bar2");
 	});
-	const values = await keyv.get<string>(["foo", "foo1", "foo2"]);
-	t.expect(Array.isArray(values)).toBeTruthy();
-	t.expect(values[0]).toBe("bar");
-	t.expect(values[1]).toBeUndefined();
-	t.expect(values[2]).toBe("bar2");
-});
 
-testRunner.it(
-	"keyv.get([keys]) should return array value undefined when expires sqlite",
-	async (t) => {
+	test("keyv.get([keys]) should return array value undefined when expires sqlite", async () => {
 		const keyv = new Keyv({ store: new Map() });
 
 		const dataSet = [
@@ -213,14 +213,11 @@ testRunner.it(
 
 		await delay(30);
 		const values = await keyv.get<string>(dataSet.map((item) => item.key));
-		t.expect(Array.isArray(values)).toBeTruthy();
-		t.expect(values).toEqual([dataSet[0].value, undefined, dataSet[2].value]);
-	},
-);
+		expect(Array.isArray(values)).toBeTruthy();
+		expect(values).toEqual([dataSet[0].value, undefined, dataSet[2].value]);
+	});
 
-testRunner.it(
-	"keyv.get([keys]) should return empty array when expires with storage adapter",
-	async (t) => {
+	test("keyv.get([keys]) should return empty array when expires with storage adapter", async () => {
 		const keyv = new Keyv({ store: createStore() });
 		await keyv.clear();
 		await keyv.set("foo", "bar", 1);
@@ -232,100 +229,90 @@ testRunner.it(
 			}, 30);
 		});
 		const values = await keyv.get(["foo", "foo1", "foo2"]);
-		t.expect(Array.isArray(values)).toBeTruthy();
-		t.expect(values.length).toBe(3);
-	},
-);
+		expect(Array.isArray(values)).toBeTruthy();
+		expect(values.length).toBe(3);
+	});
 
-testRunner.it(
-	"keyv.getManyRaw([keys]) should return array raw values undefined with storage adapter",
-	async (t) => {
+	test("keyv.getManyRaw([keys]) should return array raw values undefined with storage adapter", async () => {
 		const keyv = new Keyv({ store: createStore() });
 		await keyv.clear();
 		const values = await keyv.getManyRaw<string>(["foo", "foo1"]);
-		t.expect(Array.isArray(values)).toBeTruthy();
-		t.expect(values[0]).toBeUndefined();
-		t.expect(values[1]).toBeUndefined();
-	},
-);
+		expect(Array.isArray(values)).toBeTruthy();
+		expect(values[0]).toBeUndefined();
+		expect(values[1]).toBeUndefined();
+	});
 
-testRunner.it("keyv.get([keys]) should return array values with undefined", async (t) => {
-	const keyv = new Keyv({ store: new Map() });
-	await keyv.set("foo", "bar");
-	await keyv.set("foo2", "bar2");
-	const values = await keyv.get<string>(["foo", "foo1", "foo2"]);
-	t.expect(Array.isArray(values)).toBeTruthy();
-	t.expect(values[0]).toBe("bar");
-	t.expect(values[1]).toBeUndefined();
-	t.expect(values[2]).toBe("bar2");
-});
+	test("keyv.get([keys]) should return array values with undefined", async () => {
+		const keyv = new Keyv({ store: new Map() });
+		await keyv.set("foo", "bar");
+		await keyv.set("foo2", "bar2");
+		const values = await keyv.get<string>(["foo", "foo1", "foo2"]);
+		expect(Array.isArray(values)).toBeTruthy();
+		expect(values[0]).toBe("bar");
+		expect(values[1]).toBeUndefined();
+		expect(values[2]).toBe("bar2");
+	});
 
-testRunner.it(
-	"keyv.get([keys]) should return array values with all undefined using storage adapter",
-	async (t) => {
+	test("keyv.get([keys]) should return array values with all undefined using storage adapter", async () => {
 		const keyv = new Keyv({ store: createStore() });
 		const values = await keyv.get<string>(["foo", "foo1", "foo2"]);
-		t.expect(Array.isArray(values)).toBeTruthy();
-		t.expect(values[0]).toBeUndefined();
-		t.expect(values[1]).toBeUndefined();
-		t.expect(values[2]).toBeUndefined();
-	},
-);
+		expect(Array.isArray(values)).toBeTruthy();
+		expect(values[0]).toBeUndefined();
+		expect(values[1]).toBeUndefined();
+		expect(values[2]).toBeUndefined();
+	});
 
-testRunner.it(
-	"keyv.get([keys]) should return undefined array for all no existent keys",
-	async (t) => {
+	test("keyv.get([keys]) should return undefined array for all no existent keys", async () => {
 		const keyv = new Keyv({ store: new Map() });
 		const values = await keyv.get(["foo", "foo1", "foo2"]);
-		t.expect(Array.isArray(values)).toBeTruthy();
-		t.expect(values).toEqual([undefined, undefined, undefined]);
-	},
-);
+		expect(Array.isArray(values)).toBeTruthy();
+		expect(values).toEqual([undefined, undefined, undefined]);
+	});
 
-testRunner.it("get keys, one key expired", async (t) => {
-	const keyv = new Keyv({ store: new Map() });
-	await keyv.set("foo", "bar", 10_000);
-	await keyv.set("fizz", "buzz", 100);
-	await keyv.set("ping", "pong", 10_000);
-	await snooze(150);
-	await keyv.get(["foo", "fizz", "ping"]);
-	t.expect(await keyv.get("fizz")).toBeUndefined();
-	t.expect(await keyv.get("foo")).toBe("bar");
-	t.expect(await keyv.get("ping")).toBe("pong");
+	test("get keys, one key expired", async () => {
+		const keyv = new Keyv({ store: new Map() });
+		await keyv.set("foo", "bar", 10_000);
+		await keyv.set("fizz", "buzz", 100);
+		await keyv.set("ping", "pong", 10_000);
+		await snooze(150);
+		await keyv.get(["foo", "fizz", "ping"]);
+		expect(await keyv.get("fizz")).toBeUndefined();
+		expect(await keyv.get("foo")).toBe("bar");
+		expect(await keyv.get("ping")).toBe("pong");
+	});
 });
 
 // --- Coverage tests for fallback paths ---
 
-testRunner.it("getMany should fallback to individual get when store has no getMany", async (t) => {
-	const store = createStore();
-	store.getMany = undefined as unknown as typeof store.getMany;
-	const keyv = new Keyv({ store });
-	await keyv.set("key1", "val1");
-	await keyv.set("key2", "val2");
-	const result = await keyv.getMany(["key1", "key2", "nonexistent"]);
-	t.expect(result).toEqual(["val1", "val2", undefined]);
-});
+describe("getMany", () => {
+	test("getMany should fallback to individual get when store has no getMany", async () => {
+		const store = createStore();
+		store.getMany = undefined as unknown as typeof store.getMany;
+		const keyv = new Keyv({ store });
+		await keyv.set("key1", "val1");
+		await keyv.set("key2", "val2");
+		const result = await keyv.getMany(["key1", "key2", "nonexistent"]);
+		expect(result).toEqual(["val1", "val2", undefined]);
+	});
 
-testRunner.it("getMany fallback should handle expired keys", async (t) => {
-	const store = createStore();
-	store.getMany = undefined as unknown as typeof store.getMany;
-	const keyv = new Keyv({ store, checkExpired: true });
-	await keyv.set("key1", "val1", 1);
-	await snooze(100);
-	const result = await keyv.getMany(["key1"]);
-	t.expect(result).toEqual([undefined]);
-});
+	test("getMany fallback should handle expired keys", async () => {
+		const store = createStore();
+		store.getMany = undefined as unknown as typeof store.getMany;
+		const keyv = new Keyv({ store, checkExpired: true });
+		await keyv.set("key1", "val1", 1);
+		await snooze(100);
+		const result = await keyv.getMany(["key1"]);
+		expect(result).toEqual([undefined]);
+	});
 
-testRunner.it(
-	"getManyRaw should fallback to individual get when store has no getMany",
-	async (t) => {
+	test("getManyRaw should fallback to individual get when store has no getMany", async () => {
 		const store = createStore();
 		store.getMany = undefined as unknown as typeof store.getMany;
 		const keyv = new Keyv({ store });
 		await keyv.set("key1", "val1");
 		const result = await keyv.getManyRaw(["key1", "nonexistent"]);
-		t.expect(result[0]).toBeDefined();
-		t.expect(result[0]?.value).toBe("val1");
-		t.expect(result[1]).toBeUndefined();
-	},
-);
+		expect(result[0]).toBeDefined();
+		expect(result[0]?.value).toBe("val1");
+		expect(result[1]).toBeUndefined();
+	});
+});

--- a/core/keyv/test/json-serializer.test.ts
+++ b/core/keyv/test/json-serializer.test.ts
@@ -1,5 +1,5 @@
 import { Buffer } from "node:buffer";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import { jsonSerializer, KeyvJsonSerializer } from "../src/json-serializer.js";
 
 afterEach(() => {
@@ -7,12 +7,12 @@ afterEach(() => {
 });
 
 describe("KeyvJsonSerializer", () => {
-	it("should be instantiable and have a default instance", () => {
+	test("should be instantiable and have a default instance", () => {
 		expect(new KeyvJsonSerializer()).toBeInstanceOf(KeyvJsonSerializer);
 		expect(jsonSerializer).toBeInstanceOf(KeyvJsonSerializer);
 	});
 
-	it("stringify and parse of primitive and complex types", () => {
+	test("stringify and parse of primitive and complex types", () => {
 		// String
 		expect(
 			jsonSerializer.parse<{ value: string }>(jsonSerializer.stringify({ value: "foo" })).value,
@@ -67,7 +67,7 @@ describe("KeyvJsonSerializer", () => {
 		expect(jsonSerializer.stringify(nullObj)).toBe('{"someKey":"value"}');
 	});
 
-	it("stringify and parse of Buffer and Uint8Array", () => {
+	test("stringify and parse of Buffer and Uint8Array", () => {
 		const buffer = Buffer.from("hello world", "utf8");
 		expect(jsonSerializer.stringify(buffer)).toBe(
 			JSON.stringify(`:base64:${buffer.toString("base64")}`),
@@ -97,7 +97,7 @@ describe("KeyvJsonSerializer", () => {
 		expect(parsed.encoded.toString()).toBe("hello world");
 	});
 
-	it("handles Buffer unavailable fallback with btoa/Uint8Array", () => {
+	test("handles Buffer unavailable fallback with btoa/Uint8Array", () => {
 		vi.stubGlobal("Buffer", undefined);
 		const bytes = new Uint8Array([104, 101, 108, 108, 111]);
 		expect(jsonSerializer.stringify(bytes)).toBe(JSON.stringify(":base64:aGVsbG8="));
@@ -109,7 +109,7 @@ describe("KeyvJsonSerializer", () => {
 		expect(Array.from(parsed.encoded)).toEqual([104, 101, 108, 108, 111]);
 	});
 
-	it("stringify and parse of BigInt values", () => {
+	test("stringify and parse of BigInt values", () => {
 		expect(
 			jsonSerializer.parse<{ value: bigint }>(
 				jsonSerializer.stringify({ value: BigInt("9223372036854775807") }),
@@ -131,7 +131,7 @@ describe("KeyvJsonSerializer", () => {
 		).toEqual([BigInt(1), BigInt(2), BigInt(3)]);
 	});
 
-	it("parse removes the first colon from non-base64 prefixed strings", () => {
+	test("parse removes the first colon from non-base64 prefixed strings", () => {
 		expect(
 			jsonSerializer.parse<{ simple: string }>(JSON.stringify({ simple: ":hello" })).simple,
 		).toBe("hello");
@@ -139,7 +139,7 @@ describe("KeyvJsonSerializer", () => {
 });
 
 describe("Colon-prefixed keys bug fix", () => {
-	it("should preserve object keys with leading colons at all nesting levels", () => {
+	test("should preserve object keys with leading colons at all nesting levels", () => {
 		const data = { my: { ":name": { one: "colon" } } };
 		expect(jsonSerializer.parse<typeof data>(jsonSerializer.stringify(data))).toEqual(data);
 		expect(
@@ -163,7 +163,7 @@ describe("Colon-prefixed keys bug fix", () => {
 		expect(jsonSerializer.parse<typeof nested>(jsonSerializer.stringify(nested))).toEqual(nested);
 	});
 
-	it("should handle colon-prefixed values, arrays, and base64-like strings", () => {
+	test("should handle colon-prefixed values, arrays, and base64-like strings", () => {
 		// Colon-prefixed values
 		const values = { normalKey: ":valueWithColon", anotherKey: "::doubleColonValue" };
 		expect(jsonSerializer.parse<typeof values>(jsonSerializer.stringify(values))).toEqual(values);

--- a/core/keyv/test/keyv-hooks.test.ts
+++ b/core/keyv/test/keyv-hooks.test.ts
@@ -1,265 +1,267 @@
 import { faker } from "@faker-js/faker";
-import * as test from "vitest";
+import { describe, expect, test } from "vitest";
 import Keyv, { KeyvHooks } from "../src/index.js";
 import { createStore, delay } from "./test-utils.js";
 
-test.it("BEFORE_SET hook", async (t) => {
-	const keyv = new Keyv();
-	keyv.addHook(KeyvHooks.BEFORE_SET, (data) => {
-		t.expect(data.key).toBe("foo");
-		t.expect(data.value).toBe("bar");
-	});
-	t.expect(keyv.getHooks(KeyvHooks.BEFORE_SET)?.length).toBe(1);
-	await keyv.set("foo", "bar");
-});
-
-test.it("BEFORE_SET hook with manipulation", async (t) => {
-	const keyId = faker.string.alphanumeric(10);
-	const newKeyId = `${keyId}1`;
-	const keyValue = faker.lorem.sentence();
-	const keyv = new Keyv();
-	keyv.addHook(KeyvHooks.BEFORE_SET, (data) => {
-		data.key = newKeyId;
-	});
-	await keyv.set(keyId, keyValue);
-	t.expect(await keyv.get(newKeyId)).toBe(keyValue);
-});
-
-test.it("AFTER_SET hook", async (t) => {
-	const keyv = new Keyv();
-	keyv.addHook(KeyvHooks.AFTER_SET, (data) => {
-		t.expect(data.key).toBe("foo");
-		t.expect(data.value).toBe('{"value":"bar"}');
-	});
-	await keyv.set("foo", "bar");
-});
-
-test.it("BEFORE_GET_MANY and manipulation", async () => {
-	const keyv = new Keyv();
-	keyv.addHook(KeyvHooks.BEFORE_GET_MANY, (data) => {
-		test.expect(data.keys[0]).toBe("foo");
-		test.expect(data.keys[1]).toBe("foo1");
-		data.keys[0] = "fake";
-	});
-	test.expect(keyv.getHooks(KeyvHooks.BEFORE_GET_MANY)?.length).toBe(1);
-	const values = await keyv.get(["foo", "foo1"]);
-	test.expect(values[0]).toBeUndefined();
-});
-
-test.it("AFTER_GET_MANY with and without getMany function", async () => {
-	// Without getMany
-	const keyv = new Keyv();
-	await keyv.set("foo", "bar");
-	await keyv.set("foo1", "bar1");
-	keyv.addHook(KeyvHooks.AFTER_GET_MANY, (data) => {
-		test.expect(data[0]).toBe("bar");
-		test.expect(data[1]).toBe("bar1");
-	});
-	await keyv.get(["foo", "foo1"]);
-
-	// With getMany and manipulation
-	const keyv2 = new Keyv({ store: createStore() });
-	await keyv2.set("foo", "bar");
-	await keyv2.set("foo1", "bar1");
-	keyv2.addHook(KeyvHooks.AFTER_GET_MANY, (data) => {
-		data[1] = "fake";
-	});
-	const values = await keyv2.get(["foo", "foo1"]);
-	test.expect(values[1]).toBe("fake");
-});
-
-test.it("BEFORE_DELETE and AFTER_DELETE hooks", async () => {
-	const keyv = new Keyv();
-	keyv.addHook(KeyvHooks.BEFORE_DELETE, (data) => {
-		test.expect(data.key).toBe("foo");
-	});
-	keyv.addHook(KeyvHooks.AFTER_DELETE, (data) => {
-		test.expect(data).toBeTruthy();
-	});
-	await keyv.set("foo", "bar");
-	await keyv.delete("foo");
-});
-
-test.it("BEFORE_GET hook", async () => {
-	const keyv = new Keyv();
-	keyv.addHook(KeyvHooks.BEFORE_GET, (data) => {
-		test.expect(data.key).toBe("foo");
-	});
-	await keyv.set("foo", "bar");
-	await keyv.get("foo");
-});
-
-test.it("AFTER_GET hook on hit, miss, and expired", async () => {
-	const keyv = new Keyv();
-	await keyv.set("foo", "bar");
-
-	// Hit
-	// biome-ignore lint/suspicious/noExplicitAny: test hook data
-	let hookData: any;
-	keyv.addHook(KeyvHooks.AFTER_GET, (data) => {
-		hookData = data;
-	});
-	await keyv.get("foo");
-	test.expect(hookData.key).toBe("foo");
-	test.expect(hookData.value).toEqual({ value: "bar" });
-
-	// Miss
-	await keyv.get("nonexistent");
-	test.expect(hookData.key).toBe("nonexistent");
-	test.expect(hookData.value).toBeUndefined();
-
-	// Expired
-	await keyv.set("exp", "val", 1);
-	await delay(10);
-	await keyv.get("exp");
-	test.expect(hookData.key).toBe("exp");
-	test.expect(hookData.value).toBeUndefined();
-});
-
-test.it("AFTER_GET_RAW hook on hit, miss, and expired", async () => {
-	const keyv = new Keyv();
-	await keyv.set("foo", "bar");
-
-	// biome-ignore lint/suspicious/noExplicitAny: test hook data
-	let hookData: any;
-	keyv.addHook(KeyvHooks.AFTER_GET_RAW, (data) => {
-		hookData = data;
+describe("hooks", () => {
+	test("BEFORE_SET hook", async () => {
+		const keyv = new Keyv();
+		keyv.addHook(KeyvHooks.BEFORE_SET, (data) => {
+			expect(data.key).toBe("foo");
+			expect(data.value).toBe("bar");
+		});
+		expect(keyv.getHooks(KeyvHooks.BEFORE_SET)?.length).toBe(1);
+		await keyv.set("foo", "bar");
 	});
 
-	await keyv.getRaw("foo");
-	test.expect(hookData.key).toBe("foo");
-	test.expect(hookData.value).toEqual({ value: "bar" });
+	test("BEFORE_SET hook with manipulation", async () => {
+		const keyId = faker.string.alphanumeric(10);
+		const newKeyId = `${keyId}1`;
+		const keyValue = faker.lorem.sentence();
+		const keyv = new Keyv();
+		keyv.addHook(KeyvHooks.BEFORE_SET, (data) => {
+			data.key = newKeyId;
+		});
+		await keyv.set(keyId, keyValue);
+		expect(await keyv.get(newKeyId)).toBe(keyValue);
+	});
 
-	await keyv.getRaw("nonexistent");
-	test.expect(hookData.value).toBeUndefined();
+	test("AFTER_SET hook", async () => {
+		const keyv = new Keyv();
+		keyv.addHook(KeyvHooks.AFTER_SET, (data) => {
+			expect(data.key).toBe("foo");
+			expect(data.value).toBe('{"value":"bar"}');
+		});
+		await keyv.set("foo", "bar");
+	});
 
-	await keyv.set("exp", "val", 1);
-	await delay(10);
-	await keyv.getRaw("exp");
-	test.expect(hookData.value).toBeUndefined();
-});
+	test("BEFORE_GET_MANY and manipulation", async () => {
+		const keyv = new Keyv();
+		keyv.addHook(KeyvHooks.BEFORE_GET_MANY, (data) => {
+			expect(data.keys[0]).toBe("foo");
+			expect(data.keys[1]).toBe("foo1");
+			data.keys[0] = "fake";
+		});
+		expect(keyv.getHooks(KeyvHooks.BEFORE_GET_MANY)?.length).toBe(1);
+		const values = await keyv.get(["foo", "foo1"]);
+		expect(values[0]).toBeUndefined();
+	});
 
-test.it("deprecated hooks (PRE_SET, POST_SET, PRE_GET, POST_DELETE) still fire", async (t) => {
-	const keyv = new Keyv();
-	keyv.on("warn", () => {});
-	const fired: string[] = [];
-	keyv.addHook(KeyvHooks.PRE_SET, () => {
-		fired.push("PRE_SET");
-	});
-	keyv.addHook(KeyvHooks.POST_SET, () => {
-		fired.push("POST_SET");
-	});
-	keyv.addHook(KeyvHooks.PRE_GET, () => {
-		fired.push("PRE_GET");
-	});
-	keyv.addHook(KeyvHooks.POST_DELETE, () => {
-		fired.push("POST_DELETE");
-	});
-	await keyv.set("foo", "bar");
-	await keyv.get("foo");
-	await keyv.delete("foo");
-	t.expect(fired).toEqual(["PRE_SET", "POST_SET", "PRE_GET", "POST_DELETE"]);
-});
+	test("AFTER_GET_MANY with and without getMany function", async () => {
+		// Without getMany
+		const keyv = new Keyv();
+		await keyv.set("foo", "bar");
+		await keyv.set("foo1", "bar1");
+		keyv.addHook(KeyvHooks.AFTER_GET_MANY, (data) => {
+			expect(data[0]).toBe("bar");
+			expect(data[1]).toBe("bar1");
+		});
+		await keyv.get(["foo", "foo1"]);
 
-test.it("BEFORE_SET_MANY and AFTER_SET_MANY hooks with manipulation", async () => {
-	const keyv = new Keyv();
-	keyv.addHook(KeyvHooks.BEFORE_SET_MANY, (data) => {
-		test.expect(data.entries).toHaveLength(2);
-		data.entries[0].value = "modified";
+		// With getMany and manipulation
+		const keyv2 = new Keyv({ store: createStore() });
+		await keyv2.set("foo", "bar");
+		await keyv2.set("foo1", "bar1");
+		keyv2.addHook(KeyvHooks.AFTER_GET_MANY, (data) => {
+			data[1] = "fake";
+		});
+		const values = await keyv2.get(["foo", "foo1"]);
+		expect(values[1]).toBe("fake");
 	});
-	keyv.addHook(KeyvHooks.AFTER_SET_MANY, (data) => {
-		test.expect(data.entries).toHaveLength(2);
-		test.expect(data.values).toEqual([true, true]);
-	});
-	await keyv.setMany([
-		{ key: "foo", value: "bar" },
-		{ key: "foo1", value: "bar1" },
-	]);
-	const values = await keyv.get(["foo", "foo1"]);
-	test.expect(values[0]).toBe("modified");
-	test.expect(values[1]).toBe("bar1");
-});
 
-test.it("BEFORE_DELETE_MANY, AFTER_DELETE_MANY, and legacy hooks for deleteMany", async (t) => {
-	const keyv = new Keyv();
-	const fired: string[] = [];
-	keyv.addHook(KeyvHooks.BEFORE_DELETE_MANY, (data) => {
-		test.expect(data.keys).toEqual(["foo", "foo1"]);
-		fired.push("BEFORE_DELETE_MANY");
+	test("BEFORE_DELETE and AFTER_DELETE hooks", async () => {
+		const keyv = new Keyv();
+		keyv.addHook(KeyvHooks.BEFORE_DELETE, (data) => {
+			expect(data.key).toBe("foo");
+		});
+		keyv.addHook(KeyvHooks.AFTER_DELETE, (data) => {
+			expect(data).toBeTruthy();
+		});
+		await keyv.set("foo", "bar");
+		await keyv.delete("foo");
 	});
-	keyv.addHook(KeyvHooks.AFTER_DELETE_MANY, (data) => {
-		test.expect(data.values).toEqual([true, true]);
-		fired.push("AFTER_DELETE_MANY");
-	});
-	keyv.addHook(KeyvHooks.BEFORE_DELETE, () => {
-		fired.push("BEFORE_DELETE");
-	});
-	keyv.addHook(KeyvHooks.AFTER_DELETE, () => {
-		fired.push("AFTER_DELETE");
-	});
-	await keyv.set("foo", "bar");
-	await keyv.set("foo1", "bar1");
-	await keyv.delete(["foo", "foo1"]);
-	t.expect(fired).toContain("BEFORE_DELETE_MANY");
-	t.expect(fired).toContain("AFTER_DELETE_MANY");
-	t.expect(fired).toContain("BEFORE_DELETE");
-	t.expect(fired).toContain("AFTER_DELETE");
-});
 
-test.it("BEFORE_CLEAR and AFTER_CLEAR hooks with namespace", async (t) => {
-	const keyv = new Keyv({ namespace: "test-ns" });
-	// biome-ignore lint/suspicious/noExplicitAny: test hook data
-	let beforeData: any;
-	// biome-ignore lint/suspicious/noExplicitAny: test hook data
-	let afterData: any;
-	let valueBeforeClear: string | undefined;
-	keyv.addHook(KeyvHooks.BEFORE_CLEAR, async (data) => {
-		beforeData = data;
-		valueBeforeClear = await keyv.get("foo");
+	test("BEFORE_GET hook", async () => {
+		const keyv = new Keyv();
+		keyv.addHook(KeyvHooks.BEFORE_GET, (data) => {
+			expect(data.key).toBe("foo");
+		});
+		await keyv.set("foo", "bar");
+		await keyv.get("foo");
 	});
-	keyv.addHook(KeyvHooks.AFTER_CLEAR, (data) => {
-		afterData = data;
-	});
-	await keyv.set("foo", "bar");
-	await keyv.clear();
-	t.expect(beforeData.namespace).toBe("test-ns");
-	t.expect(afterData.namespace).toBe("test-ns");
-	t.expect(valueBeforeClear).toBe("bar");
 
-	// Without namespace
-	const keyv2 = new Keyv();
-	// biome-ignore lint/suspicious/noExplicitAny: test hook data
-	let ns: any;
-	keyv2.addHook(KeyvHooks.BEFORE_CLEAR, (data) => {
-		ns = data.namespace;
-	});
-	await keyv2.clear();
-	t.expect(ns).toBeUndefined();
-});
+	test("AFTER_GET hook on hit, miss, and expired", async () => {
+		const keyv = new Keyv();
+		await keyv.set("foo", "bar");
 
-test.it("BEFORE_DISCONNECT and AFTER_DISCONNECT hooks with namespace", async (t) => {
-	const keyv = new Keyv({ namespace: "test-ns" });
-	// biome-ignore lint/suspicious/noExplicitAny: test hook data
-	let beforeData: any;
-	// biome-ignore lint/suspicious/noExplicitAny: test hook data
-	let afterData: any;
-	keyv.addHook(KeyvHooks.BEFORE_DISCONNECT, (data) => {
-		beforeData = data;
-	});
-	keyv.addHook(KeyvHooks.AFTER_DISCONNECT, (data) => {
-		afterData = data;
-	});
-	await keyv.disconnect();
-	t.expect(beforeData.namespace).toBe("test-ns");
-	t.expect(afterData.namespace).toBe("test-ns");
+		// Hit
+		// biome-ignore lint/suspicious/noExplicitAny: test hook data
+		let hookData: any;
+		keyv.addHook(KeyvHooks.AFTER_GET, (data) => {
+			hookData = data;
+		});
+		await keyv.get("foo");
+		expect(hookData.key).toBe("foo");
+		expect(hookData.value).toEqual({ value: "bar" });
 
-	// Without namespace
-	const keyv2 = new Keyv();
-	// biome-ignore lint/suspicious/noExplicitAny: test hook data
-	let ns: any;
-	keyv2.addHook(KeyvHooks.BEFORE_DISCONNECT, (data) => {
-		ns = data.namespace;
+		// Miss
+		await keyv.get("nonexistent");
+		expect(hookData.key).toBe("nonexistent");
+		expect(hookData.value).toBeUndefined();
+
+		// Expired
+		await keyv.set("exp", "val", 1);
+		await delay(10);
+		await keyv.get("exp");
+		expect(hookData.key).toBe("exp");
+		expect(hookData.value).toBeUndefined();
 	});
-	await keyv2.disconnect();
-	t.expect(ns).toBeUndefined();
+
+	test("AFTER_GET_RAW hook on hit, miss, and expired", async () => {
+		const keyv = new Keyv();
+		await keyv.set("foo", "bar");
+
+		// biome-ignore lint/suspicious/noExplicitAny: test hook data
+		let hookData: any;
+		keyv.addHook(KeyvHooks.AFTER_GET_RAW, (data) => {
+			hookData = data;
+		});
+
+		await keyv.getRaw("foo");
+		expect(hookData.key).toBe("foo");
+		expect(hookData.value).toEqual({ value: "bar" });
+
+		await keyv.getRaw("nonexistent");
+		expect(hookData.value).toBeUndefined();
+
+		await keyv.set("exp", "val", 1);
+		await delay(10);
+		await keyv.getRaw("exp");
+		expect(hookData.value).toBeUndefined();
+	});
+
+	test("deprecated hooks (PRE_SET, POST_SET, PRE_GET, POST_DELETE) still fire", async () => {
+		const keyv = new Keyv();
+		keyv.on("warn", () => {});
+		const fired: string[] = [];
+		keyv.addHook(KeyvHooks.PRE_SET, () => {
+			fired.push("PRE_SET");
+		});
+		keyv.addHook(KeyvHooks.POST_SET, () => {
+			fired.push("POST_SET");
+		});
+		keyv.addHook(KeyvHooks.PRE_GET, () => {
+			fired.push("PRE_GET");
+		});
+		keyv.addHook(KeyvHooks.POST_DELETE, () => {
+			fired.push("POST_DELETE");
+		});
+		await keyv.set("foo", "bar");
+		await keyv.get("foo");
+		await keyv.delete("foo");
+		expect(fired).toEqual(["PRE_SET", "POST_SET", "PRE_GET", "POST_DELETE"]);
+	});
+
+	test("BEFORE_SET_MANY and AFTER_SET_MANY hooks with manipulation", async () => {
+		const keyv = new Keyv();
+		keyv.addHook(KeyvHooks.BEFORE_SET_MANY, (data) => {
+			expect(data.entries).toHaveLength(2);
+			data.entries[0].value = "modified";
+		});
+		keyv.addHook(KeyvHooks.AFTER_SET_MANY, (data) => {
+			expect(data.entries).toHaveLength(2);
+			expect(data.values).toEqual([true, true]);
+		});
+		await keyv.setMany([
+			{ key: "foo", value: "bar" },
+			{ key: "foo1", value: "bar1" },
+		]);
+		const values = await keyv.get(["foo", "foo1"]);
+		expect(values[0]).toBe("modified");
+		expect(values[1]).toBe("bar1");
+	});
+
+	test("BEFORE_DELETE_MANY, AFTER_DELETE_MANY, and legacy hooks for deleteMany", async () => {
+		const keyv = new Keyv();
+		const fired: string[] = [];
+		keyv.addHook(KeyvHooks.BEFORE_DELETE_MANY, (data) => {
+			expect(data.keys).toEqual(["foo", "foo1"]);
+			fired.push("BEFORE_DELETE_MANY");
+		});
+		keyv.addHook(KeyvHooks.AFTER_DELETE_MANY, (data) => {
+			expect(data.values).toEqual([true, true]);
+			fired.push("AFTER_DELETE_MANY");
+		});
+		keyv.addHook(KeyvHooks.BEFORE_DELETE, () => {
+			fired.push("BEFORE_DELETE");
+		});
+		keyv.addHook(KeyvHooks.AFTER_DELETE, () => {
+			fired.push("AFTER_DELETE");
+		});
+		await keyv.set("foo", "bar");
+		await keyv.set("foo1", "bar1");
+		await keyv.delete(["foo", "foo1"]);
+		expect(fired).toContain("BEFORE_DELETE_MANY");
+		expect(fired).toContain("AFTER_DELETE_MANY");
+		expect(fired).toContain("BEFORE_DELETE");
+		expect(fired).toContain("AFTER_DELETE");
+	});
+
+	test("BEFORE_CLEAR and AFTER_CLEAR hooks with namespace", async () => {
+		const keyv = new Keyv({ namespace: "test-ns" });
+		// biome-ignore lint/suspicious/noExplicitAny: test hook data
+		let beforeData: any;
+		// biome-ignore lint/suspicious/noExplicitAny: test hook data
+		let afterData: any;
+		let valueBeforeClear: string | undefined;
+		keyv.addHook(KeyvHooks.BEFORE_CLEAR, async (data) => {
+			beforeData = data;
+			valueBeforeClear = await keyv.get("foo");
+		});
+		keyv.addHook(KeyvHooks.AFTER_CLEAR, (data) => {
+			afterData = data;
+		});
+		await keyv.set("foo", "bar");
+		await keyv.clear();
+		expect(beforeData.namespace).toBe("test-ns");
+		expect(afterData.namespace).toBe("test-ns");
+		expect(valueBeforeClear).toBe("bar");
+
+		// Without namespace
+		const keyv2 = new Keyv();
+		// biome-ignore lint/suspicious/noExplicitAny: test hook data
+		let ns: any;
+		keyv2.addHook(KeyvHooks.BEFORE_CLEAR, (data) => {
+			ns = data.namespace;
+		});
+		await keyv2.clear();
+		expect(ns).toBeUndefined();
+	});
+
+	test("BEFORE_DISCONNECT and AFTER_DISCONNECT hooks with namespace", async () => {
+		const keyv = new Keyv({ namespace: "test-ns" });
+		// biome-ignore lint/suspicious/noExplicitAny: test hook data
+		let beforeData: any;
+		// biome-ignore lint/suspicious/noExplicitAny: test hook data
+		let afterData: any;
+		keyv.addHook(KeyvHooks.BEFORE_DISCONNECT, (data) => {
+			beforeData = data;
+		});
+		keyv.addHook(KeyvHooks.AFTER_DISCONNECT, (data) => {
+			afterData = data;
+		});
+		await keyv.disconnect();
+		expect(beforeData.namespace).toBe("test-ns");
+		expect(afterData.namespace).toBe("test-ns");
+
+		// Without namespace
+		const keyv2 = new Keyv();
+		// biome-ignore lint/suspicious/noExplicitAny: test hook data
+		let ns: any;
+		keyv2.addHook(KeyvHooks.BEFORE_DISCONNECT, (data) => {
+			ns = data.namespace;
+		});
+		await keyv2.disconnect();
+		expect(ns).toBeUndefined();
+	});
 });

--- a/core/keyv/test/keyv-telemetry.test.ts
+++ b/core/keyv/test/keyv-telemetry.test.ts
@@ -1,356 +1,366 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import type { KeyvTelemetryEvent } from "../src/index.js";
 import { Keyv, KeyvEvents, KeyvMemoryAdapter } from "../src/index.js";
 
 describe("Keyv Telemetry Events", () => {
-	it("should emit stat:set on set()", async () => {
-		const keyv = new Keyv({ stats: true });
-		const listener = vi.fn();
-		keyv.on(KeyvEvents.STAT_SET, listener);
+	describe("single-key operations", () => {
+		test("should emit stat:set on set()", async () => {
+			const keyv = new Keyv({ stats: true });
+			const listener = vi.fn();
+			keyv.on(KeyvEvents.STAT_SET, listener);
 
-		await keyv.set("key1", "value1");
+			await keyv.set("key1", "value1");
 
-		expect(listener).toHaveBeenCalledOnce();
-		const payload = listener.mock.calls[0][0] as KeyvTelemetryEvent;
-		expect(payload.event).toBe("set");
-		expect(payload.key).toBe("key1");
-		expect(payload.timestamp).toBeTypeOf("number");
-	});
-
-	it("should emit stat:hit on get() cache hit", async () => {
-		const keyv = new Keyv({ stats: true });
-		const listener = vi.fn();
-		keyv.on(KeyvEvents.STAT_HIT, listener);
-
-		await keyv.set("key1", "value1");
-		await keyv.get("key1");
-
-		expect(listener).toHaveBeenCalledOnce();
-		const payload = listener.mock.calls[0][0] as KeyvTelemetryEvent;
-		expect(payload.event).toBe("hit");
-		expect(payload.key).toBe("key1");
-	});
-
-	it("should emit stat:miss on get() cache miss", async () => {
-		const keyv = new Keyv({ stats: true });
-		const listener = vi.fn();
-		keyv.on(KeyvEvents.STAT_MISS, listener);
-
-		await keyv.get("nonexistent");
-
-		expect(listener).toHaveBeenCalledOnce();
-		const payload = listener.mock.calls[0][0] as KeyvTelemetryEvent;
-		expect(payload.event).toBe("miss");
-		expect(payload.key).toBe("nonexistent");
-	});
-
-	it("should emit stat:miss on get() when data is expired", async () => {
-		const keyv = new Keyv({ stats: true });
-		const listener = vi.fn();
-		keyv.on(KeyvEvents.STAT_MISS, listener);
-
-		await keyv.set("key1", "value1", 1);
-		await new Promise((resolve) => {
-			setTimeout(resolve, 50);
+			expect(listener).toHaveBeenCalledOnce();
+			const payload = listener.mock.calls[0][0] as KeyvTelemetryEvent;
+			expect(payload.event).toBe("set");
+			expect(payload.key).toBe("key1");
+			expect(payload.timestamp).toBeTypeOf("number");
 		});
-		await keyv.get("key1");
 
-		expect(listener).toHaveBeenCalled();
-		const calls = listener.mock.calls.filter(
-			(call: KeyvTelemetryEvent[]) => call[0].key === "key1",
-		);
-		expect(calls.length).toBeGreaterThanOrEqual(1);
+		test("should emit stat:hit on get() cache hit", async () => {
+			const keyv = new Keyv({ stats: true });
+			const listener = vi.fn();
+			keyv.on(KeyvEvents.STAT_HIT, listener);
+
+			await keyv.set("key1", "value1");
+			await keyv.get("key1");
+
+			expect(listener).toHaveBeenCalledOnce();
+			const payload = listener.mock.calls[0][0] as KeyvTelemetryEvent;
+			expect(payload.event).toBe("hit");
+			expect(payload.key).toBe("key1");
+		});
+
+		test("should emit stat:miss on get() cache miss", async () => {
+			const keyv = new Keyv({ stats: true });
+			const listener = vi.fn();
+			keyv.on(KeyvEvents.STAT_MISS, listener);
+
+			await keyv.get("nonexistent");
+
+			expect(listener).toHaveBeenCalledOnce();
+			const payload = listener.mock.calls[0][0] as KeyvTelemetryEvent;
+			expect(payload.event).toBe("miss");
+			expect(payload.key).toBe("nonexistent");
+		});
+
+		test("should emit stat:miss on get() when data is expired", async () => {
+			const keyv = new Keyv({ stats: true });
+			const listener = vi.fn();
+			keyv.on(KeyvEvents.STAT_MISS, listener);
+
+			await keyv.set("key1", "value1", 1);
+			await new Promise((resolve) => {
+				setTimeout(resolve, 50);
+			});
+			await keyv.get("key1");
+
+			expect(listener).toHaveBeenCalled();
+			const calls = listener.mock.calls.filter(
+				(call: KeyvTelemetryEvent[]) => call[0].key === "key1",
+			);
+			expect(calls.length).toBeGreaterThanOrEqual(1);
+		});
+
+		test("should emit stat:delete on delete()", async () => {
+			const keyv = new Keyv({ stats: true });
+			const listener = vi.fn();
+			keyv.on(KeyvEvents.STAT_DELETE, listener);
+
+			await keyv.set("key1", "value1");
+			await keyv.delete("key1");
+
+			expect(listener).toHaveBeenCalledOnce();
+			const payload = listener.mock.calls[0][0] as KeyvTelemetryEvent;
+			expect(payload.event).toBe("delete");
+			expect(payload.key).toBe("key1");
+		});
+
+		test("should emit stat:hit on getRaw() cache hit", async () => {
+			const keyv = new Keyv({ stats: true });
+			const listener = vi.fn();
+			keyv.on(KeyvEvents.STAT_HIT, listener);
+
+			await keyv.set("key1", "value1");
+			await keyv.getRaw("key1");
+
+			expect(listener).toHaveBeenCalledOnce();
+			const payload = listener.mock.calls[0][0] as KeyvTelemetryEvent;
+			expect(payload.event).toBe("hit");
+			expect(payload.key).toBe("key1");
+		});
+
+		test("should emit stat:miss on getRaw() cache miss", async () => {
+			const keyv = new Keyv({ stats: true });
+			const listener = vi.fn();
+			keyv.on(KeyvEvents.STAT_MISS, listener);
+
+			await keyv.getRaw("nonexistent");
+
+			expect(listener).toHaveBeenCalledOnce();
+			const payload = listener.mock.calls[0][0] as KeyvTelemetryEvent;
+			expect(payload.event).toBe("miss");
+			expect(payload.key).toBe("nonexistent");
+		});
+
+		test("should emit stat:set on setRaw()", async () => {
+			const keyv = new Keyv({ stats: true });
+			const listener = vi.fn();
+			keyv.on(KeyvEvents.STAT_SET, listener);
+
+			await keyv.setRaw("key1", { value: "value1" });
+
+			expect(listener).toHaveBeenCalledOnce();
+			const payload = listener.mock.calls[0][0] as KeyvTelemetryEvent;
+			expect(payload.event).toBe("set");
+			expect(payload.key).toBe("key1");
+		});
 	});
 
-	it("should emit stat:delete on delete()", async () => {
-		const keyv = new Keyv({ stats: true });
-		const listener = vi.fn();
-		keyv.on(KeyvEvents.STAT_DELETE, listener);
+	describe("many-key operations", () => {
+		test("should emit per-key hit/miss on getMany()", async () => {
+			const keyv = new Keyv({ stats: true });
+			const hitListener = vi.fn();
+			const missListener = vi.fn();
+			keyv.on(KeyvEvents.STAT_HIT, hitListener);
+			keyv.on(KeyvEvents.STAT_MISS, missListener);
 
-		await keyv.set("key1", "value1");
-		await keyv.delete("key1");
+			await keyv.set("key1", "value1");
+			await keyv.set("key2", "value2");
+			// key3 does not exist
+			await keyv.get(["key1", "key2", "key3"]);
 
-		expect(listener).toHaveBeenCalledOnce();
-		const payload = listener.mock.calls[0][0] as KeyvTelemetryEvent;
-		expect(payload.event).toBe("delete");
-		expect(payload.key).toBe("key1");
+			expect(hitListener).toHaveBeenCalledTimes(2);
+			expect(missListener).toHaveBeenCalledTimes(1);
+
+			const hitKeys = hitListener.mock.calls.map((call: KeyvTelemetryEvent[]) => call[0].key);
+			expect(hitKeys).toContain("key1");
+			expect(hitKeys).toContain("key2");
+
+			const missPayload = missListener.mock.calls[0][0] as KeyvTelemetryEvent;
+			expect(missPayload.key).toBe("key3");
+		});
+
+		test("should emit per-key hit/miss on getManyRaw()", async () => {
+			const keyv = new Keyv({ stats: true });
+			const hitListener = vi.fn();
+			const missListener = vi.fn();
+			keyv.on(KeyvEvents.STAT_HIT, hitListener);
+			keyv.on(KeyvEvents.STAT_MISS, missListener);
+
+			await keyv.set("key1", "value1");
+			await keyv.getManyRaw(["key1", "missing"]);
+
+			expect(hitListener).toHaveBeenCalledOnce();
+			expect(missListener).toHaveBeenCalledOnce();
+			expect((hitListener.mock.calls[0][0] as KeyvTelemetryEvent).key).toBe("key1");
+			expect((missListener.mock.calls[0][0] as KeyvTelemetryEvent).key).toBe("missing");
+		});
+
+		test("should emit per-key stat:set on setMany()", async () => {
+			const keyv = new Keyv({ stats: true });
+			const listener = vi.fn();
+			keyv.on(KeyvEvents.STAT_SET, listener);
+
+			await keyv.setMany([
+				{ key: "a", value: 1 },
+				{ key: "b", value: 2 },
+				{ key: "c", value: 3 },
+			]);
+
+			expect(listener).toHaveBeenCalledTimes(3);
+			const keys = listener.mock.calls.map((call: KeyvTelemetryEvent[]) => call[0].key);
+			expect(keys).toContain("a");
+			expect(keys).toContain("b");
+			expect(keys).toContain("c");
+		});
+
+		test("should emit per-key stat:delete on deleteMany()", async () => {
+			const keyv = new Keyv({ stats: true });
+			const listener = vi.fn();
+			keyv.on(KeyvEvents.STAT_DELETE, listener);
+
+			await keyv.set("a", 1);
+			await keyv.set("b", 2);
+			await keyv.set("c", 3);
+			await keyv.delete(["a", "b", "c"]);
+
+			expect(listener).toHaveBeenCalledTimes(3);
+			const keys = listener.mock.calls.map((call: KeyvTelemetryEvent[]) => call[0].key);
+			expect(keys).toContain("a");
+			expect(keys).toContain("b");
+			expect(keys).toContain("c");
+		});
 	});
 
-	it("should emit per-key hit/miss on getMany()", async () => {
-		const keyv = new Keyv({ stats: true });
-		const hitListener = vi.fn();
-		const missListener = vi.fn();
-		keyv.on(KeyvEvents.STAT_HIT, hitListener);
-		keyv.on(KeyvEvents.STAT_MISS, missListener);
+	describe("errors", () => {
+		test("should emit stat:error on store error", async () => {
+			// biome-ignore lint/suspicious/noExplicitAny: testing with Map as store
+			const errorStore = new Map() as any;
+			const keyv = new Keyv({ store: errorStore, stats: true });
+			keyv.on("error", () => {}); // suppress unhandled error
 
-		await keyv.set("key1", "value1");
-		await keyv.set("key2", "value2");
-		// key3 does not exist
-		await keyv.get(["key1", "key2", "key3"]);
+			const listener = vi.fn();
+			keyv.on(KeyvEvents.STAT_ERROR, listener);
 
-		expect(hitListener).toHaveBeenCalledTimes(2);
-		expect(missListener).toHaveBeenCalledTimes(1);
+			// Force an error by making store.get throw
+			errorStore.get = () => {
+				throw new Error("store error");
+			};
 
-		const hitKeys = hitListener.mock.calls.map((call: KeyvTelemetryEvent[]) => call[0].key);
-		expect(hitKeys).toContain("key1");
-		expect(hitKeys).toContain("key2");
+			await keyv.get("key1");
 
-		const missPayload = missListener.mock.calls[0][0] as KeyvTelemetryEvent;
-		expect(missPayload.key).toBe("key3");
-	});
-
-	it("should emit stat:hit on getRaw() cache hit", async () => {
-		const keyv = new Keyv({ stats: true });
-		const listener = vi.fn();
-		keyv.on(KeyvEvents.STAT_HIT, listener);
-
-		await keyv.set("key1", "value1");
-		await keyv.getRaw("key1");
-
-		expect(listener).toHaveBeenCalledOnce();
-		const payload = listener.mock.calls[0][0] as KeyvTelemetryEvent;
-		expect(payload.event).toBe("hit");
-		expect(payload.key).toBe("key1");
-	});
-
-	it("should emit stat:miss on getRaw() cache miss", async () => {
-		const keyv = new Keyv({ stats: true });
-		const listener = vi.fn();
-		keyv.on(KeyvEvents.STAT_MISS, listener);
-
-		await keyv.getRaw("nonexistent");
-
-		expect(listener).toHaveBeenCalledOnce();
-		const payload = listener.mock.calls[0][0] as KeyvTelemetryEvent;
-		expect(payload.event).toBe("miss");
-		expect(payload.key).toBe("nonexistent");
-	});
-
-	it("should emit per-key hit/miss on getManyRaw()", async () => {
-		const keyv = new Keyv({ stats: true });
-		const hitListener = vi.fn();
-		const missListener = vi.fn();
-		keyv.on(KeyvEvents.STAT_HIT, hitListener);
-		keyv.on(KeyvEvents.STAT_MISS, missListener);
-
-		await keyv.set("key1", "value1");
-		await keyv.getManyRaw(["key1", "missing"]);
-
-		expect(hitListener).toHaveBeenCalledOnce();
-		expect(missListener).toHaveBeenCalledOnce();
-		expect((hitListener.mock.calls[0][0] as KeyvTelemetryEvent).key).toBe("key1");
-		expect((missListener.mock.calls[0][0] as KeyvTelemetryEvent).key).toBe("missing");
-	});
-
-	it("should emit stat:set on setRaw()", async () => {
-		const keyv = new Keyv({ stats: true });
-		const listener = vi.fn();
-		keyv.on(KeyvEvents.STAT_SET, listener);
-
-		await keyv.setRaw("key1", { value: "value1" });
-
-		expect(listener).toHaveBeenCalledOnce();
-		const payload = listener.mock.calls[0][0] as KeyvTelemetryEvent;
-		expect(payload.event).toBe("set");
-		expect(payload.key).toBe("key1");
-	});
-
-	it("should emit stat:error on store error", async () => {
-		// biome-ignore lint/suspicious/noExplicitAny: testing with Map as store
-		const errorStore = new Map() as any;
-		const keyv = new Keyv({ store: errorStore, stats: true });
-		keyv.on("error", () => {}); // suppress unhandled error
-
-		const listener = vi.fn();
-		keyv.on(KeyvEvents.STAT_ERROR, listener);
-
-		// Force an error by making store.get throw
-		errorStore.get = () => {
-			throw new Error("store error");
-		};
-
-		await keyv.get("key1");
-
-		expect(listener).toHaveBeenCalledOnce();
-		const payload = listener.mock.calls[0][0] as KeyvTelemetryEvent;
-		expect(payload.event).toBe("error");
-		expect(payload.key).toBe("key1");
-	});
-
-	it("should include namespace in telemetry payload", async () => {
-		const keyv = new Keyv({ namespace: "test-ns", stats: true });
-		const listener = vi.fn();
-		keyv.on(KeyvEvents.STAT_SET, listener);
-
-		await keyv.set("key1", "value1");
-
-		const payload = listener.mock.calls[0][0] as KeyvTelemetryEvent;
-		expect(payload.namespace).toBe("test-ns");
-	});
-
-	it("should have correct payload shape for all events", async () => {
-		const keyv = new Keyv({ namespace: "shape-test", stats: true });
-		const events: KeyvTelemetryEvent[] = [];
-
-		keyv.on(KeyvEvents.STAT_SET, (e: KeyvTelemetryEvent) => events.push(e));
-		keyv.on(KeyvEvents.STAT_HIT, (e: KeyvTelemetryEvent) => events.push(e));
-		keyv.on(KeyvEvents.STAT_MISS, (e: KeyvTelemetryEvent) => events.push(e));
-		keyv.on(KeyvEvents.STAT_DELETE, (e: KeyvTelemetryEvent) => events.push(e));
-
-		await keyv.set("key1", "value1");
-		await keyv.get("key1");
-		await keyv.get("nonexistent");
-		await keyv.delete("key1");
-
-		expect(events.length).toBe(4);
-		for (const event of events) {
-			expect(event.event).toBeTypeOf("string");
-			expect(event.key).toBeTypeOf("string");
-			expect(event.namespace).toBe("shape-test");
-			expect(event.timestamp).toBeTypeOf("number");
-			expect(event.timestamp).toBeGreaterThan(0);
-		}
-	});
-
-	it("should emit telemetry events even when stats are disabled", async () => {
-		const keyv = new Keyv({ stats: false });
-		const listener = vi.fn();
-		keyv.on(KeyvEvents.STAT_SET, listener);
-
-		await keyv.set("key1", "value1");
-
-		expect(listener).toHaveBeenCalledOnce();
-	});
-
-	it("should track correct per-key stats with getMany (bug fix validation)", async () => {
-		const keyv = new Keyv({ stats: true });
-
-		await keyv.set("a", 1);
-		await keyv.set("b", 2);
-		await keyv.set("c", 3);
-
-		keyv.stats.reset();
-		await keyv.get(["a", "b", "c"]);
-
-		expect(keyv.stats.hits).toBe(3);
-		expect(keyv.stats.misses).toBe(0);
-	});
-
-	it("should track per-key misses with getMany", async () => {
-		const keyv = new Keyv({ stats: true });
-
-		await keyv.set("a", 1);
-		keyv.stats.reset();
-
-		await keyv.get(["a", "missing1", "missing2"]);
-
-		expect(keyv.stats.hits).toBe(1);
-		expect(keyv.stats.misses).toBe(2);
-	});
-
-	it("should emit per-key stat:set on setMany()", async () => {
-		const keyv = new Keyv({ stats: true });
-		const listener = vi.fn();
-		keyv.on(KeyvEvents.STAT_SET, listener);
-
-		await keyv.setMany([
-			{ key: "a", value: 1 },
-			{ key: "b", value: 2 },
-			{ key: "c", value: 3 },
-		]);
-
-		expect(listener).toHaveBeenCalledTimes(3);
-		const keys = listener.mock.calls.map((call: KeyvTelemetryEvent[]) => call[0].key);
-		expect(keys).toContain("a");
-		expect(keys).toContain("b");
-		expect(keys).toContain("c");
-	});
-
-	it("should emit per-key stat:error on setMany() failure", async () => {
-		const errorStore = new KeyvMemoryAdapter(new Map());
-		errorStore.setMany = () => {
-			throw new Error("store error");
-		};
-		const keyv = new Keyv({ store: errorStore, stats: true });
-		keyv.on("error", () => {}); // suppress unhandled error
-
-		const listener = vi.fn();
-		keyv.on(KeyvEvents.STAT_ERROR, listener);
-
-		await keyv.setMany([
-			{ key: "a", value: 1 },
-			{ key: "b", value: 2 },
-		]);
-
-		expect(listener).toHaveBeenCalledTimes(2);
-		for (const call of listener.mock.calls) {
-			const payload = call[0] as KeyvTelemetryEvent;
+			expect(listener).toHaveBeenCalledOnce();
+			const payload = listener.mock.calls[0][0] as KeyvTelemetryEvent;
 			expect(payload.event).toBe("error");
-			expect(payload.key).toBeTypeOf("string");
-			expect(payload).not.toHaveProperty("keys");
-		}
+			expect(payload.key).toBe("key1");
+		});
+
+		test("should emit per-key stat:error on setMany() failure", async () => {
+			const errorStore = new KeyvMemoryAdapter(new Map());
+			errorStore.setMany = () => {
+				throw new Error("store error");
+			};
+			const keyv = new Keyv({ store: errorStore, stats: true });
+			keyv.on("error", () => {}); // suppress unhandled error
+
+			const listener = vi.fn();
+			keyv.on(KeyvEvents.STAT_ERROR, listener);
+
+			await keyv.setMany([
+				{ key: "a", value: 1 },
+				{ key: "b", value: 2 },
+			]);
+
+			expect(listener).toHaveBeenCalledTimes(2);
+			for (const call of listener.mock.calls) {
+				const payload = call[0] as KeyvTelemetryEvent;
+				expect(payload.event).toBe("error");
+				expect(payload.key).toBeTypeOf("string");
+				expect(payload).not.toHaveProperty("keys");
+			}
+		});
+
+		test("should emit per-key stat:error on deleteMany() failure", async () => {
+			const errorStore = new KeyvMemoryAdapter(new Map());
+			errorStore.deleteMany = () => {
+				throw new Error("store error");
+			};
+			const keyv = new Keyv({ store: errorStore, stats: true });
+			keyv.on("error", () => {}); // suppress unhandled error
+
+			const listener = vi.fn();
+			keyv.on(KeyvEvents.STAT_ERROR, listener);
+
+			await keyv.delete(["x", "y"]);
+
+			expect(listener).toHaveBeenCalledTimes(2);
+			for (const call of listener.mock.calls) {
+				const payload = call[0] as KeyvTelemetryEvent;
+				expect(payload.event).toBe("error");
+				expect(payload.key).toBeTypeOf("string");
+				expect(payload).not.toHaveProperty("keys");
+			}
+		});
 	});
 
-	it("should emit per-key stat:delete on deleteMany()", async () => {
-		const keyv = new Keyv({ stats: true });
-		const listener = vi.fn();
-		keyv.on(KeyvEvents.STAT_DELETE, listener);
+	describe("payload shape and namespace", () => {
+		test("should include namespace in telemetry payload", async () => {
+			const keyv = new Keyv({ namespace: "test-ns", stats: true });
+			const listener = vi.fn();
+			keyv.on(KeyvEvents.STAT_SET, listener);
 
-		await keyv.set("a", 1);
-		await keyv.set("b", 2);
-		await keyv.set("c", 3);
-		await keyv.delete(["a", "b", "c"]);
+			await keyv.set("key1", "value1");
 
-		expect(listener).toHaveBeenCalledTimes(3);
-		const keys = listener.mock.calls.map((call: KeyvTelemetryEvent[]) => call[0].key);
-		expect(keys).toContain("a");
-		expect(keys).toContain("b");
-		expect(keys).toContain("c");
+			const payload = listener.mock.calls[0][0] as KeyvTelemetryEvent;
+			expect(payload.namespace).toBe("test-ns");
+		});
+
+		test("should have correct payload shape for all events", async () => {
+			const keyv = new Keyv({ namespace: "shape-test", stats: true });
+			const events: KeyvTelemetryEvent[] = [];
+
+			keyv.on(KeyvEvents.STAT_SET, (e: KeyvTelemetryEvent) => events.push(e));
+			keyv.on(KeyvEvents.STAT_HIT, (e: KeyvTelemetryEvent) => events.push(e));
+			keyv.on(KeyvEvents.STAT_MISS, (e: KeyvTelemetryEvent) => events.push(e));
+			keyv.on(KeyvEvents.STAT_DELETE, (e: KeyvTelemetryEvent) => events.push(e));
+
+			await keyv.set("key1", "value1");
+			await keyv.get("key1");
+			await keyv.get("nonexistent");
+			await keyv.delete("key1");
+
+			expect(events.length).toBe(4);
+			for (const event of events) {
+				expect(event.event).toBeTypeOf("string");
+				expect(event.key).toBeTypeOf("string");
+				expect(event.namespace).toBe("shape-test");
+				expect(event.timestamp).toBeTypeOf("number");
+				expect(event.timestamp).toBeGreaterThan(0);
+			}
+		});
+
+		test("should emit telemetry events even when stats are disabled", async () => {
+			const keyv = new Keyv({ stats: false });
+			const listener = vi.fn();
+			keyv.on(KeyvEvents.STAT_SET, listener);
+
+			await keyv.set("key1", "value1");
+
+			expect(listener).toHaveBeenCalledOnce();
+		});
+
+		test("should never include keys property in telemetry events", async () => {
+			const keyv = new Keyv({ stats: true });
+			const events: KeyvTelemetryEvent[] = [];
+
+			keyv.on(KeyvEvents.STAT_SET, (e: KeyvTelemetryEvent) => events.push(e));
+			keyv.on(KeyvEvents.STAT_HIT, (e: KeyvTelemetryEvent) => events.push(e));
+			keyv.on(KeyvEvents.STAT_MISS, (e: KeyvTelemetryEvent) => events.push(e));
+			keyv.on(KeyvEvents.STAT_DELETE, (e: KeyvTelemetryEvent) => events.push(e));
+
+			await keyv.set("a", 1);
+			await keyv.set("b", 2);
+			await keyv.get(["a", "b", "missing"]);
+			await keyv.setMany([
+				{ key: "c", value: 3 },
+				{ key: "d", value: 4 },
+			]);
+			await keyv.delete(["a", "b"]);
+
+			expect(events.length).toBeGreaterThan(0);
+			for (const event of events) {
+				expect(event).not.toHaveProperty("keys");
+			}
+		});
 	});
 
-	it("should emit per-key stat:error on deleteMany() failure", async () => {
-		const errorStore = new KeyvMemoryAdapter(new Map());
-		errorStore.deleteMany = () => {
-			throw new Error("store error");
-		};
-		const keyv = new Keyv({ store: errorStore, stats: true });
-		keyv.on("error", () => {}); // suppress unhandled error
+	describe("stats tracking", () => {
+		test("should track correct per-key stats with getMany (bug fix validation)", async () => {
+			const keyv = new Keyv({ stats: true });
 
-		const listener = vi.fn();
-		keyv.on(KeyvEvents.STAT_ERROR, listener);
+			await keyv.set("a", 1);
+			await keyv.set("b", 2);
+			await keyv.set("c", 3);
 
-		await keyv.delete(["x", "y"]);
+			keyv.stats.reset();
+			await keyv.get(["a", "b", "c"]);
 
-		expect(listener).toHaveBeenCalledTimes(2);
-		for (const call of listener.mock.calls) {
-			const payload = call[0] as KeyvTelemetryEvent;
-			expect(payload.event).toBe("error");
-			expect(payload.key).toBeTypeOf("string");
-			expect(payload).not.toHaveProperty("keys");
-		}
-	});
+			expect(keyv.stats.hits).toBe(3);
+			expect(keyv.stats.misses).toBe(0);
+		});
 
-	it("should never include keys property in telemetry events", async () => {
-		const keyv = new Keyv({ stats: true });
-		const events: KeyvTelemetryEvent[] = [];
+		test("should track per-key misses with getMany", async () => {
+			const keyv = new Keyv({ stats: true });
 
-		keyv.on(KeyvEvents.STAT_SET, (e: KeyvTelemetryEvent) => events.push(e));
-		keyv.on(KeyvEvents.STAT_HIT, (e: KeyvTelemetryEvent) => events.push(e));
-		keyv.on(KeyvEvents.STAT_MISS, (e: KeyvTelemetryEvent) => events.push(e));
-		keyv.on(KeyvEvents.STAT_DELETE, (e: KeyvTelemetryEvent) => events.push(e));
+			await keyv.set("a", 1);
+			keyv.stats.reset();
 
-		await keyv.set("a", 1);
-		await keyv.set("b", 2);
-		await keyv.get(["a", "b", "missing"]);
-		await keyv.setMany([
-			{ key: "c", value: 3 },
-			{ key: "d", value: 4 },
-		]);
-		await keyv.delete(["a", "b"]);
+			await keyv.get(["a", "missing1", "missing2"]);
 
-		expect(events.length).toBeGreaterThan(0);
-		for (const event of events) {
-			expect(event).not.toHaveProperty("keys");
-		}
+			expect(keyv.stats.hits).toBe(1);
+			expect(keyv.stats.misses).toBe(2);
+		});
 	});
 });

--- a/core/keyv/test/set.test.ts
+++ b/core/keyv/test/set.test.ts
@@ -1,6 +1,5 @@
 import { faker } from "@faker-js/faker";
 import tk from "timekeeper";
-import * as testRunner from "vitest";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import Keyv, { KeyvMemoryAdapter, type KeyvStorageAdapter } from "../src/index.js";
 import { createStore } from "./test-utils.js";
@@ -63,132 +62,129 @@ describe("Keyv", async () => {
 	});
 });
 
-testRunner.it("Keyv passes ttl info to stores", async (t) => {
-	t.expect.assertions(1);
-	const store = new Map();
-	const storeSet = store.set;
-	// @ts-expect-error
-	store.set = (key, value, ttl) => {
-		t.expect(ttl).toBe(100);
+describe("ttl", () => {
+	test("Keyv passes ttl info to stores", async () => {
+		expect.assertions(1);
+		const store = new Map();
+		const storeSet = store.set;
 		// @ts-expect-error
-		storeSet.call(store, key, value, ttl);
-	};
+		store.set = (key, value, ttl) => {
+			expect(ttl).toBe(100);
+			// @ts-expect-error
+			storeSet.call(store, key, value, ttl);
+		};
 
-	const keyv = new Keyv({ store });
-	await keyv.set("foo", "bar", 100);
-});
+		const keyv = new Keyv({ store });
+		await keyv.set("foo", "bar", 100);
+	});
 
-testRunner.it("Keyv respects default ttl option", async (t) => {
-	const store = new Map();
-	const keyv = new Keyv({ store, ttl: 100 });
-	await keyv.set("foo", "bar");
-	t.expect(await keyv.get("foo")).toBe("bar");
-	tk.freeze(Date.now() + 150);
-	t.expect(await keyv.get("foo")).toBeUndefined();
-	t.expect(store.size).toBe(0);
-	tk.reset();
-});
+	test("Keyv respects default ttl option", async () => {
+		const store = new Map();
+		const keyv = new Keyv({ store, ttl: 100 });
+		await keyv.set("foo", "bar");
+		expect(await keyv.get("foo")).toBe("bar");
+		tk.freeze(Date.now() + 150);
+		expect(await keyv.get("foo")).toBeUndefined();
+		expect(store.size).toBe(0);
+		tk.reset();
+	});
 
-testRunner.it(".set(key, val, ttl) overwrites default ttl option", async (t) => {
-	const startTime = Date.now();
-	tk.freeze(startTime);
-	const keyv = new Keyv({ ttl: 200 });
-	await keyv.set("foo", "bar");
-	await keyv.set("fizz", "buzz", 100);
-	await keyv.set("ping", "pong", 300);
-	t.expect(await keyv.get("foo")).toBe("bar");
-	t.expect(await keyv.get("fizz")).toBe("buzz");
-	t.expect(await keyv.get("ping")).toBe("pong");
-	tk.freeze(startTime + 150);
-	t.expect(await keyv.get("foo")).toBe("bar");
-	t.expect(await keyv.get("fizz")).toBeUndefined();
-	t.expect(await keyv.get("ping")).toBe("pong");
-	tk.freeze(startTime + 250);
-	t.expect(await keyv.get("foo")).toBeUndefined();
-	t.expect(await keyv.get("ping")).toBe("pong");
-	tk.freeze(startTime + 350);
-	t.expect(await keyv.get("ping")).toBeUndefined();
-	tk.reset();
-});
+	test(".set(key, val, ttl) overwrites default ttl option", async () => {
+		const startTime = Date.now();
+		tk.freeze(startTime);
+		const keyv = new Keyv({ ttl: 200 });
+		await keyv.set("foo", "bar");
+		await keyv.set("fizz", "buzz", 100);
+		await keyv.set("ping", "pong", 300);
+		expect(await keyv.get("foo")).toBe("bar");
+		expect(await keyv.get("fizz")).toBe("buzz");
+		expect(await keyv.get("ping")).toBe("pong");
+		tk.freeze(startTime + 150);
+		expect(await keyv.get("foo")).toBe("bar");
+		expect(await keyv.get("fizz")).toBeUndefined();
+		expect(await keyv.get("ping")).toBe("pong");
+		tk.freeze(startTime + 250);
+		expect(await keyv.get("foo")).toBeUndefined();
+		expect(await keyv.get("ping")).toBe("pong");
+		tk.freeze(startTime + 350);
+		expect(await keyv.get("ping")).toBeUndefined();
+		tk.reset();
+	});
 
-testRunner.it(
-	'.set(key, val, ttl) where ttl is "0" overwrites default ttl option and sets key to never expire',
-	async (t) => {
+	test('.set(key, val, ttl) where ttl is "0" overwrites default ttl option and sets key to never expire', async () => {
 		const startTime = Date.now();
 		tk.freeze(startTime);
 		const store = new Map();
 		const keyv = new Keyv({ store, ttl: 200 });
 		await keyv.set("foo", "bar", 0);
-		t.expect(await keyv.get("foo")).toBe("bar");
+		expect(await keyv.get("foo")).toBe("bar");
 		tk.freeze(startTime + 250);
-		t.expect(await keyv.get("foo")).toBe("bar");
+		expect(await keyv.get("foo")).toBe("bar");
 		tk.reset();
-	},
-);
+	});
 
-testRunner.it("should be able to set the ttl as default option and then property", async (t) => {
-	const keyv = new Keyv({ store: new Map(), ttl: 100 });
-	t.expect(keyv.ttl).toBe(100);
-	keyv.ttl = 200;
-	t.expect(keyv.ttl).toBe(200);
-	t.expect(keyv.ttl).toBe(200);
-});
-
-testRunner.it(
-	"should be able to set the ttl as default option and then property with undefined",
-	async (t) => {
-		const keyv = new Keyv({ store: new Map() });
-		t.expect(keyv.ttl).not.toBeDefined();
+	test("should be able to set the ttl as default option and then property", async () => {
+		const keyv = new Keyv({ store: new Map(), ttl: 100 });
+		expect(keyv.ttl).toBe(100);
 		keyv.ttl = 200;
-		t.expect(keyv.ttl).toBe(200);
-		t.expect(keyv.ttl).toBe(200);
+		expect(keyv.ttl).toBe(200);
+		expect(keyv.ttl).toBe(200);
+	});
+
+	test("should be able to set the ttl as default option and then property with undefined", async () => {
+		const keyv = new Keyv({ store: new Map() });
+		expect(keyv.ttl).not.toBeDefined();
+		keyv.ttl = 200;
+		expect(keyv.ttl).toBe(200);
+		expect(keyv.ttl).toBe(200);
 		keyv.ttl = undefined;
-		t.expect(keyv.ttl).not.toBeDefined();
-		t.expect(keyv.ttl).not.toBeDefined();
-	},
-);
-
-testRunner.it("should emit error if set fails", async (t) => {
-	const adapter = new KeyvMemoryAdapter(new Map());
-	adapter.set = testRunner.vi.fn().mockRejectedValue(new Error("store set error"));
-	const keyv = new Keyv({ store: adapter });
-	const errorHandler = testRunner.vi.fn();
-	keyv.on("error", errorHandler);
-	const result = await keyv.set("foo", "bar");
-	t.expect(result).toBe(false);
-	t.expect(errorHandler).toHaveBeenCalledWith(new Error("store set error"));
+		expect(keyv.ttl).not.toBeDefined();
+		expect(keyv.ttl).not.toBeDefined();
+	});
 });
 
-testRunner.it("should return when value equals non boolean", async (t) => {
-	const store = new Map();
-	// @ts-expect-error
-	store.set = () => "foo";
-	const keyv = new Keyv(store);
-	const result = await keyv.set("foo111", "bar111");
-	t.expect(result).toBe(true);
+describe("set", () => {
+	test("should emit error if set fails", async () => {
+		const adapter = new KeyvMemoryAdapter(new Map());
+		adapter.set = vi.fn().mockRejectedValue(new Error("store set error"));
+		const keyv = new Keyv({ store: adapter });
+		const errorHandler = vi.fn();
+		keyv.on("error", errorHandler);
+		const result = await keyv.set("foo", "bar");
+		expect(result).toBe(false);
+		expect(errorHandler).toHaveBeenCalledWith(new Error("store set error"));
+	});
+
+	test("should return when value equals non boolean", async () => {
+		const store = new Map();
+		// @ts-expect-error
+		store.set = () => "foo";
+		const keyv = new Keyv(store);
+		const result = await keyv.set("foo111", "bar111");
+		expect(result).toBe(true);
+	});
+
+	test("should return store set value equals non boolean", async () => {
+		const store = new Map();
+		// @ts-expect-error
+		store.set = () => true;
+		const keyv = new Keyv(store);
+		const result = await keyv.set("foo1112", "bar1112");
+		expect(result).toBe(true);
+	});
+
+	test("should emit error and return false when setting a Symbol value", async () => {
+		const keyv = new Keyv({ store: new Map() });
+		const errorHandler = vi.fn();
+		keyv.on("error", errorHandler);
+		const result = await keyv.set("key", Symbol("test"));
+		expect(result).toBe(false);
+		expect(errorHandler).toHaveBeenCalledWith("symbol cannot be serialized");
+	});
 });
 
-testRunner.it("should return store set value equals non boolean", async (t) => {
-	const store = new Map();
-	// @ts-expect-error
-	store.set = () => true;
-	const keyv = new Keyv(store);
-	const result = await keyv.set("foo1112", "bar1112");
-	t.expect(result).toBe(true);
-});
-
-testRunner.it("should emit error and return false when setting a Symbol value", async (t) => {
-	const keyv = new Keyv({ store: new Map() });
-	const errorHandler = testRunner.vi.fn();
-	keyv.on("error", errorHandler);
-	const result = await keyv.set("key", Symbol("test"));
-	t.expect(result).toBe(false);
-	t.expect(errorHandler).toHaveBeenCalledWith("symbol cannot be serialized");
-});
-
-testRunner.it(
-	"setMany returns array of true when store.setMany returns void (backward compat)",
-	async (t) => {
+describe("setMany", () => {
+	test("setMany returns array of true when store.setMany returns void (backward compat)", async () => {
 		const map = new Map<string, unknown>();
 		const store: KeyvStorageAdapter = {
 			namespace: undefined as string | undefined,
@@ -217,43 +213,43 @@ testRunner.it(
 			{ key: "a", value: "1" },
 			{ key: "b", value: "2" },
 		]);
-		t.expect(result).toEqual([true, true]);
-	},
-);
+		expect(result).toEqual([true, true]);
+	});
 
-testRunner.it("setMany returns false entries when store.setMany throws", async (t) => {
-	const store = {
-		async get(_key: string) {},
-		async set(_key: string, _value: unknown) {},
-		async delete(_key: string) {
-			return true;
-		},
-		async clear() {},
-		async setMany(_entries: Array<{ key: string; value: unknown; ttl?: number }>) {
-			throw new Error("store setMany failure");
-		},
-		on() {
-			return store;
-		},
-	};
-	// biome-ignore lint/suspicious/noExplicitAny: test mock
-	const keyv = new Keyv({ store: store as any });
-	keyv.on("error", () => {});
-	const result = await keyv.setMany([
-		{ key: "a", value: "1" },
-		{ key: "b", value: "2" },
-	]);
-	t.expect(result).toEqual([false, false]);
-});
+	test("setMany returns false entries when store.setMany throws", async () => {
+		const store = {
+			async get(_key: string) {},
+			async set(_key: string, _value: unknown) {},
+			async delete(_key: string) {
+				return true;
+			},
+			async clear() {},
+			async setMany(_entries: Array<{ key: string; value: unknown; ttl?: number }>) {
+				throw new Error("store setMany failure");
+			},
+			on() {
+				return store;
+			},
+		};
+		// biome-ignore lint/suspicious/noExplicitAny: test mock
+		const keyv = new Keyv({ store: store as any });
+		keyv.on("error", () => {});
+		const result = await keyv.setMany([
+			{ key: "a", value: "1" },
+			{ key: "b", value: "2" },
+		]);
+		expect(result).toEqual([false, false]);
+	});
 
-testRunner.it("setMany should fallback to individual set when store has no setMany", async (t) => {
-	const store = createStore();
-	const keyv = new Keyv({ store });
-	const result = await keyv.setMany([
-		{ key: "k1", value: "v1" },
-		{ key: "k2", value: "v2" },
-	]);
-	t.expect(result).toEqual([true, true]);
-	t.expect(await keyv.get("k1")).toBe("v1");
-	t.expect(await keyv.get("k2")).toBe("v2");
+	test("setMany should fallback to individual set when store has no setMany", async () => {
+		const store = createStore();
+		const keyv = new Keyv({ store });
+		const result = await keyv.setMany([
+			{ key: "k1", value: "v1" },
+			{ key: "k2", value: "v2" },
+		]);
+		expect(result).toEqual([true, true]);
+		expect(await keyv.get("k1")).toBe("v1");
+		expect(await keyv.get("k2")).toBe("v2");
+	});
 });

--- a/core/keyv/test/stats.test.ts
+++ b/core/keyv/test/stats.test.ts
@@ -1,80 +1,85 @@
-import { describe, expect, it } from "vitest";
+import { faker } from "@faker-js/faker";
+import { describe, expect, test } from "vitest";
 import { Keyv } from "../src/index.js";
 import { KeyvStats } from "../src/stats.js";
 
-it("will initialize at zero, increment counters, and handle errors", async () => {
-	const stats = new KeyvStats({ enabled: true });
-	expect(stats.hits).toBe(0);
-	expect(stats.misses).toBe(0);
-	expect(stats.sets).toBe(0);
-	expect(stats.deletes).toBe(0);
-	expect(stats.errors).toBe(0);
+describe("stats counters", () => {
+	test("will initialize at zero, increment counters, and handle errors", async () => {
+		const stats = new KeyvStats({ enabled: true });
+		expect(stats.hits).toBe(0);
+		expect(stats.misses).toBe(0);
+		expect(stats.sets).toBe(0);
+		expect(stats.deletes).toBe(0);
+		expect(stats.errors).toBe(0);
 
-	const keyv = new Keyv({ stats: true });
-	await keyv.set("key1", "value1");
-	expect(keyv.stats.sets).toBe(1);
-	await keyv.get("key1");
-	expect(keyv.stats.hits).toBe(1);
-	await keyv.get("missing");
-	expect(keyv.stats.misses).toBe(1);
-	await keyv.delete("key1");
-	expect(keyv.stats.deletes).toBe(1);
-});
+		const keyv = new Keyv({ stats: true });
+		const key = faker.string.alphanumeric(10);
+		const value = faker.string.alphanumeric(10);
+		await keyv.set(key, value);
+		expect(keyv.stats.sets).toBe(1);
+		await keyv.get(key);
+		expect(keyv.stats.hits).toBe(1);
+		await keyv.get(faker.string.alphanumeric(10));
+		expect(keyv.stats.misses).toBe(1);
+		await keyv.delete(key);
+		expect(keyv.stats.deletes).toBe(1);
+	});
 
-it("will increment error counter on store error", async () => {
-	// biome-ignore lint/suspicious/noExplicitAny: testing with Map as store
-	const errorStore = new Map() as any;
-	const keyv = new Keyv({ store: errorStore, stats: true });
-	keyv.on("error", () => {});
-	errorStore.get = () => {
-		throw new Error("store error");
-	};
-	await keyv.get("badkey");
-	expect(keyv.stats.errors).toBe(1);
-});
+	test("will increment error counter on store error", async () => {
+		// biome-ignore lint/suspicious/noExplicitAny: testing with Map as store
+		const errorStore = new Map() as any;
+		const keyv = new Keyv({ store: errorStore, stats: true });
+		keyv.on("error", () => {});
+		errorStore.get = () => {
+			throw new Error("store error");
+		};
+		await keyv.get("badkey");
+		expect(keyv.stats.errors).toBe(1);
+	});
 
-it("will not increment counters when disabled, and reset works", async () => {
-	const keyv = new Keyv({ stats: false });
-	await keyv.set("key1", "value1");
-	await keyv.get("key1");
-	expect(keyv.stats.sets).toBe(0);
-	expect(keyv.stats.hits).toBe(0);
+	test("will not increment counters when disabled, and reset works", async () => {
+		const keyv = new Keyv({ stats: false });
+		await keyv.set("key1", "value1");
+		await keyv.get("key1");
+		expect(keyv.stats.sets).toBe(0);
+		expect(keyv.stats.hits).toBe(0);
 
-	// Reset
-	const keyv2 = new Keyv({ stats: true });
-	await keyv2.set("key1", "value1");
-	await keyv2.get("key1");
-	await keyv2.get("missing");
-	await keyv2.delete("key1");
-	keyv2.stats.reset();
-	expect(keyv2.stats.sets).toBe(0);
-	expect(keyv2.stats.hits).toBe(0);
-	expect(keyv2.stats.misses).toBe(0);
-	expect(keyv2.stats.deletes).toBe(0);
-});
+		// Reset
+		const keyv2 = new Keyv({ stats: true });
+		await keyv2.set("key1", "value1");
+		await keyv2.get("key1");
+		await keyv2.get("missing");
+		await keyv2.delete("key1");
+		keyv2.stats.reset();
+		expect(keyv2.stats.sets).toBe(0);
+		expect(keyv2.stats.hits).toBe(0);
+		expect(keyv2.stats.misses).toBe(0);
+		expect(keyv2.stats.deletes).toBe(0);
+	});
 
-it("will default enabled to false and maxEntries to 1000", () => {
-	const stats = new KeyvStats();
-	expect(stats.enabled).toBe(false);
-	expect(stats.maxEntries).toBe(1000);
-});
+	test("will default enabled to false and maxEntries to 1000", () => {
+		const stats = new KeyvStats();
+		expect(stats.enabled).toBe(false);
+		expect(stats.maxEntries).toBe(1000);
+	});
 
-it("will unsubscribe when enabled is set to false and re-subscribe on true", async () => {
-	const keyv = new Keyv({ stats: true });
-	await keyv.set("key1", "value1");
-	expect(keyv.stats.sets).toBe(1);
+	test("will unsubscribe when enabled is set to false and re-subscribe on true", async () => {
+		const keyv = new Keyv({ stats: true });
+		await keyv.set("key1", "value1");
+		expect(keyv.stats.sets).toBe(1);
 
-	keyv.stats.enabled = false;
-	await keyv.set("key2", "value2");
-	expect(keyv.stats.sets).toBe(1);
+		keyv.stats.enabled = false;
+		await keyv.set("key2", "value2");
+		expect(keyv.stats.sets).toBe(1);
 
-	keyv.stats.enabled = true;
-	await keyv.set("key3", "value3");
-	expect(keyv.stats.sets).toBe(2);
+		keyv.stats.enabled = true;
+		await keyv.set("key3", "value3");
+		expect(keyv.stats.sets).toBe(2);
+	});
 });
 
 describe("LRU key frequency maps", () => {
-	it("should accept options and enforce maxEntries", () => {
+	test("should accept options and enforce maxEntries", () => {
 		const stats = new KeyvStats({ enabled: true, maxEntries: 500 });
 		expect(stats.maxEntries).toBe(500);
 
@@ -86,7 +91,7 @@ describe("LRU key frequency maps", () => {
 		expect(stats2.hitKeys.size).toBe(1000);
 	});
 
-	it("should track keys, evict LRU, and preserve recently accessed", () => {
+	test("should track keys, evict LRU, and preserve recently accessed", () => {
 		const stats = new KeyvStats();
 		stats.incrementKeys(stats.hitKeys, "user:123");
 		stats.incrementKeys(stats.hitKeys, "user:123");
@@ -116,7 +121,7 @@ describe("LRU key frequency maps", () => {
 		expect(stats3.hitKeys.has("b")).toBe(false);
 	});
 
-	it("should track each event type independently", () => {
+	test("should track each event type independently", () => {
 		const stats = new KeyvStats();
 		stats.incrementKeys(stats.hitKeys, "key1");
 		stats.incrementKeys(stats.missKeys, "key1");
@@ -131,7 +136,7 @@ describe("LRU key frequency maps", () => {
 		expect(stats.errorKeys.get("key4")).toBe(1);
 	});
 
-	it("should build composite key with and without namespace", () => {
+	test("should build composite key with and without namespace", () => {
 		const stats = new KeyvStats();
 		expect(
 			stats.buildKeyEventName({
@@ -147,7 +152,7 @@ describe("LRU key frequency maps", () => {
 		expect(stats.buildKeyEventName({ event: "error", timestamp: Date.now() })).toBe("");
 	});
 
-	it("should not track empty keys or when maxEntries is 0", () => {
+	test("should not track empty keys or when maxEntries is 0", () => {
 		const stats = new KeyvStats();
 		stats.incrementKeys(stats.errorKeys, "");
 		expect(stats.errorKeys.size).toBe(0);
@@ -157,7 +162,7 @@ describe("LRU key frequency maps", () => {
 		expect(stats2.hitKeys.size).toBe(0);
 	});
 
-	it("should clear all LRU maps on reset", () => {
+	test("should clear all LRU maps on reset", () => {
 		const stats = new KeyvStats();
 		stats.incrementKeys(stats.hitKeys, "a");
 		stats.incrementKeys(stats.missKeys, "b");
@@ -169,7 +174,7 @@ describe("LRU key frequency maps", () => {
 		expect(stats.missKeys.size).toBe(0);
 	});
 
-	it("should populate LRU maps via subscribe with namespace", async () => {
+	test("should populate LRU maps via subscribe with namespace", async () => {
 		const keyv = new Keyv({ stats: true, namespace: "myns" });
 		await keyv.set("foo", "bar");
 		await keyv.get("foo");
@@ -181,7 +186,7 @@ describe("LRU key frequency maps", () => {
 		expect(keyv.stats.deleteKeys.get("myns:foo")).toBe(1);
 	});
 
-	it("should track error keys via subscribe", async () => {
+	test("should track error keys via subscribe", async () => {
 		// biome-ignore lint/suspicious/noExplicitAny: testing with Map as store
 		const errorStore = new Map() as any;
 		const keyv = new Keyv({ store: errorStore, stats: true });
@@ -195,7 +200,7 @@ describe("LRU key frequency maps", () => {
 });
 
 describe("unsubscribe", () => {
-	it("should stop tracking and be safe to call multiple times", async () => {
+	test("should stop tracking and be safe to call multiple times", async () => {
 		const keyv = new Keyv({ stats: true });
 		await keyv.set("key1", "value1");
 		keyv.stats.unsubscribe();


### PR DESCRIPTION
## Summary

A full code and test review of the core `keyv` package covering each requested item. No behavior changes — all 312 tests pass and `biome` is clean.

### 1. README API accuracy
The README documented several things that don't exist and missed several that do:
- **Removed** docs for the non‑existent `emitErrors` and `useKeyPrefix` properties/options.
- **Added** docs for the real `.encryption` and `.checkExpired` properties and the missing `stats`, `throwOnErrors`, `sanitize`, `encryption`, and `checkExpired` constructor options.
- **Hooks**: rewrote to use the current `BEFORE_*`/`AFTER_*` names (noting the deprecated `PRE_*`/`POST_*` aliases), completed the hook list, and fixed registration to `keyv.onHook(...)` — the documented `keyv.hooks.addHandler(...)` does not exist (`.hooks` is a `Map`).
- **Capability Detection**: rewrote to match the actual return shapes (`{ compatible, methods, properties }` / `{ compatible, store, methods }`) and dropped the non‑existent `detectCapabilities` helper.
- **Encryption**: it is now wired into the encode/decode pipeline, so the "not yet wired in" note was removed and the option/property documented.
- Fixed `.get(key)` / `.getMany(keys)` signatures (the `[options]` argument is gone), the `.iterator()` "emits an error event" claim (it yields nothing), the Pipeline JSON‑fallback claim, and the `.sanitize` runtime examples (the setter takes a `KeyvSanitize` adapter, not a boolean).
- Updated the Table of Contents to match.

### 2. Tests use faker
faker remains the source of arbitrary key/value data across the CRUD‑style suites; left semantically‑meaningful literals (serialization fixtures, sanitize patterns, capability shapes, per‑key stat assertions) as‑is.

### 3. Uniform tests
Converted the remaining `it()` / `testRunner.it()` / `test.it()` calls to `test()` and grouped loose top‑level tests under `describe()` blocks (`get.test.ts`, `set.test.ts`, `keyv-hooks.test.ts`, `keyv-telemetry.test.ts`, `stats.test.ts`, `json-serializer.test.ts`).

### 4. `undefined`, not `null`
Confirmed the public API returns `undefined` (not `null`) and no test asserts `.toBeNull()` on a return value.

### 5. Events via hookified
Validated that `Keyv` extends `Hookified` and wires up `emit`/`on`, `hook`/`onHook`/`getHooks`, the deprecated‑hook map, and store error forwarding correctly. The only fix needed was the README hook‑registration example.

### 6. Robust jsDocs
Added/strengthened `@param` and Promise‑wrapped `@returns` on the public CRUD methods (`get`, `getMany`, `set`, `setMany`, `setRaw`, `setManyRaw`, `delete`, `deleteMany`, `has`, `hasMany`, `clear`) and the `checkExpired` getter.

### 7. Private functions below public
Verified private methods remain below the public ones.

### 8. Properties under the constructor
Moved the private property fields from above the constructor to directly below it (under a `// --- Properties ---` divider), above the accessors and methods; grouped the `stats` getter/setter together.

## Validation
- `npx tsdown` — build complete
- `npx biome check src test` — clean (31 files)
- `npx vitest run` — **312 passed**, 4 todo (19 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0127VbC9okZqA3dxGnubAWpA)_