### PR TITLE
keyv (breaking) - storage adapters now only use expires instead of ttl

### DIFF
--- a/core/keyv/README.md
+++ b/core/keyv/README.md
@@ -412,6 +412,32 @@ const keyv = new Keyv({ store: lru });
 
 View the complete list of third-party storage adapters and learn how to build your own at https://keyv.org/docs/third-party-storage-adapters/
 
+## Storage Adapter Contract (v6)
+
+> The public API above is unchanged — `keyv.set(key, value, ttl)` still takes a relative TTL in milliseconds. The change below only affects authors of custom **storage adapters**.
+
+As of v6, Keyv passes an **absolute `expires`** timestamp (Unix ms since epoch) to a storage adapter's write methods instead of a relative TTL. Keyv computes `expires` once, so adapters never need to derive or parse it:
+
+```ts
+import { keyvStorageCapability } from 'keyv';
+
+type KeyvStorageEntry<Value> = { key: string; value: Value; expires?: number };
+
+class MyAdapter {
+  // Declare support for the absolute-`expires` contract:
+  get capabilities() {
+    return keyvStorageCapability(this); // -> { ...detected, expires: true }
+  }
+
+  // `expires` is absolute Unix ms; `undefined` means no expiry; `<= Date.now()` means already expired.
+  async set(key: string, value: unknown, expires?: number): Promise<boolean> { /* ... */ }
+  async setMany<Value>(entries: KeyvStorageEntry<Value>[]): Promise<boolean[] | undefined> { /* ... */ }
+  // ...get, delete, clear, has, getMany, deleteMany, hasMany, etc.
+}
+```
+
+A v6 adapter declares `capabilities.expires === true` (the `keyvStorageCapability(this)` helper sets it for you). Keyv then passes the absolute `expires` to it directly. Any **legacy** storage adapter that does *not* declare `capabilities.expires` is treated as a relative-TTL adapter and transparently wrapped by [`KeyvBridgeAdapter`](#third-party-storage-adapters), which converts the absolute `expires` back to a TTL (`Math.max(0, expires - Date.now())`) before delegating — so existing third-party adapters keep working unchanged. Stores that expose absolute-expiry primitives (e.g. Redis `PXAT`) use `expires` directly. Map-like stores wrapped via `new Keyv({ store: new Map() })` are unaffected.
+
 # Using BigMap to Scale
 
 ## Understanding JavaScript Map Limitations

--- a/core/keyv/README.md
+++ b/core/keyv/README.md
@@ -436,7 +436,9 @@ class MyAdapter {
 }
 ```
 
-A v6 adapter declares `capabilities.expires === true` (the `keyvStorageCapability(this)` helper sets it for you). Keyv then passes the absolute `expires` to it directly. Any **legacy** storage adapter that does *not* declare `capabilities.expires` is treated as a relative-TTL adapter and transparently wrapped by [`KeyvBridgeAdapter`](#third-party-storage-adapters), which converts the absolute `expires` back to a TTL (`Math.max(0, expires - Date.now())`) before delegating — so existing third-party adapters keep working unchanged. Stores that expose absolute-expiry primitives (e.g. Redis `PXAT`) use `expires` directly. Map-like stores wrapped via `new Keyv({ store: new Map() })` are unaffected.
+A v6 adapter declares `capabilities.expires === true` (the `keyvStorageCapability(this)` helper sets it for you). Keyv then passes the absolute `expires` to it directly — this takes precedence over structural detection, so an adapter whose methods aren't written with `async` is still used directly rather than bridged. Any **legacy** storage adapter that does *not* declare `capabilities.expires` is treated as a relative-TTL adapter and transparently wrapped by [`KeyvBridgeAdapter`](#third-party-storage-adapters), which converts the absolute `expires` back to a relative TTL before delegating (and deletes outright when the deadline has already elapsed) — so existing third-party adapters keep working unchanged. Stores that expose absolute-expiry primitives (e.g. Redis `PXAT`) use `expires` directly. Map-like stores wrapped via `new Keyv({ store: new Map() })` are unaffected.
+
+> **Adapters are the expiry authority.** Declaring `capabilities.expires === true` is a two-way contract: because Keyv core does not filter expired reads by default (`checkExpired` is off), a v6 adapter must enforce expiry itself — `get`/`getMany`/`has` must not return a key past its deadline, whether via a native mechanism (key expiry, TTL index, lease) or a client-side check. Run `@keyv/test-suite`'s `storageTtlTests` against your adapter to verify it.
 
 # Using BigMap to Scale
 

--- a/core/keyv/src/adapters/bridge.ts
+++ b/core/keyv/src/adapters/bridge.ts
@@ -29,6 +29,8 @@ export type KeyvBridgeAdapterOptions = {
 export type KeyvBridgeStore = {
 	/** Store configuration/options (e.g. dialect, url) */
 	opts?: any;
+	/** Namespace the store scopes its keys under, when it manages its own namespacing. */
+	namespace?: string;
 	/** Retrieves a value by key */
 	get(key: string): Promise<any>;
 	/** Sets a value with a key and optional TTL */
@@ -87,6 +89,12 @@ export class KeyvBridgeAdapter extends Hookified implements KeyvStorageAdapter {
 	private _namespace?: string;
 	private _keySeparator = ":";
 	private readonly _capabilities: KeyvStorageCapability;
+	/**
+	 * Whether the wrapped store manages its own namespace (exposes a `namespace` property).
+	 * When true the bridge propagates its namespace to the store and does not prefix keys,
+	 * so the store's native, namespace-scoped operations (notably `clear()`) are used directly.
+	 */
+	private readonly _storeHandlesNamespace: boolean;
 
 	/**
 	 * Creates a new KeyvBridgeAdapter instance.
@@ -97,6 +105,14 @@ export class KeyvBridgeAdapter extends Hookified implements KeyvStorageAdapter {
 		super({ throwOnHookError: false });
 		this._store = store;
 
+		// Detect optional methods at construction time
+		this._capabilities = detectKeyvStorage(store);
+		// Only a full storage adapter (keyvStorage) that exposes a `namespace` manages its own
+		// namespacing. asyncMap/map-like stores — even if they expose `namespace` — stay on the
+		// bridge's key-prefixing path so a single shared store can host multiple namespaces.
+		this._storeHandlesNamespace =
+			this._capabilities.store === "keyvStorage" && "namespace" in store;
+
 		if (options?.keySeparator) {
 			this._keySeparator = options.keySeparator;
 		}
@@ -105,8 +121,10 @@ export class KeyvBridgeAdapter extends Hookified implements KeyvStorageAdapter {
 			this._namespace = options.namespace;
 		}
 
-		// Detect optional methods at construction time
-		this._capabilities = detectKeyvStorage(store);
+		// Hand our namespace to a store that scopes its own keys.
+		if (this._storeHandlesNamespace) {
+			this._store.namespace = this._namespace;
+		}
 
 		// Forward error events from the underlying store
 		if (typeof store.on === "function") {
@@ -159,10 +177,14 @@ export class KeyvBridgeAdapter extends Hookified implements KeyvStorageAdapter {
 	}
 
 	/**
-	 * Sets the namespace.
+	 * Sets the namespace. When the wrapped store manages its own namespace, the value is
+	 * propagated to it so its native scoped operations stay in sync.
 	 */
 	public set namespace(namespace: string | undefined) {
 		this._namespace = namespace;
+		if (this._storeHandlesNamespace) {
+			this._store.namespace = namespace;
+		}
 	}
 
 	/**
@@ -172,6 +194,12 @@ export class KeyvBridgeAdapter extends Hookified implements KeyvStorageAdapter {
 	 * @returns The prefixed key if namespace is provided, otherwise the original key
 	 */
 	public getKeyPrefix(key: string, namespace?: string) {
+		// When the wrapped store manages its own namespace, the bridge must not also prefix
+		// keys — that would double-namespace. The store applies the namespace itself.
+		if (this._storeHandlesNamespace) {
+			return key;
+		}
+
 		if (namespace) {
 			return `${namespace}${this._keySeparator}${key}`;
 		}
@@ -385,6 +413,13 @@ export class KeyvBridgeAdapter extends Hookified implements KeyvStorageAdapter {
 	 * entire store is cleared.
 	 */
 	public async clear(): Promise<void> {
+		// A store that manages its own namespace scopes clear() to the namespace the bridge
+		// propagated to it, so delegate directly rather than risk an unscoped wipe of the backend.
+		if (this._namespace && this._storeHandlesNamespace) {
+			await this._store.clear();
+			return;
+		}
+
 		if (!this._namespace || !this._capabilities.methods.iterator.exists) {
 			await this._store.clear();
 			return;
@@ -419,7 +454,10 @@ export class KeyvBridgeAdapter extends Hookified implements KeyvStorageAdapter {
 		}
 
 		const namespace = this._namespace;
-		const prefix = namespace ? `${namespace}${this._keySeparator}` : undefined;
+		// A namespace-managing store already scopes its iterator, so the bridge must not also
+		// filter/strip a prefix it never applied.
+		const prefix =
+			namespace && !this._storeHandlesNamespace ? `${namespace}${this._keySeparator}` : undefined;
 
 		/* v8 ignore next -- @preserve */
 		for await (const entry of this._store.iterator?.(this._namespace) ?? []) {

--- a/core/keyv/src/adapters/bridge.ts
+++ b/core/keyv/src/adapters/bridge.ts
@@ -2,8 +2,8 @@
 import { Hookified } from "hookified";
 import { detectKeyvStorage, type KeyvStorageCapability } from "../capabilities.js";
 import type { KeyvStorageAdapter, KeyvStorageGetResult } from "../types/adapters.js";
-import { type KeyvEntry, KeyvEvents } from "../types/keyv.js";
-import { isDataExpired } from "../utils.js";
+import { KeyvEvents, type KeyvStorageEntry } from "../types/keyv.js";
+import { isDataExpired, ttlFromExpires } from "../utils.js";
 
 /**
  * Configuration options for KeyvBridgeAdapter.
@@ -129,10 +129,12 @@ export class KeyvBridgeAdapter extends Hookified implements KeyvStorageAdapter {
 	}
 
 	/**
-	 * Gets the detected capabilities of the underlying store.
+	 * Gets the capabilities of the underlying store, with `expires: true` to declare that
+	 * the bridge accepts an absolute `expires` timestamp (which it converts to a ttl for the
+	 * wrapped legacy store).
 	 */
 	public get capabilities(): KeyvStorageCapability {
-		return this._capabilities;
+		return { ...this._capabilities, expires: true };
 	}
 
 	/**
@@ -255,15 +257,18 @@ export class KeyvBridgeAdapter extends Hookified implements KeyvStorageAdapter {
 	}
 
 	/**
-	 * Stores a value in the store with an optional TTL.
+	 * Stores a value in the store with an optional absolute expiry.
+	 * The wrapped store's `set(key, value, ttl?)` expects a relative duration, so the
+	 * absolute `expires` is converted to a remaining ttl (`undefined` when already expired
+	 * or absent); expiry of stored values is still enforced via the embedded envelope on read.
 	 * @param key - The key to store the value under
 	 * @param value - The value to store
-	 * @param ttl - Optional time-to-live in milliseconds
+	 * @param expires - Optional absolute expiry as Unix ms since epoch
 	 * @returns Always returns true indicating success
 	 */
-	public async set(key: string, value: any, ttl?: number): Promise<boolean> {
+	public async set(key: string, value: any, expires?: number): Promise<boolean> {
 		const keyPrefix = this.getKeyPrefix(key, this._namespace);
-		const result = await this._store.set(keyPrefix, value, ttl);
+		const result = await this._store.set(keyPrefix, value, ttlFromExpires(expires));
 		if (typeof result === "boolean") {
 			return result;
 		}
@@ -274,13 +279,14 @@ export class KeyvBridgeAdapter extends Hookified implements KeyvStorageAdapter {
 	/**
 	 * Stores multiple entries in the store at once.
 	 * Delegates to the store's native setMany if available, otherwise loops over set.
-	 * @param entries - Array of entries containing key, value, and optional TTL
+	 * @param entries - Array of entries containing key, value, and optional absolute `expires`
 	 */
-	public async setMany<Value>(entries: KeyvEntry<Value>[]): Promise<boolean[] | undefined> {
+	public async setMany<Value>(entries: KeyvStorageEntry<Value>[]): Promise<boolean[] | undefined> {
 		if (this._capabilities.methods.setMany.exists) {
 			const prefixedEntries = entries.map((entry) => ({
-				...entry,
 				key: this.getKeyPrefix(entry.key, this._namespace),
+				value: entry.value,
+				ttl: ttlFromExpires(entry.expires),
 			}));
 			await this._store.setMany?.(prefixedEntries);
 			return entries.map(() => true);
@@ -288,7 +294,7 @@ export class KeyvBridgeAdapter extends Hookified implements KeyvStorageAdapter {
 
 		const results: boolean[] = [];
 		for (const entry of entries) {
-			await this.set(entry.key, entry.value, entry.ttl);
+			await this.set(entry.key, entry.value, entry.expires);
 			results.push(true);
 		}
 

--- a/core/keyv/src/adapters/bridge.ts
+++ b/core/keyv/src/adapters/bridge.ts
@@ -286,9 +286,12 @@ export class KeyvBridgeAdapter extends Hookified implements KeyvStorageAdapter {
 
 	/**
 	 * Stores a value in the store with an optional absolute expiry.
-	 * The wrapped store's `set(key, value, ttl?)` expects a relative duration, so the
-	 * absolute `expires` is converted to a remaining ttl (`undefined` when already expired
-	 * or absent); expiry of stored values is still enforced via the embedded envelope on read.
+	 * The wrapped store's `set(key, value, ttl?)` expects a relative duration, so the absolute
+	 * `expires` is converted to a remaining ttl (`undefined` when already expired or absent).
+	 * The value is passed through unchanged — the bridge does not wrap it in an envelope — so
+	 * expiry is enforced by the wrapped legacy store's own ttl handling. (The read-side
+	 * {@link isDataExpired} check only fires when a caller stores a raw `{ value, expires }`
+	 * object directly; when Keyv core drives the bridge the value arrives already encoded.)
 	 * @param key - The key to store the value under
 	 * @param value - The value to store
 	 * @param expires - Optional absolute expiry as Unix ms since epoch
@@ -296,6 +299,15 @@ export class KeyvBridgeAdapter extends Hookified implements KeyvStorageAdapter {
 	 */
 	public async set(key: string, value: any, expires?: number): Promise<boolean> {
 		const keyPrefix = this.getKeyPrefix(key, this._namespace);
+		// `ttlFromExpires` returns undefined for both "no expiry" and "already expired", so an
+		// elapsed deadline would otherwise be stored with no ttl and persist forever (the bridge
+		// embeds no envelope to expire it on read). Delete instead, so a past `expires` yields an
+		// absent key — consistent with how the native adapters treat an already-expired write.
+		if (typeof expires === "number" && expires <= Date.now()) {
+			await this._store.delete(keyPrefix);
+			return true;
+		}
+
 		const result = await this._store.set(keyPrefix, value, ttlFromExpires(expires));
 		if (typeof result === "boolean") {
 			return result;
@@ -311,12 +323,28 @@ export class KeyvBridgeAdapter extends Hookified implements KeyvStorageAdapter {
 	 */
 	public async setMany<Value>(entries: KeyvStorageEntry<Value>[]): Promise<boolean[] | undefined> {
 		if (this._capabilities.methods.setMany.exists) {
-			const prefixedEntries = entries.map((entry) => ({
-				key: this.getKeyPrefix(entry.key, this._namespace),
-				value: entry.value,
-				ttl: ttlFromExpires(entry.expires),
-			}));
-			await this._store.setMany?.(prefixedEntries);
+			const now = Date.now();
+			const isExpired = (entry: KeyvStorageEntry<Value>) =>
+				typeof entry.expires === "number" && entry.expires <= now;
+			// Already-expired entries must not persist (see `set`); batch the live ones and
+			// delete the elapsed ones rather than writing them with no ttl.
+			const live = entries.filter((entry) => !isExpired(entry));
+			if (live.length > 0) {
+				await this._store.setMany?.(
+					live.map((entry) => ({
+						key: this.getKeyPrefix(entry.key, this._namespace),
+						value: entry.value,
+						ttl: ttlFromExpires(entry.expires),
+					})),
+				);
+			}
+
+			for (const entry of entries) {
+				if (isExpired(entry)) {
+					await this._store.delete(this.getKeyPrefix(entry.key, this._namespace));
+				}
+			}
+
 			return entries.map(() => true);
 		}
 

--- a/core/keyv/src/adapters/memory.ts
+++ b/core/keyv/src/adapters/memory.ts
@@ -3,7 +3,8 @@ import { Hookified } from "hookified";
 import { detectKeyvStorage, type KeyvStorageCapability } from "../capabilities.js";
 import { Keyv } from "../keyv.js";
 import type { KeyvStorageAdapter, KeyvStorageGetResult } from "../types/adapters.js";
-import { type KeyvEntry, KeyvEvents } from "../types/keyv.js";
+import { KeyvEvents, type KeyvStorageEntry } from "../types/keyv.js";
+import { ttlFromExpires } from "../utils.js";
 
 /**
  * Internal wrapper for values stored in the memory adapter.
@@ -102,10 +103,11 @@ export class KeyvMemoryAdapter extends Hookified implements KeyvStorageAdapter {
 	}
 
 	/**
-	 * Gets the detected capabilities of the underlying store.
+	 * Gets the capabilities of the underlying store, with `expires: true` to declare that
+	 * this adapter accepts an absolute `expires` timestamp (the v6 storage contract).
 	 */
 	public get capabilities(): KeyvStorageCapability {
-		return this._capabilities;
+		return { ...this._capabilities, expires: true };
 	}
 
 	/**
@@ -202,35 +204,36 @@ export class KeyvMemoryAdapter extends Hookified implements KeyvStorageAdapter {
 	}
 
 	/**
-	 * Stores a value in the store with an optional TTL.
+	 * Stores a value in the store with an optional absolute expiry.
 	 * @param key - The key to store the value under
 	 * @param value - The value to store
-	 * @param ttl - Optional time-to-live in milliseconds
+	 * @param expires - Optional absolute expiry as Unix ms since epoch
 	 * @returns Always returns true indicating success
 	 */
-	public async set(key: string, value: any, ttl?: number): Promise<boolean> {
+	public async set(key: string, value: any, expires?: number): Promise<boolean> {
 		const keyPrefix = this.getKeyPrefix(key, this._namespace);
 		const entry: MemoryEntry = {
 			value,
-			expires: ttl ? Date.now() + ttl : undefined,
+			expires: typeof expires === "number" ? expires : undefined,
 		};
-		this._store.set(keyPrefix, entry, ttl);
+		// A Map/LRU underlay (e.g. QuickLRU) expects a relative duration, so derive it here.
+		this._store.set(keyPrefix, entry, ttlFromExpires(expires));
 		return true;
 	}
 
 	/**
 	 * Stores multiple entries in the store at once.
-	 * @param entries - Array of entries containing key, value, and optional TTL
+	 * @param entries - Array of entries containing key, value, and optional absolute `expires`
 	 */
-	public async setMany<Value>(entries: KeyvEntry<Value>[]): Promise<boolean[] | undefined> {
+	public async setMany<Value>(entries: KeyvStorageEntry<Value>[]): Promise<boolean[] | undefined> {
 		const results: boolean[] = [];
 		for (const entry of entries) {
 			const keyPrefix = this.getKeyPrefix(entry.key, this._namespace);
 			const memEntry: MemoryEntry = {
 				value: entry.value,
-				expires: entry.ttl ? Date.now() + entry.ttl : undefined,
+				expires: typeof entry.expires === "number" ? entry.expires : undefined,
 			};
-			this._store.set(keyPrefix, memEntry, entry.ttl);
+			this._store.set(keyPrefix, memEntry, ttlFromExpires(entry.expires));
 			results.push(true);
 		}
 

--- a/core/keyv/src/capabilities.ts
+++ b/core/keyv/src/capabilities.ts
@@ -59,6 +59,13 @@ export type KeyvStorageCapability = {
 	compatible: boolean;
 	store: "mapLike" | "keyvStorage" | "asyncMap" | "none";
 	methods: KeyvStorageMethods;
+	/**
+	 * Whether the adapter implements the v6 storage contract — it accepts an absolute
+	 * `expires` timestamp (ms since epoch) on `set`/`setMany`. Adapters that omit this
+	 * (legacy relative-`ttl` adapters) are wrapped by `KeyvBridgeAdapter`, which converts
+	 * the absolute `expires` back to a relative ttl before delegating.
+	 */
+	expires?: boolean;
 };
 
 // --- Compression adapter ---
@@ -264,6 +271,24 @@ export function detectKeyvStorage(obj: unknown): KeyvStorageCapability {
 	}
 
 	return { compatible: false, store: "none", methods };
+}
+
+/**
+ * Build the capability descriptor for a v6 storage adapter: the structurally detected
+ * methods plus `expires: true`, declaring that the adapter accepts an absolute `expires`
+ * timestamp on `set`/`setMany`. First-party adapters expose this from their `capabilities`
+ * getter so Keyv uses them directly instead of bridging.
+ * @param adapter - The storage adapter to describe (typically `this`).
+ * @returns A {@link KeyvStorageCapability} with `expires` set to `true`.
+ * @example
+ * ```typescript
+ * public get capabilities(): KeyvStorageCapability {
+ *   return keyvStorageCapability(this);
+ * }
+ * ```
+ */
+export function keyvStorageCapability(adapter: object): KeyvStorageCapability {
+	return { ...detectKeyvStorage(adapter), expires: true };
 }
 
 /**

--- a/core/keyv/src/capabilities.ts
+++ b/core/keyv/src/capabilities.ts
@@ -64,6 +64,13 @@ export type KeyvStorageCapability = {
 	 * `expires` timestamp (ms since epoch) on `set`/`setMany`. Adapters that omit this
 	 * (legacy relative-`ttl` adapters) are wrapped by `KeyvBridgeAdapter`, which converts
 	 * the absolute `expires` back to a relative ttl before delegating.
+	 *
+	 * Declaring `expires: true` is a two-way contract: the adapter is then used directly and
+	 * must ENFORCE expiry on read. Keyv core does not filter expired entries by default
+	 * (`checkExpired` is off), so the adapter is the expiry authority — `get`/`getMany`/`has`
+	 * must return nothing for a key past its deadline, via a native mechanism (TTL index, key
+	 * expiry, lease) and/or a client-side check. Validate with `@keyv/test-suite`'s
+	 * `storageTtlTests`.
 	 */
 	expires?: boolean;
 };

--- a/core/keyv/src/index.ts
+++ b/core/keyv/src/index.ts
@@ -23,6 +23,7 @@ export {
 	detectKeyvEncryption,
 	detectKeyvSerialization,
 	detectKeyvStorage,
+	keyvStorageCapability,
 } from "./capabilities.js";
 export { jsonSerializer, KeyvJsonSerializer } from "./json-serializer.js";
 export { Keyv, Keyv as default } from "./keyv.js";
@@ -44,6 +45,7 @@ export type {
 	KeyvEntry,
 	KeyvMapAny,
 	KeyvOptions,
+	KeyvStorageEntry,
 	KeyvValue,
 } from "./types/keyv.js";
 export { KeyvEvents, KeyvHooks } from "./types/keyv.js";

--- a/core/keyv/src/keyv.ts
+++ b/core/keyv/src/keyv.ts
@@ -296,11 +296,15 @@ export class Keyv<GenericValue = any> extends Hookified {
 	}
 
 	/**
-	 * Resolves a store to a fully-compliant KeyvStorageAdapter using a 3-tier detection chain:
-	 * 1. If the store already implements the full KeyvStorageAdapter interface, use it directly.
-	 * 2. If the store is map-like (synchronous get/set/delete/has), wrap it in KeyvMemoryAdapter.
-	 * 3. If the store has async get/set/delete/clear, wrap it in KeyvBridgeAdapter.
-	 * 4. Otherwise, emit an error and fall back to a default in-memory KeyvMemoryAdapter.
+	 * Resolves a store to a fully-compliant KeyvStorageAdapter:
+	 * 1. If the store declares the v6 `capabilities.expires` contract, use it directly (this takes
+	 *    precedence over structural detection, so a full adapter whose async methods aren't written
+	 *    with the `async` keyword is not mis-bridged).
+	 * 2. If the store implements the full async storage interface (but doesn't declare `expires`),
+	 *    treat it as a legacy relative-`ttl` adapter and wrap it in KeyvBridgeAdapter.
+	 * 3. If the store is map-like (synchronous get/set/delete/has), wrap it in KeyvMemoryAdapter.
+	 * 4. If the store has async get/set/delete/clear, wrap it in KeyvBridgeAdapter.
+	 * 5. Otherwise, emit an error and fall back to a default in-memory KeyvMemoryAdapter.
 	 *
 	 * NOTE: this is used for internal but provided public for custom adapter testing
 	 * @param {unknown} store The store to resolve.
@@ -308,17 +312,19 @@ export class Keyv<GenericValue = any> extends Hookified {
 	 */
 	// biome-ignore lint/suspicious/noExplicitAny: accepts any store type
 	public resolveStore(store: any): KeyvStorageAdapter {
+		// A v6 adapter explicitly declaring the absolute-`expires` contract is authoritative and
+		// used directly, even when structural detection would classify it as `asyncMap` (e.g. its
+		// methods return promises without the `async` keyword). Without this it would be bridged
+		// and wrongly handed a relative ttl where its contract expects an absolute `expires`.
+		if ((store as KeyvStorageAdapter | undefined)?.capabilities?.expires === true) {
+			return store as KeyvStorageAdapter;
+		}
+
 		const cap = detectKeyvStorage(store);
 
 		if (cap.store === "keyvStorage") {
-			const adapter = store as KeyvStorageAdapter;
-			// v6 adapters declare `capabilities.expires` and receive the absolute `expires`
-			// directly. Legacy relative-`ttl` adapters (no such capability) are wrapped by the
-			// bridge, which converts the absolute `expires` back to a ttl before delegating.
-			if (adapter.capabilities?.expires) {
-				return adapter;
-			}
-
+			// Full async adapter without the `expires` capability → legacy relative-`ttl` adapter;
+			// the bridge converts the absolute `expires` back to a ttl before delegating.
 			return new KeyvBridgeAdapter(store as KeyvBridgeStore);
 		}
 
@@ -431,6 +437,24 @@ export class Keyv<GenericValue = any> extends Hookified {
 	}
 
 	/**
+	 * Reads many keys from the store, preferring its native `getMany` and falling back to parallel
+	 * single `get`s when an adapter does not implement it. A directly-used v6 adapter is not
+	 * structurally required to provide `getMany` (the bridge and memory adapters always do), so
+	 * this keeps `getMany`/`getManyRaw` working regardless of the resolved adapter.
+	 * @param keys - the keys to read
+	 * @returns the raw store results in the same order as `keys`
+	 */
+	private async storeGetMany<Value>(
+		keys: string[],
+	): Promise<Array<KeyvStorageGetResult<Value | undefined>>> {
+		if (typeof this._store.getMany === "function") {
+			return this._store.getMany<Value>(keys);
+		}
+
+		return Promise.all(keys.map(async (key) => this._store.get<Value>(key)));
+	}
+
+	/**
 	 * Get many values for an array of keys.
 	 * @param {string[]} keys the keys to get
 	 * @returns {Promise<Array<Value | undefined>>} an array of values in the same order as the
@@ -441,9 +465,7 @@ export class Keyv<GenericValue = any> extends Hookified {
 
 		await this.hookWithDeprecated(KeyvHooks.BEFORE_GET_MANY, { keys });
 
-		const rawData =
-			await // biome-ignore lint/style/noNonNullAssertion: guaranteed by resolveStore
-			this._store.getMany!<Value>(keys);
+		const rawData = await this.storeGetMany<Value>(keys);
 
 		let deserialized: Array<KeyvValue<Value> | undefined>;
 		if (this._checkExpired) {
@@ -545,9 +567,7 @@ export class Keyv<GenericValue = any> extends Hookified {
 			return result;
 		}
 
-		const rawData =
-			await // biome-ignore lint/style/noNonNullAssertion: guaranteed by resolveStore
-			this._store.getMany!<Value>(keys);
+		const rawData = await this.storeGetMany<Value>(keys);
 
 		let result: Array<KeyvValue<Value> | undefined>;
 		if (this._checkExpired) {

--- a/core/keyv/src/keyv.ts
+++ b/core/keyv/src/keyv.ts
@@ -311,7 +311,15 @@ export class Keyv<GenericValue = any> extends Hookified {
 		const cap = detectKeyvStorage(store);
 
 		if (cap.store === "keyvStorage") {
-			return store as KeyvStorageAdapter;
+			const adapter = store as KeyvStorageAdapter;
+			// v6 adapters declare `capabilities.expires` and receive the absolute `expires`
+			// directly. Legacy relative-`ttl` adapters (no such capability) are wrapped by the
+			// bridge, which converts the absolute `expires` back to a ttl before delegating.
+			if (adapter.capabilities?.expires) {
+				return adapter;
+			}
+
+			return new KeyvBridgeAdapter(store as KeyvBridgeStore);
 		}
 
 		if (cap.store === "mapLike") {
@@ -610,7 +618,7 @@ export class Keyv<GenericValue = any> extends Hookified {
 
 		try {
 			encodedValue = await this.encode(formattedValue);
-			result = await this._store.set(data.key, encodedValue, data.ttl);
+			result = await this._store.set(data.key, encodedValue, expires);
 		} catch (error) {
 			result = false;
 			this.emit(KeyvEvents.ERROR, error);
@@ -664,7 +672,7 @@ export class Keyv<GenericValue = any> extends Hookified {
 
 					const formattedValue = { value, expires };
 					const encodedValue = await this.encode(formattedValue);
-					return { key, value: encodedValue, ttl };
+					return { key, value: encodedValue, expires };
 				}),
 			);
 			// biome-ignore lint/style/noNonNullAssertion: guaranteed by resolveStore
@@ -711,13 +719,16 @@ export class Keyv<GenericValue = any> extends Hookified {
 		const data = { key, value };
 		await this.hookWithDeprecated(KeyvHooks.BEFORE_SET_RAW, data);
 
-		const ttl = ttlFromExpires(data.value.expires);
+		// `expires` is the canonical value passed to the store; `ttl` is derived
+		// only for the public AFTER_SET_RAW hook payload below.
+		const expires = data.value.expires;
+		const ttl = ttlFromExpires(expires);
 
 		let result = true;
 
 		try {
 			const encodedValue = await this.encode(data.value);
-			const storeResult = await this._store.set(data.key, encodedValue, ttl);
+			const storeResult = await this._store.set(data.key, encodedValue, expires);
 
 			if (typeof storeResult === "boolean") {
 				result = storeResult;
@@ -763,9 +774,8 @@ export class Keyv<GenericValue = any> extends Hookified {
 		try {
 			const rawEntries = await Promise.all(
 				entries.map(async ({ key, value }) => {
-					const ttl = ttlFromExpires(value.expires);
 					const encodedValue = await this.encode(value);
-					return { key, value: encodedValue, ttl };
+					return { key, value: encodedValue, expires: value.expires };
 				}),
 			);
 			const storeResult = await this._store.setMany(rawEntries);

--- a/core/keyv/src/types/adapters.ts
+++ b/core/keyv/src/types/adapters.ts
@@ -1,6 +1,6 @@
 import type { IEventEmitter } from "hookified";
 import type { KeyvStorageCapability } from "../capabilities.js";
-import type { KeyvEntry, KeyvValue } from "./keyv.js";
+import type { KeyvStorageEntry, KeyvValue } from "./keyv.js";
 
 /**
  * Adapter interface for custom serialization.
@@ -44,14 +44,23 @@ export type KeyvStorageGetResult<Value> = KeyvValue<Value> | string | undefined;
 export type KeyvStorageAdapter = {
 	/** Optional namespace for key isolation. */
 	namespace?: string | undefined;
-	/** Detected capabilities of the underlying store. */
+	/**
+	 * The adapter's capabilities. v6 adapters set `capabilities.expires = true` (e.g. via
+	 * `keyvStorageCapability(this)`) to declare they accept an absolute `expires` timestamp
+	 * on `set`/`setMany`. Full storage adapters that omit it are treated as legacy relative-`ttl`
+	 * adapters and wrapped by `KeyvBridgeAdapter`, which converts `expires` back to a ttl.
+	 */
 	capabilities?: KeyvStorageCapability;
 	/** Retrieves a value by key. */
 	get<Value>(key: string): Promise<KeyvStorageGetResult<Value>>;
-	/** Stores a value with a key and optional TTL in milliseconds. */
-	set(key: string, value: unknown, ttl?: number): Promise<boolean>;
-	/** Stores multiple entries at once. */
-	setMany<Value>(values: KeyvEntry<Value>[]): Promise<boolean[] | undefined>;
+	/**
+	 * Stores a value with a key and optional absolute expiry.
+	 * @param expires Absolute expiry as Unix ms since epoch; `undefined` means no expiry.
+	 * A value `<= Date.now()` is already expired and the adapter may delete/skip it.
+	 */
+	set(key: string, value: unknown, expires?: number): Promise<boolean>;
+	/** Stores multiple entries at once, each with an absolute `expires` timestamp. */
+	setMany<Value>(values: KeyvStorageEntry<Value>[]): Promise<boolean[] | undefined>;
 	/** Deletes a key from the store. */
 	delete(key: string): Promise<boolean>;
 	/** Clears all entries from the store (respects namespace if set). */

--- a/core/keyv/src/types/adapters.ts
+++ b/core/keyv/src/types/adapters.ts
@@ -49,6 +49,10 @@ export type KeyvStorageAdapter = {
 	 * `keyvStorageCapability(this)`) to declare they accept an absolute `expires` timestamp
 	 * on `set`/`setMany`. Full storage adapters that omit it are treated as legacy relative-`ttl`
 	 * adapters and wrapped by `KeyvBridgeAdapter`, which converts `expires` back to a ttl.
+	 *
+	 * Declaring `expires: true` also obliges the adapter to enforce expiry on read: Keyv core
+	 * does not filter expired entries by default, so `get`/`getMany`/`has` must not return a key
+	 * past its deadline. See {@link KeyvStorageCapability.expires}.
 	 */
 	capabilities?: KeyvStorageCapability;
 	/** Retrieves a value by key. */

--- a/core/keyv/src/types/keyv.ts
+++ b/core/keyv/src/types/keyv.ts
@@ -127,7 +127,8 @@ export enum KeyvHooks {
 }
 
 /**
- * Represents a key-value entry with an optional TTL, used for batch operations like `setMany`.
+ * Represents a key-value entry with an optional TTL, used for the public
+ * batch API `Keyv.setMany`.
  */
 // biome-ignore lint/suspicious/noExplicitAny: type format
 export type KeyvEntry<Value = any> = {
@@ -143,6 +144,22 @@ export type KeyvEntry<Value = any> = {
 	 * Time to live in milliseconds.
 	 */
 	ttl?: number;
+};
+
+/**
+ * Represents a key-value entry at the storage-adapter boundary, carrying an
+ * absolute `expires` timestamp instead of a relative `ttl`. Keyv core computes
+ * `expires` once and passes these to a storage adapter's `setMany`, so adapters
+ * never derive expiry themselves.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: type format
+export type KeyvStorageEntry<Value = any> = {
+	/** Key to set. */
+	key: string;
+	/** Value to set (already encoded by Keyv core). */
+	value: Value;
+	/** Absolute expiry as Unix ms since epoch, or `undefined` for no expiry. */
+	expires?: number;
 };
 
 /**

--- a/core/keyv/test/adapters/bridge-integration.test.ts
+++ b/core/keyv/test/adapters/bridge-integration.test.ts
@@ -119,6 +119,29 @@ describe("KeyvBridgeAdapter + keyv-file", () => {
 		await keyv.delete(key);
 		expect(await keyv.get(key)).toBeUndefined();
 	});
+
+	test("should expire values end-to-end when Keyv wraps a legacy store via the bridge", async () => {
+		const filename = path.join(tmpDir, `${faker.string.alphanumeric(8)}.json`);
+		const legacyStore = new KeyvFile({ filename, writeDelay: 0 });
+		// Passing the raw legacy adapter (no `capabilities.expires`) makes Keyv resolve it through
+		// KeyvBridgeAdapter. A relative ttl from the public API must round-trip to an absolute
+		// `expires`, convert back to a ttl the legacy store honors, and actually expire.
+		const keyv = new Keyv({ store: legacyStore });
+		const key = faker.string.uuid();
+		await keyv.set(key, "value", 100);
+		expect(await keyv.get(key)).toBe("value");
+		await new Promise((resolve) => setTimeout(resolve, 300));
+		expect(await keyv.get(key)).toBeUndefined();
+	});
+
+	test("should not persist a value written with an already-elapsed expires", async () => {
+		const key = faker.string.uuid();
+		await bridge.set(key, "live");
+		// An already-expired write must remove the key, not store it without a ttl.
+		await bridge.set(key, "stale", Date.now() - 1000);
+		expect(await bridge.get(key)).toBeUndefined();
+		expect(await bridge.has(key)).toBe(false);
+	});
 });
 
 // keyv-anyredis tests - requires a running Redis server

--- a/core/keyv/test/adapters/bridge.test.ts
+++ b/core/keyv/test/adapters/bridge.test.ts
@@ -172,12 +172,15 @@ describe("KeyvBridgeAdapter - Core Operations (minimal store)", () => {
 		expect(await bridge.get("nullkey")).toBeUndefined();
 	});
 
-	test("should pass ttl to store set", async () => {
+	test("should convert absolute expires to a relative ttl for the wrapped store", async () => {
 		const setSpy = vi.fn().mockResolvedValue(undefined);
 		const store: KeyvBridgeStore = { get: vi.fn(), set: setSpy, delete: vi.fn(), clear: vi.fn() };
 		const bridge = new KeyvBridgeAdapter(store);
-		await bridge.set("key", "value", 5000);
-		expect(setSpy).toHaveBeenCalledWith("key", "value", 5000);
+		await bridge.set("key", "value", Date.now() + 5000);
+		expect(setSpy).toHaveBeenCalledWith("key", "value", expect.any(Number));
+		const passedTtl = setSpy.mock.calls[0][2] as number;
+		expect(passedTtl).toBeGreaterThan(4000);
+		expect(passedTtl).toBeLessThanOrEqual(5000);
 	});
 });
 

--- a/core/keyv/test/adapters/bridge.test.ts
+++ b/core/keyv/test/adapters/bridge.test.ts
@@ -547,3 +547,83 @@ describe("KeyvBridgeAdapter - v5 Adapter Compatibility", () => {
 		expect(iteratorSpy).toHaveBeenCalledWith(undefined);
 	});
 });
+
+describe("KeyvBridgeAdapter - namespace-managing store", () => {
+	// Simulates a legacy full adapter that scopes its own keys by `namespace` (like the
+	// first-party storage adapters do), including a namespace-scoped clear() and NO iterator().
+	function createNamespacingStore() {
+		const map = new Map<string, unknown>();
+		const nsKey = (key: string) => (store.namespace ? `${store.namespace}::${key}` : key);
+		const store = {
+			namespace: undefined as string | undefined,
+			async get(key: string) {
+				return map.get(nsKey(key));
+			},
+			async set(key: string, value: unknown, _ttl?: number) {
+				map.set(nsKey(key), value);
+			},
+			async delete(key: string) {
+				return map.delete(nsKey(key));
+			},
+			async clear() {
+				const prefix = store.namespace ? `${store.namespace}::` : "";
+				for (const k of [...map.keys()]) {
+					if (k.startsWith(prefix)) {
+						map.delete(k);
+					}
+				}
+			},
+			async has(key: string) {
+				return map.has(nsKey(key));
+			},
+			async hasMany(keys: string[]) {
+				return keys.map((key) => map.has(nsKey(key)));
+			},
+			async getMany(keys: string[]) {
+				return keys.map((key) => map.get(nsKey(key)));
+			},
+			async setMany(entries: Array<{ key: string; value: unknown; ttl?: number }>) {
+				for (const entry of entries) {
+					map.set(nsKey(entry.key), entry.value);
+				}
+				return entries.map(() => true);
+			},
+			async deleteMany(keys: string[]) {
+				return keys.map((key) => map.delete(nsKey(key)));
+			},
+			_map: map,
+		};
+		return store;
+	}
+
+	test("propagates namespace and does not double-prefix keys", async () => {
+		const store = createNamespacingStore();
+		const bridge = new KeyvBridgeAdapter(store, { namespace: "a" });
+		// The bridge hands its namespace to the store instead of prefixing keys itself.
+		expect(store.namespace).toBe("a");
+		await bridge.set("k", "v");
+		expect(store._map.has("a::k")).toBe(true); // store's own namespacing
+		expect(store._map.has("a:k")).toBe(false); // NOT bridge-prefixed
+		expect(await bridge.get("k")).toBe("v");
+	});
+
+	test("scopes clear() to the namespace instead of wiping the whole backend", async () => {
+		const store = createNamespacingStore();
+		const bridge = new KeyvBridgeAdapter(store, { namespace: "a" });
+		await bridge.set("k", "v");
+		// Another namespace's data living in the same backend.
+		store._map.set("b::other", "keep");
+
+		await bridge.clear();
+
+		expect(store._map.has("a::k")).toBe(false); // our namespace cleared
+		expect(store._map.has("b::other")).toBe(true); // other namespace preserved
+	});
+
+	test("setter re-propagates the namespace to the store", () => {
+		const store = createNamespacingStore();
+		const bridge = new KeyvBridgeAdapter(store);
+		bridge.namespace = "x";
+		expect(store.namespace).toBe("x");
+	});
+});

--- a/core/keyv/test/adapters/bridge.test.ts
+++ b/core/keyv/test/adapters/bridge.test.ts
@@ -202,6 +202,17 @@ describe("KeyvBridgeAdapter - TTL / Expiration", () => {
 		store._map.set(key3, { value: "permanent" });
 		expect(await bridge.get(key3)).toEqual({ value: "permanent" });
 	});
+
+	test("should delete rather than persist a write with an already-elapsed expires", async () => {
+		const store = createFullStore();
+		const bridge = new KeyvBridgeAdapter(store);
+		await bridge.set("k", "live");
+		expect(store._map.has("k")).toBe(true);
+		// An elapsed deadline must remove the key, not store it forever with no ttl.
+		expect(await bridge.set("k", "stale", Date.now() - 1000)).toBe(true);
+		expect(store._map.has("k")).toBe(false);
+		expect(await bridge.get("k")).toBeUndefined();
+	});
 });
 
 describe("KeyvBridgeAdapter - Fallback Methods (minimal store)", () => {
@@ -333,6 +344,35 @@ describe("KeyvBridgeAdapter - Native Delegation (full store)", () => {
 		expect(nsSetManySpy).toHaveBeenCalledWith([{ key: "ns:key1", value: "value1" }]);
 		await nsBridge.deleteMany(["key1", "key2"]);
 		expect(nsDeleteManySpy).toHaveBeenCalledWith(["ns:key1", "ns:key2"]);
+	});
+
+	test("setMany should batch only live entries and delete already-expired ones", async () => {
+		const store = createFullStore();
+		const setManySpy = vi.spyOn(store, "setMany");
+		const bridge = new KeyvBridgeAdapter(store);
+
+		// Seed a key that the expired entry in the batch should remove.
+		await bridge.set("gone", "old");
+		const result = await bridge.setMany([
+			{ key: "live", value: "v1", expires: Date.now() + 60_000 },
+			{ key: "gone", value: "v2", expires: Date.now() - 1000 },
+		]);
+		expect(result).toEqual([true, true]);
+		// Only the live entry is batched into the native setMany.
+		expect(setManySpy).toHaveBeenCalledWith([
+			{ key: "live", value: "v1", ttl: expect.any(Number) },
+		]);
+		expect(store._map.has("live")).toBe(true);
+		expect(store._map.has("gone")).toBe(false);
+
+		// An all-expired batch skips the native setMany entirely.
+		setManySpy.mockClear();
+		await bridge.set("p", "present");
+		expect(await bridge.setMany([{ key: "p", value: "x", expires: Date.now() - 1 }])).toEqual([
+			true,
+		]);
+		expect(setManySpy).not.toHaveBeenCalled();
+		expect(store._map.has("p")).toBe(false);
 	});
 });
 

--- a/core/keyv/test/capabilities.test.ts
+++ b/core/keyv/test/capabilities.test.ts
@@ -5,6 +5,7 @@ import {
 	detectKeyvEncryption,
 	detectKeyvSerialization,
 	detectKeyvStorage,
+	keyvStorageCapability,
 } from "../src/capabilities.js";
 import { Keyv } from "../src/index.js";
 
@@ -262,6 +263,31 @@ describe("capabilities", () => {
 			expect(result.methods.set.methodType).toBe("sync");
 			expect(result.methods.delete.methodType).toBe("async");
 			expect(result.methods.clear.methodType).toBe("sync");
+		});
+	});
+
+	describe("keyvStorageCapability", () => {
+		test("should return detected methods with the v6 expires contract flag", () => {
+			const adapter = {
+				get: async () => {},
+				set: async () => {},
+				delete: async () => {},
+				clear: async () => {},
+				has: async () => true,
+				getMany: async () => [],
+				setMany: async () => {},
+				deleteMany: async () => true,
+				hasMany: async () => [],
+				disconnect: async () => {},
+				iterator: async function* () {
+					yield ["key", "value"];
+				},
+			};
+			const result = keyvStorageCapability(adapter);
+			expect(result.expires).toBe(true);
+			expect(result.store).toBe("keyvStorage");
+			expect(result.methods.get.exists).toBe(true);
+			expect(result.methods.set.exists).toBe(true);
 		});
 	});
 

--- a/core/keyv/test/keyv.test.ts
+++ b/core/keyv/test/keyv.test.ts
@@ -1,6 +1,6 @@
 import { faker } from "@faker-js/faker";
 import { beforeEach, describe, expect, test, vi } from "vitest";
-import Keyv, { KeyvMemoryAdapter, KeyvSanitize } from "../src/index.js";
+import Keyv, { KeyvBridgeAdapter, KeyvMemoryAdapter, KeyvSanitize } from "../src/index.js";
 import { KeyvStats } from "../src/stats.js";
 import { createMockCompression, createStore, delay } from "./test-utils.js";
 
@@ -900,5 +900,72 @@ describe("decodeWithExpire", () => {
 		const result = await keyv.decodeWithExpire("key", objectData);
 		expect(result[0]?.value).toBe("test-value");
 		expect(mockCompression.decompress).not.toHaveBeenCalled();
+	});
+});
+
+describe("storage adapter expiry negotiation", () => {
+	const createFullStorageAdapter = (capabilities?: { expires?: boolean }) => {
+		const calls: Array<{ key: string; arg?: number }> = [];
+		return {
+			namespace: undefined as string | undefined,
+			capabilities,
+			calls,
+			async get() {
+				return undefined;
+			},
+			async set(key: string, _value: unknown, arg?: number) {
+				calls.push({ key, arg });
+				return true;
+			},
+			async setMany() {
+				return [];
+			},
+			async delete() {
+				return true;
+			},
+			async deleteMany() {
+				return [];
+			},
+			async clear() {},
+			async has() {
+				return false;
+			},
+			async hasMany() {
+				return [];
+			},
+			async getMany() {
+				return [];
+			},
+			on() {},
+		};
+	};
+
+	test("uses a v6 adapter (capabilities.expires) directly", () => {
+		const keyv = new Keyv();
+		const adapter = createFullStorageAdapter({ expires: true });
+		// biome-ignore lint/suspicious/noExplicitAny: test stub adapter
+		expect(keyv.resolveStore(adapter as any)).toBe(adapter);
+	});
+
+	test("wraps a legacy ttl adapter (no capabilities) in the bridge", () => {
+		const keyv = new Keyv();
+		const adapter = createFullStorageAdapter();
+		// biome-ignore lint/suspicious/noExplicitAny: test stub adapter
+		expect(keyv.resolveStore(adapter as any)).toBeInstanceOf(KeyvBridgeAdapter);
+	});
+
+	test("passes absolute expires to a v6 adapter but a relative ttl to a legacy adapter", async () => {
+		const v6 = createFullStorageAdapter({ expires: true });
+		// biome-ignore lint/suspicious/noExplicitAny: test stub adapter
+		await new Keyv({ store: v6 as any }).set("k", "v", 1000);
+		// An absolute ms-since-epoch timestamp is far larger than any relative ttl.
+		expect(v6.calls[0].arg).toBeGreaterThan(1e12);
+
+		const legacy = createFullStorageAdapter();
+		// biome-ignore lint/suspicious/noExplicitAny: test stub adapter
+		await new Keyv({ store: legacy as any }).set("k", "v", 1000);
+		// The bridge converts the absolute expires back to a relative ttl (~1000ms).
+		expect(legacy.calls[0].arg).toBeGreaterThan(500);
+		expect(legacy.calls[0].arg).toBeLessThanOrEqual(1000);
 	});
 });

--- a/core/keyv/test/keyv.test.ts
+++ b/core/keyv/test/keyv.test.ts
@@ -968,4 +968,86 @@ describe("storage adapter expiry negotiation", () => {
 		expect(legacy.calls[0].arg).toBeGreaterThan(500);
 		expect(legacy.calls[0].arg).toBeLessThanOrEqual(1000);
 	});
+
+	// A v6 adapter whose methods return promises WITHOUT the `async` keyword structurally
+	// classifies as map-like rather than keyvStorage. The explicit `capabilities.expires`
+	// declaration must still make Keyv use it directly (not wrap it).
+	const createNonAsyncV6Adapter = (capabilities?: { expires?: boolean }) => {
+		const map = new Map<string, unknown>();
+		const calls: Array<{ key: string; arg?: number }> = [];
+		return {
+			capabilities,
+			calls,
+			get(key: string) {
+				return Promise.resolve(map.get(key));
+			},
+			set(key: string, value: unknown, arg?: number) {
+				calls.push({ key, arg });
+				map.set(key, value);
+				return Promise.resolve(true);
+			},
+			delete(key: string) {
+				return Promise.resolve(map.delete(key));
+			},
+			clear() {
+				map.clear();
+				return Promise.resolve();
+			},
+			has(key: string) {
+				return Promise.resolve(map.has(key));
+			},
+			on() {},
+		};
+	};
+
+	test("uses a capabilities.expires adapter directly even when its methods are not async", async () => {
+		const keyv = new Keyv();
+		// Without the capability it is not used directly (structurally wrapped)...
+		// biome-ignore lint/suspicious/noExplicitAny: test stub adapter
+		const plain = createNonAsyncV6Adapter() as any;
+		expect(keyv.resolveStore(plain)).not.toBe(plain);
+
+		// ...but the explicit declaration is authoritative and used directly.
+		const v6 = createNonAsyncV6Adapter({ expires: true });
+		// biome-ignore lint/suspicious/noExplicitAny: test stub adapter
+		expect(keyv.resolveStore(v6 as any)).toBe(v6);
+
+		// And it receives an absolute expires (proving it was not bridged to a relative ttl).
+		// biome-ignore lint/suspicious/noExplicitAny: test stub adapter
+		await new Keyv({ store: v6 as any }).set("k", "v", 1000);
+		expect(v6.calls[0].arg).toBeGreaterThan(1e12);
+	});
+
+	test("getMany/getManyRaw fall back to single gets when a directly-used adapter lacks getMany", async () => {
+		const map = new Map<string, unknown>();
+		const adapter = {
+			capabilities: { expires: true },
+			async get(key: string) {
+				return map.get(key);
+			},
+			async set(key: string, value: unknown) {
+				map.set(key, value);
+				return true;
+			},
+			async delete(key: string) {
+				return map.delete(key);
+			},
+			async clear() {
+				map.clear();
+			},
+			async has(key: string) {
+				return map.has(key);
+			},
+			on() {},
+			// intentionally no getMany
+		};
+		// biome-ignore lint/suspicious/noExplicitAny: test stub adapter
+		const keyv = new Keyv({ store: adapter as any });
+		await keyv.set("a", "1");
+		await keyv.set("b", "2");
+		expect(await keyv.getMany(["a", "b", "c"])).toEqual(["1", "2", undefined]);
+		const raw = await keyv.getManyRaw(["a", "c"]);
+		expect(raw[0]).toMatchObject({ value: "1" });
+		expect(raw[1]).toBeUndefined();
+	});
 });

--- a/core/keyv/test/set.test.ts
+++ b/core/keyv/test/set.test.ts
@@ -65,17 +65,25 @@ describe("Keyv", async () => {
 describe("ttl", () => {
 	test("Keyv passes ttl info to stores", async () => {
 		expect.assertions(1);
-		const store = new Map();
-		const storeSet = store.set;
-		// @ts-expect-error
-		store.set = (key, value, ttl) => {
-			expect(ttl).toBe(100);
+		// Freeze time: the storage boundary now carries an absolute `expires`, and the memory
+		// adapter derives the underlay ttl as `expires - Date.now()`. Without a frozen clock the
+		// ~sub-ms elapsed between computing `expires` and deriving the ttl yields 99 instead of 100.
+		tk.freeze(Date.now());
+		try {
+			const store = new Map();
+			const storeSet = store.set;
 			// @ts-expect-error
-			storeSet.call(store, key, value, ttl);
-		};
+			store.set = (key, value, ttl) => {
+				expect(ttl).toBe(100);
+				// @ts-expect-error
+				storeSet.call(store, key, value, ttl);
+			};
 
-		const keyv = new Keyv({ store });
-		await keyv.set("foo", "bar", 100);
+			const keyv = new Keyv({ store });
+			await keyv.set("foo", "bar", 100);
+		} finally {
+			tk.reset();
+		}
 	});
 
 	test("Keyv respects default ttl option", async () => {

--- a/core/test-suite/src/storage-ttl.ts
+++ b/core/test-suite/src/storage-ttl.ts
@@ -35,6 +35,17 @@ const storageTtlTests = (test: TestFunction, store: StorageFn, options?: Storage
 		t.expect(await s.get(key)).toBe(missingValue);
 	});
 
+	test("set(key, value, expires) with an already-elapsed deadline does not persist", async (t) => {
+		const s = store();
+		const key = faker.string.alphanumeric(10);
+		// An absolute expiry already in the past can reach an adapter via setRaw or write
+		// latency. The write must be accepted (not rejected, e.g. Redis `PX 0`) and the entry
+		// must not survive as a live, never-expiring value.
+		await s.set(key, faker.lorem.word(), expiresIn(-ttl));
+		await delay(expiryDelay);
+		t.expect(await s.get(key)).toBe(missingValue);
+	});
+
 	test("has(key) returns false for expired key", async (t) => {
 		const s = store();
 		const key = faker.string.alphanumeric(10);

--- a/core/test-suite/src/storage-ttl.ts
+++ b/core/test-suite/src/storage-ttl.ts
@@ -3,10 +3,11 @@ import { delay } from "./helper.js";
 import type { StorageFn, StorageTestOptions, TestFunction } from "./types.js";
 
 /**
- * Registers TTL expiration tests directly on the storage adapter: set with TTL,
- * has after expiry, and setMany with per-entry TTL. Skipped if `options.ttl` is `false`.
- * Set `options.ttlGranularity` to "seconds" for backends that only support
- * second-level TTLs (e.g. etcd leases, DynamoDB TTL) so second-scale values are used.
+ * Registers expiry tests directly on the storage adapter: set with an absolute
+ * `expires`, has after expiry, and setMany with per-entry `expires`. Skipped if
+ * `options.ttl` is `false`. Set `options.ttlGranularity` to "seconds" for backends
+ * that only support second-level expiry (e.g. etcd leases, DynamoDB TTL) so
+ * second-scale deadlines are used.
  * @param test - The test registration function (e.g. vitest `it`)
  * @param store - Factory that returns a fresh {@link KeyvStorageAdapter} instance
  * @param options - Test configuration (missingValue, ttlGranularity, toggle flags)
@@ -21,12 +22,14 @@ const storageTtlTests = (test: TestFunction, store: StorageFn, options?: Storage
 	const seconds = options?.ttlGranularity === "seconds";
 	const ttl = seconds ? 1000 : 100;
 	const expiryDelay = seconds ? 3000 : 200;
+	// The storage contract takes an absolute expiry (ms since epoch), not a relative ttl.
+	const expiresIn = (ms: number) => Date.now() + ms;
 
-	test("set(key, value, ttl) expires after TTL", async (t) => {
+	test("set(key, value, expires) expires after the deadline", async (t) => {
 		const s = store();
 		const key = faker.string.alphanumeric(10);
 		const value = faker.lorem.word();
-		await s.set(key, value, ttl);
+		await s.set(key, value, expiresIn(ttl));
 		t.expect(await s.get(key)).toBe(value);
 		await delay(expiryDelay);
 		t.expect(await s.get(key)).toBe(missingValue);
@@ -35,19 +38,19 @@ const storageTtlTests = (test: TestFunction, store: StorageFn, options?: Storage
 	test("has(key) returns false for expired key", async (t) => {
 		const s = store();
 		const key = faker.string.alphanumeric(10);
-		await s.set(key, faker.lorem.word(), ttl);
+		await s.set(key, faker.lorem.word(), expiresIn(ttl));
 		await delay(expiryDelay);
 		t.expect(await s.has(key)).toBe(false);
 	});
 
-	test("setMany with per-entry TTL expires individual entries", async (t) => {
+	test("setMany with per-entry expires expires individual entries", async (t) => {
 		const s = store();
 		const key1 = faker.string.alphanumeric(10);
 		const key2 = faker.string.alphanumeric(10);
 		const val1 = faker.lorem.word();
 		const val2 = faker.lorem.word();
 		await s.setMany([
-			{ key: key1, value: val1, ttl },
+			{ key: key1, value: val1, expires: expiresIn(ttl) },
 			{ key: key2, value: val2 },
 		]);
 		t.expect(await s.get(key1)).toBe(val1);

--- a/storage/dynamo/src/index.ts
+++ b/storage/dynamo/src/index.ts
@@ -19,9 +19,20 @@ import {
 	type ScanCommandOutput,
 } from "@aws-sdk/lib-dynamodb";
 import { Hookified } from "hookified";
-import { Keyv, type KeyvEntry, type KeyvStorageAdapter, type KeyvStorageGetResult } from "keyv";
+import {
+	Keyv,
+	type KeyvStorageAdapter,
+	type KeyvStorageEntry,
+	type KeyvStorageGetResult,
+	keyvStorageCapability,
+} from "keyv";
 
 export class KeyvDynamo extends Hookified implements KeyvStorageAdapter {
+	/** Declares the v6 absolute-`expires` storage contract via `capabilities.expires`. */
+	public get capabilities() {
+		return keyvStorageCapability(this);
+	}
+
 	private _sixHoursInMilliseconds = 6 * 60 * 60 * 1000;
 	private _namespace?: string;
 	private _opts: Omit<KeyvDynamoOptions, "tableName"> & { tableName: string };
@@ -192,18 +203,18 @@ export class KeyvDynamo extends Hookified implements KeyvStorageAdapter {
 	}
 
 	/**
-	 * Stores a value in DynamoDB. Uses a 6-hour default TTL if no TTL is specified.
+	 * Stores a value in DynamoDB. Uses a 6-hour default expiry if no expiry is specified.
 	 * @param key - The key to store
 	 * @param value - The value to store
-	 * @param ttl - Optional TTL in milliseconds
+	 * @param expires - Absolute expiry as Unix ms since epoch, or `undefined` for the 6-hour default.
 	 * @returns `true` if the value was stored, `false` if the write failed.
 	 */
-	public async set(key: string, value: unknown, ttl?: number): Promise<boolean> {
+	public async set(key: string, value: unknown, expires?: number): Promise<boolean> {
 		try {
 			await this._tableReady;
 
-			const now = Date.now();
-			const expiresAtMs = typeof ttl === "number" ? now + ttl : now + this._sixHoursInMilliseconds;
+			const expiresAtMs =
+				typeof expires === "number" ? expires : Date.now() + this._sixHoursInMilliseconds;
 			const expiresAt = Math.ceil(expiresAtMs / 1000);
 
 			const putInput: PutCommandInput = {
@@ -229,10 +240,11 @@ export class KeyvDynamo extends Hookified implements KeyvStorageAdapter {
 	/**
 	 * Stores multiple values in DynamoDB.
 	 * @template Value - The type of the values being stored.
-	 * @param entries - An array of objects containing key, value, and optional ttl
+	 * @param entries - An array of `{ key, value, expires? }` entries, where `expires` is an
+	 * absolute Unix ms timestamp (or `undefined` for the 6-hour default).
 	 * @returns An array of booleans, one per entry, indicating which writes succeeded.
 	 */
-	public async setMany<Value>(entries: KeyvEntry<Value>[]): Promise<boolean[] | undefined> {
+	public async setMany<Value>(entries: KeyvStorageEntry<Value>[]): Promise<boolean[] | undefined> {
 		try {
 			await this._tableReady;
 
@@ -240,11 +252,9 @@ export class KeyvDynamo extends Hookified implements KeyvStorageAdapter {
 				return entries.map(() => true);
 			}
 
-			const now = Date.now();
-
-			const putRequests = entries.map(({ key, value, ttl }) => {
+			const putRequests = entries.map(({ key, value, expires }) => {
 				const expiresAtMs =
-					typeof ttl === "number" ? now + ttl : now + this._sixHoursInMilliseconds;
+					typeof expires === "number" ? expires : Date.now() + this._sixHoursInMilliseconds;
 				const expiresAt = Math.ceil(expiresAtMs / 1000);
 
 				return {

--- a/storage/dynamo/test/test.ts
+++ b/storage/dynamo/test/test.ts
@@ -144,7 +144,7 @@ describe("expiration", () => {
 		const value = faker.lorem.sentence();
 
 		const beforeSet = Date.now();
-		await store.set(key, value, 1000);
+		await store.set(key, value, Date.now() + 1000);
 		const afterSet = Date.now();
 
 		const result = await store.client.get({
@@ -177,8 +177,8 @@ describe("expiration", () => {
 	it("should return false from has for an expired key", async (t) => {
 		const store = new KeyvDynamo({ endpoint: dynamoURL });
 		const key = faker.string.uuid();
-		// Set with a TTL of 0ms so it expires immediately (expiresAt will be ~now+1s)
-		await store.set(key, faker.lorem.word(), 0);
+		// Set with an absolute expiry of now so it expires immediately (expiresAt will be ~now+1s)
+		await store.set(key, faker.lorem.word(), Date.now());
 		// Manually overwrite with an already-expired expiresAt
 		await store.client.put({
 			TableName: store.tableName,
@@ -212,14 +212,14 @@ describe("expiration", () => {
 });
 
 describe("batch operations", () => {
-	it("should set many entries with per-entry ttl", async (t) => {
+	it("should set many entries with per-entry expires", async (t) => {
 		const store = new KeyvDynamo({ endpoint: dynamoURL });
 		const key1 = faker.string.uuid();
 		const key2 = faker.string.uuid();
 		const value1 = faker.lorem.word();
 		const value2 = faker.lorem.word();
 		const result = await store.setMany([
-			{ key: key1, value: value1, ttl: 5000 },
+			{ key: key1, value: value1, expires: Date.now() + 5000 },
 			{ key: key2, value: value2 },
 		]);
 		t.expect(result).toEqual([true, true]);

--- a/storage/etcd/README.md
+++ b/storage/etcd/README.md
@@ -43,7 +43,7 @@
   - [constructor(url?, options?)](#constructorurl-options)
   - [.get(key)](#getkey)
   - [.getMany(keys)](#getmanykeys)
-  - [.set(key, value, ttl?)](#setkey-value-ttl)
+  - [.set(key, value, expires?)](#setkey-value-expires)
   - [.setMany(entries)](#setmanyentries)
   - [.delete(key)](#deletekey)
   - [.deleteMany(keys)](#deletemanykeys)
@@ -282,24 +282,26 @@ await store.set('key2', 'value2');
 const results = await store.getMany(['key1', 'key2']);
 ```
 
-### .set(key, value, ttl?)
+### .set(key, value, expires?)
 
-Stores a value in the etcd server. If a `ttl` is provided, a dedicated etcd lease is created for that key. Otherwise, if a default TTL is configured via the constructor `ttl` option, the shared lease is used. Returns `true` on success, `false` on failure.
+Stores a value in the etcd server. If `expires` is provided, a dedicated etcd lease (sized from the remaining time) is created for that key. Otherwise, if a default TTL is configured via the constructor `ttl` option, the shared lease is used. Returns `true` on success, `false` on failure.
+
+> When you call the adapter directly, the third argument is an **absolute** `expires` timestamp (Unix ms since epoch), not a relative duration. Through Keyv (`keyv.set(key, value, ttl)`) you still pass a relative TTL — Keyv converts it to `expires` for you.
 
 - `key` *(string)* - The key to set.
 - `value` *(any)* - The value to store.
-- `ttl` *(number, optional)* - Time to live in milliseconds.
+- `expires` *(number, optional)* - Absolute expiry as Unix ms since epoch. `undefined` means no expiry.
 - Returns: `Promise<boolean>`
 
 ```js
 const store = new KeyvEtcd('etcd://localhost:2379');
 await store.set('foo', 'bar');
-await store.set('foo', 'bar', 5000); // expires in 5 seconds
+await store.set('foo', 'bar', Date.now() + 5000); // expires in ~5 seconds
 ```
 
 ### .setMany(entries)
 
-Stores multiple values in the etcd server. Each entry is a `KeyvEntry<Value>` object (`{ key: string, value: Value, ttl?: number }`), where `Value` is inferred from the entries provided. Returns a `boolean[]` indicating whether each entry was set successfully.
+Stores multiple values in the etcd server. Each entry is a `KeyvStorageEntry<Value>` object (`{ key: string, value: Value, expires?: number }`) where `expires` is an absolute Unix ms timestamp, and `Value` is inferred from the entries provided. Returns a `boolean[]` indicating whether each entry was set successfully.
 
 ```js
 const store = new KeyvEtcd('etcd://localhost:2379');

--- a/storage/etcd/src/index.ts
+++ b/storage/etcd/src/index.ts
@@ -1,5 +1,10 @@
 import { Hookified } from "hookified";
-import { Keyv, type KeyvEntry, type KeyvStorageGetResult } from "keyv";
+import {
+	Keyv,
+	type KeyvStorageEntry,
+	type KeyvStorageGetResult,
+	keyvStorageCapability,
+} from "keyv";
 import { EtcdClient, type Lease } from "./client.js";
 import type { ClearOutput, DeleteOutput, GetOutput, HasOutput } from "./types.js";
 
@@ -31,6 +36,11 @@ export type KeyvEtcdOptions = {
  */
 // biome-ignore lint/suspicious/noExplicitAny: any is allowed
 export class KeyvEtcd<GenericValue = any> extends Hookified {
+	/** Declares the v6 absolute-`expires` storage contract via `capabilities.expires`. */
+	public get capabilities() {
+		return keyvStorageCapability(this);
+	}
+
 	private _client!: EtcdClient;
 	private _lease?: Lease;
 	private _url = "127.0.0.1:2379";
@@ -248,6 +258,8 @@ export class KeyvEtcd<GenericValue = any> extends Hookified {
 				return undefined;
 			}
 
+			// etcd leases are second-granular (and revoked lazily), so do a precise
+			// client-side expiry check from the stored `expires` metadata as well.
 			const { value, expired } = this.unwrapValue<GenericValue>(raw);
 			if (expired) {
 				await this.delete(key);
@@ -282,25 +294,33 @@ export class KeyvEtcd<GenericValue = any> extends Hookified {
 	}
 
 	/**
-	 * Stores a value in the etcd server. If a default TTL is configured, the value is stored with an etcd lease.
+	 * Stores a value in the etcd server. If an absolute `expires` is provided, the value is
+	 * stored with an etcd lease computed from the remaining duration; otherwise the configured
+	 * default TTL lease (if any) is used. etcd leases are second-granular, so the remaining
+	 * duration is clamped to a minimum of one second.
 	 * @param key - The key to store
 	 * @param value - The value to store
-	 * @param ttl - Optional TTL in milliseconds. Converted to seconds for the etcd lease.
+	 * @param expires - Optional absolute expiry as Unix ms since epoch. `undefined` means no expiry.
 	 * @returns `true` if the value was stored, `false` if the write failed.
 	 */
 	// biome-ignore lint/suspicious/noExplicitAny: type format
-	public async set(key: string, value: any, ttl?: number): Promise<boolean> {
+	public async set(key: string, value: any, expires?: number): Promise<boolean> {
 		try {
-			const target =
-				typeof ttl === "number"
-					? this._client.lease(Math.max(ttl / 1000, 1), {
-							autoKeepAlive: false,
-						})
-					: this._ttl
-						? this._lease
-						: this._client;
+			const leaseSec =
+				expires === undefined
+					? typeof this._ttl === "number"
+						? this._ttl / 1000
+						: undefined
+					: Math.max((expires - Date.now()) / 1000, 1);
 
-			await target?.put(this.formatKey(key)).value(this.wrapValue(value, ttl));
+			const target =
+				leaseSec === undefined
+					? this._client
+					: expires === undefined
+						? this._lease
+						: this._client.lease(leaseSec, { autoKeepAlive: false });
+
+			await target?.put(this.formatKey(key)).value(this.wrapValue(value, expires));
 			return true;
 		} catch (error) {
 			this.emit("error", error);
@@ -309,13 +329,55 @@ export class KeyvEtcd<GenericValue = any> extends Hookified {
 	}
 
 	/**
+	 * Wraps an (already-encoded) value with its absolute `expires` so reads can apply a precise,
+	 * millisecond-accurate expiry check independent of etcd's coarser, lazily-revoked leases.
+	 * The expiry comes from the `expires` parameter — the encoded value is never parsed.
+	 * @param value - The encoded value to store.
+	 * @param expires - Absolute expiry as Unix ms since epoch, or `undefined` for no expiry.
+	 * @returns A JSON envelope string `{ v, e }`.
+	 */
+	private wrapValue(value: unknown, expires?: number): string {
+		return JSON.stringify({ v: value, e: typeof expires === "number" ? expires : null });
+	}
+
+	/**
+	 * Unwraps a stored value, reporting whether it has expired. Values not written in the
+	 * `{ v, e }` envelope (e.g. written directly to etcd) are returned as-is and never expired.
+	 * @param raw - The raw value read back from etcd.
+	 * @returns The unwrapped `value` and an `expired` flag.
+	 */
+	private unwrapValue<T>(raw: unknown): { value: T | undefined; expired: boolean } {
+		/* v8 ignore next 3 -- @preserve */
+		if (raw === null || raw === undefined) {
+			return { value: undefined, expired: false };
+		}
+
+		try {
+			const parsed = JSON.parse(raw as string) as { v: T; e: number | null };
+			if (parsed.v === undefined) {
+				// Not our envelope format — return as-is.
+				return { value: raw as T, expired: false };
+			}
+
+			if (parsed.e !== null && Date.now() > parsed.e) {
+				return { value: undefined, expired: true };
+			}
+
+			return { value: parsed.v, expired: false };
+		} catch {
+			// Not valid JSON — return as-is.
+			return { value: raw as T, expired: false };
+		}
+	}
+
+	/**
 	 * Stores multiple values in the etcd server.
 	 * @template Value - The type of the values being stored.
-	 * @param entries - An array of objects containing key, value, and optional ttl
+	 * @param entries - An array of `{ key, value, expires? }` entries, where `expires` is an absolute Unix ms timestamp.
 	 * @returns An array of booleans, one per entry, indicating which writes succeeded.
 	 */
-	public async setMany<Value>(entries: KeyvEntry<Value>[]): Promise<boolean[] | undefined> {
-		const promises = entries.map(async ({ key, value, ttl }) => this.set(key, value, ttl));
+	public async setMany<Value>(entries: KeyvStorageEntry<Value>[]): Promise<boolean[] | undefined> {
+		const promises = entries.map(async ({ key, value, expires }) => this.set(key, value, expires));
 		const results = await Promise.allSettled(promises);
 		const boolResults: boolean[] = [];
 		for (const result of results) {
@@ -391,7 +453,7 @@ export class KeyvEtcd<GenericValue = any> extends Hookified {
 	 * be passed in — it uses the namespace configured on the adapter.
 	 * @yields `[key, value]` pairs as an async generator.
 	 */
-	public async *iterator() {
+	public async *iterator(): AsyncGenerator<[string, string], void, unknown> {
 		const prefix = this._namespace ? `${this._namespace}${this._keyPrefixSeparator}` : "";
 		const iterator = await this._client.getAll().prefix(prefix).keys();
 
@@ -403,14 +465,14 @@ export class KeyvEtcd<GenericValue = any> extends Hookified {
 					continue;
 				}
 
-				const { value, expired } = this.unwrapValue(raw);
+				const { value, expired } = this.unwrapValue<string>(raw);
 				if (expired) {
 					await this._client.delete().key(key);
 					continue;
 				}
 
 				const unprefixedKey = this.removeKeyPrefix(key, this._namespace);
-				yield [unprefixedKey, value];
+				yield [unprefixedKey, value as string];
 				/* v8 ignore start -- @preserve */
 			} catch (error) {
 				this.emit("error", error);
@@ -466,48 +528,6 @@ export class KeyvEtcd<GenericValue = any> extends Hookified {
 			this.emit("error", error);
 		}
 		/* v8 ignore stop -- @preserve */
-	}
-
-	/**
-	 * Wraps a value with expiry metadata for storage.
-	 * @param value - The value to wrap
-	 * @param ttl - Optional TTL in milliseconds used to compute the absolute expiry timestamp.
-	 * @returns A JSON string envelope containing the value and its expiry.
-	 */
-	private wrapValue(value: unknown, ttl?: number): string {
-		const expires = typeof ttl === "number" ? Date.now() + ttl : null;
-		return JSON.stringify({ v: value, e: expires });
-	}
-
-	/**
-	 * Unwraps a stored value, checking expiry metadata.
-	 * Handles legacy data (stored without envelope) gracefully.
-	 * @template T - The expected type of the stored value.
-	 * @param raw - The raw stored payload to unwrap.
-	 * @returns An object with the unwrapped `value` and an `expired` flag.
-	 */
-	private unwrapValue<T>(raw: unknown): { value: T | undefined; expired: boolean } {
-		/* v8 ignore next -- @preserve */
-		if (raw === null || raw === undefined) {
-			return { value: undefined, expired: false };
-		}
-
-		try {
-			const parsed = JSON.parse(raw as string) as { v: T; e: number | null };
-			if (parsed.v === undefined) {
-				// Not our envelope format — legacy data
-				return { value: raw as T, expired: false };
-			}
-
-			if (parsed.e !== null && Date.now() > parsed.e) {
-				return { value: undefined, expired: true };
-			}
-
-			return { value: parsed.v, expired: false };
-		} catch {
-			// Not valid JSON — legacy data, return as-is
-			return { value: raw as T, expired: false };
-		}
 	}
 }
 

--- a/storage/etcd/src/index.ts
+++ b/storage/etcd/src/index.ts
@@ -306,12 +306,15 @@ export class KeyvEtcd<GenericValue = any> extends Hookified {
 	// biome-ignore lint/suspicious/noExplicitAny: type format
 	public async set(key: string, value: any, expires?: number): Promise<boolean> {
 		try {
+			// etcd leases are second-granular, so round the duration UP. The lease is only a
+			// server-side GC backstop (precise expiry is enforced client-side via the stored
+			// `expires`); rounding up ensures the key is never reaped before its real deadline.
 			const leaseSec =
 				expires === undefined
 					? typeof this._ttl === "number"
-						? this._ttl / 1000
+						? Math.ceil(this._ttl / 1000)
 						: undefined
-					: Math.max((expires - Date.now()) / 1000, 1);
+					: Math.max(Math.ceil((expires - Date.now()) / 1000), 1);
 
 			const target =
 				leaseSec === undefined

--- a/storage/etcd/test/test.ts
+++ b/storage/etcd/test/test.ts
@@ -192,23 +192,13 @@ describe("get, set, and delete", () => {
 		t.expect(await store.delete(123)).toBeFalsy();
 	});
 
-	it("should handle legacy data stored without an envelope", async (t) => {
+	it("should store and retrieve a raw value", async (t) => {
 		const store = new KeyvEtcd(etcdUrl);
 		const key = faker.string.uuid();
-		// Write raw value directly to etcd without envelope
-		await store.client.put(store.formatKey(key)).value("raw-legacy-value");
+		// The adapter stores the raw encoded value with no envelope wrapping.
+		await store.client.put(store.formatKey(key)).value("raw-value");
 		const result = await store.get(key);
-		t.expect(result).toBe("raw-legacy-value");
-	});
-
-	it("should handle legacy JSON data without a v field", async (t) => {
-		const store = new KeyvEtcd(etcdUrl);
-		const key = faker.string.uuid();
-		// Write JSON that is not our envelope format
-		await store.client.put(store.formatKey(key)).value(JSON.stringify({ foo: "bar" }));
-		const result = await store.get(key);
-		// Should return the raw string since parsed.v is undefined
-		t.expect(result).toBe(JSON.stringify({ foo: "bar" }));
+		t.expect(result).toBe("raw-value");
 	});
 });
 
@@ -223,10 +213,11 @@ describe("ttl and expiration", () => {
 		t.expect(await keyv.get(key)).toBeUndefined();
 	});
 
-	it("should respect a per-call ttl", async (t) => {
+	it("should respect a per-call absolute expires", async (t) => {
 		const keyv = new KeyvEtcd(etcdUrl);
 		const key = faker.string.uuid();
-		await keyv.set(key, "value", 1000);
+		// Adapter set takes an absolute expiry (Unix ms). etcd leases are second-granular.
+		await keyv.set(key, "value", Date.now() + 1000);
 		t.expect(await keyv.get(key)).toBe("value");
 		await sleep(3000);
 		t.expect(await keyv.get(key)).toBeUndefined();
@@ -235,16 +226,18 @@ describe("ttl and expiration", () => {
 	it("should return false from has for an expired key", async (t) => {
 		const store = new KeyvEtcd(etcdUrl);
 		const key = faker.string.uuid();
-		await store.set(key, "value", 1);
-		await sleep(50);
+		// etcd leases are clamped to a minimum of one second, so wait past that.
+		await store.set(key, "value", Date.now() + 1000);
+		await sleep(3000);
 		t.expect(await store.has(key)).toBe(false);
 	});
 
 	it("should return undefined from get for an expired key", async (t) => {
 		const store = new KeyvEtcd(etcdUrl);
 		const key = faker.string.uuid();
-		await store.set(key, "value", 1);
-		await sleep(50);
+		// etcd leases are clamped to a minimum of one second, so wait past that.
+		await store.set(key, "value", Date.now() + 1000);
+		await sleep(3000);
 		t.expect(await store.get(key)).toBeUndefined();
 	});
 

--- a/storage/etcd/test/test.ts
+++ b/storage/etcd/test/test.ts
@@ -241,6 +241,29 @@ describe("ttl and expiration", () => {
 		t.expect(await store.get(key)).toBeUndefined();
 	});
 
+	it("should expire a present-but-stale envelope on has via the client-side check", async (t) => {
+		const store = new KeyvEtcd(etcdUrl);
+		const key = faker.string.uuid();
+		// Write an envelope whose `e` is already in the past with NO lease, so the key
+		// persists server-side. has() must apply the precise client-side check, report it
+		// expired, and reap the key (etcd leases are coarse and lazily revoked).
+		await store.client
+			.put(store.formatKey(key))
+			.value(JSON.stringify({ v: "stale", e: Date.now() - 1000 }));
+		t.expect(await store.has(key)).toBe(false);
+		t.expect(await store.client.get(store.formatKey(key))).toBeNull();
+	});
+
+	it("should return non-envelope values written directly to etcd as-is", async (t) => {
+		const store = new KeyvEtcd(etcdUrl);
+		const key = faker.string.uuid();
+		// A valid-JSON value that is not our { v, e } envelope (e.g. written by another
+		// client) must be returned verbatim and never treated as expired.
+		await store.client.put(store.formatKey(key)).value(JSON.stringify({ foo: "bar" }));
+		t.expect(await store.get(key)).toBe(JSON.stringify({ foo: "bar" }));
+		t.expect(await store.has(key)).toBe(true);
+	});
+
 	it("should cache the granted lease id across concurrent puts", async (t) => {
 		const store = new KeyvEtcd(etcdUrl, { ttl: 5000 });
 		const sharedLease = store.lease;

--- a/storage/memcache/README.md
+++ b/storage/memcache/README.md
@@ -66,6 +66,14 @@ npm install --save @keyv/memcache
 
 This package does not support compression. If you need compression, please use the `@keyv/redis` or another service package instead.
 
+## Expiration Granularity
+
+Expiry is enforced server-side by Memcached's `exptime`, which is **second-granular**. TTLs are accepted in milliseconds and rounded up to whole seconds, so a value can be returned for up to ~1 second past a sub-second (or just-elapsed) deadline before Memcached evicts it. Keyv does not filter expired reads by default (`checkExpired` defaults to `false`, trusting the store). If you need millisecond-precise expiry on Memcached, enable it on the Keyv instance:
+
+```js
+const keyv = new Keyv({ store: new KeyvMemcache('localhost:11211'), checkExpired: true });
+```
+
 ## Quick Start with createKeyv
 
 The `createKeyv` helper creates a `Keyv` instance with a Memcache store in a single call:

--- a/storage/memcache/src/index.ts
+++ b/storage/memcache/src/index.ts
@@ -129,8 +129,10 @@ export class KeyvMemcache extends Hookified implements KeyvStorageAdapter {
 	public async get<Value>(key: string): Promise<KeyvStorageGetResult<Value>> {
 		try {
 			const raw = await this.client.get(this.formatKey(key));
-			// The server evicts expired keys via the exptime set on write, so a
-			// returned value is always live. null/undefined means a cache miss.
+			// Expiry is enforced server-side by the exptime set on write. memcached's exptime is
+			// second-granular, so a value may be returned up to ~1s past a sub-second/just-elapsed
+			// deadline; enable Keyv's `checkExpired` for millisecond-precise expiry. null/undefined
+			// is a cache miss.
 			return (raw ?? undefined) as KeyvStorageGetResult<Value>;
 		} catch (error) {
 			this.emit("error", error);
@@ -229,8 +231,8 @@ export class KeyvMemcache extends Hookified implements KeyvStorageAdapter {
 	public async has(key: string): Promise<boolean> {
 		try {
 			const raw = await this.client.get(this.formatKey(key));
-			// The server evicts expired keys via the exptime set on write, so any
-			// non-null/undefined value returned here is live.
+			// Existence is determined server-side via the exptime set on write, which is
+			// second-granular (see get() for the sub-second caveat).
 			return raw !== undefined && raw !== null;
 		} catch {
 			/* v8 ignore next -- @preserve */

--- a/storage/memcache/src/index.ts
+++ b/storage/memcache/src/index.ts
@@ -63,7 +63,11 @@ export class KeyvMemcache extends Hookified implements KeyvStorageAdapter {
 		this.namespace = allOptions.namespace;
 
 		const { namespace: _namespace, ...memcacheOptions } = allOptions;
-		this.client = new Memcache(memcacheOptions);
+		// The memcache client rejects any exptime above `maxExpiration` (default 30 days). Since
+		// `set` converts a far-future absolute `expires` into a memcached absolute Unix-timestamp
+		// exptime (the >30-day rule), raise the ceiling to the 32-bit wire maximum (~year 2106) so
+		// those writes are permitted instead of throwing. A user-supplied value still wins.
+		this.client = new Memcache({ maxExpiration: 4_294_967_295, ...memcacheOptions });
 
 		// Surface asynchronous client errors (connection drops, timeouts, retry exhaustion)
 		// to listeners on the adapter. The client emits `(nodeId, error)`, so pick the Error,

--- a/storage/memcache/src/index.ts
+++ b/storage/memcache/src/index.ts
@@ -1,6 +1,6 @@
 import { Hookified } from "hookified";
-import type { KeyvEntry, KeyvStorageAdapter, KeyvStorageGetResult } from "keyv";
-import { Keyv } from "keyv";
+import type { KeyvStorageAdapter, KeyvStorageEntry, KeyvStorageGetResult } from "keyv";
+import { Keyv, keyvStorageCapability } from "keyv";
 import { Memcache, type MemcacheNode, type MemcacheOptions } from "memcache";
 
 /**
@@ -23,6 +23,11 @@ export type KeyvMemcacheOptions = {
  * ```
  */
 export class KeyvMemcache extends Hookified implements KeyvStorageAdapter {
+	/** Declares the v6 absolute-`expires` storage contract via `capabilities.expires`. */
+	public get capabilities() {
+		return keyvStorageCapability(this);
+	}
+
 	/** Optional namespace used to prefix all keys. */
 	public namespace?: string;
 	/** The underlying Memcache client instance. */
@@ -124,17 +129,9 @@ export class KeyvMemcache extends Hookified implements KeyvStorageAdapter {
 	public async get<Value>(key: string): Promise<KeyvStorageGetResult<Value>> {
 		try {
 			const raw = await this.client.get(this.formatKey(key));
-			if (raw === undefined) {
-				return undefined;
-			}
-
-			const { value, expired } = this.unwrapValue<Value>(raw);
-			if (expired) {
-				await this.delete(key);
-				return undefined;
-			}
-
-			return value as KeyvStorageGetResult<Value>;
+			// The server evicts expired keys via the exptime set on write, so a
+			// returned value is always live. null/undefined means a cache miss.
+			return (raw ?? undefined) as KeyvStorageGetResult<Value>;
 		} catch (error) {
 			this.emit("error", error);
 		}
@@ -162,13 +159,22 @@ export class KeyvMemcache extends Hookified implements KeyvStorageAdapter {
 	 * Stores a value in the memcache server.
 	 * @param key - The key to store
 	 * @param value - The value to store
-	 * @param ttl - Optional time to live in milliseconds. Converted to seconds internally for memcache.
+	 * @param expires - Optional absolute expiry as Unix ms since epoch. Converted to the memcache
+	 * `exptime` (seconds) internally; `undefined` means no expiry.
 	 * @returns `true` if the value was stored, `false` if the write failed.
 	 */
-	public async set(key: string, value: unknown, ttl?: number): Promise<boolean> {
-		const exptime = ttl !== undefined ? Math.ceil(ttl / 1000) : 0;
+	public async set(key: string, value: unknown, expires?: number): Promise<boolean> {
+		// memcache exptime: 0 = never expire. Values over 30 days (2,592,000s) are
+		// interpreted as an absolute Unix timestamp in seconds; smaller values are a
+		// relative duration in seconds. Compute from the absolute `expires` accordingly.
+		const exptime =
+			expires === undefined
+				? 0
+				: expires - Date.now() > 2_592_000_000
+					? Math.ceil(expires / 1000)
+					: Math.max(1, Math.ceil((expires - Date.now()) / 1000));
 		try {
-			await this.client.set(this.formatKey(key), this.wrapValue(value, ttl), exptime);
+			await this.client.set(this.formatKey(key), value, exptime);
 			return true;
 		} catch (error) {
 			this.emit("error", error);
@@ -179,12 +185,12 @@ export class KeyvMemcache extends Hookified implements KeyvStorageAdapter {
 	/**
 	 * Stores multiple values in the memcache server.
 	 * @template Value - The type of the values being stored.
-	 * @param entries - An array of entries, each with a key, value, and optional ttl in milliseconds.
+	 * @param entries - An array of entries, each with a key, value, and optional absolute `expires` in Unix ms.
 	 * @returns An array of booleans, one per entry, indicating which writes succeeded.
 	 */
-	public async setMany<Value>(entries: KeyvEntry<Value>[]): Promise<boolean[] | undefined> {
+	public async setMany<Value>(entries: KeyvStorageEntry<Value>[]): Promise<boolean[] | undefined> {
 		const settled = await Promise.allSettled(
-			entries.map(async ({ key, value, ttl }) => this.set(key, value, ttl)),
+			entries.map(async ({ key, value, expires }) => this.set(key, value, expires)),
 		);
 		return settled.map((result) => (result.status === "fulfilled" ? result.value : false));
 	}
@@ -223,17 +229,9 @@ export class KeyvMemcache extends Hookified implements KeyvStorageAdapter {
 	public async has(key: string): Promise<boolean> {
 		try {
 			const raw = await this.client.get(this.formatKey(key));
-			if (raw === undefined) {
-				return false;
-			}
-
-			const { expired } = this.unwrapValue(raw);
-			if (expired) {
-				await this.delete(key);
-				return false;
-			}
-
-			return true;
+			// The server evicts expired keys via the exptime set on write, so any
+			// non-null/undefined value returned here is live.
+			return raw !== undefined && raw !== null;
 		} catch {
 			/* v8 ignore next -- @preserve */
 			return false;
@@ -286,46 +284,6 @@ export class KeyvMemcache extends Hookified implements KeyvStorageAdapter {
 		}
 
 		return result;
-	}
-
-	/**
-	 * Wraps a value with expiry metadata for storage.
-	 * @param value - The value to wrap.
-	 * @param ttl - Optional time to live in milliseconds, used to compute the absolute expiry timestamp.
-	 * @returns A JSON envelope string containing the value and its expiry timestamp.
-	 */
-	private wrapValue(value: unknown, ttl?: number): string {
-		const expires = typeof ttl === "number" ? Date.now() + ttl : null;
-		return JSON.stringify({ v: value, e: expires });
-	}
-
-	/**
-	 * Unwraps a stored value, checking its expiry metadata. Handles legacy data
-	 * (stored without the envelope) gracefully by returning it as-is.
-	 * @template T - The expected type of the unwrapped value.
-	 * @param raw - The raw value read back from the memcache server.
-	 * @returns An object with the unwrapped `value` (or `undefined`) and an `expired` flag.
-	 */
-	private unwrapValue<T>(raw: unknown): { value: T | undefined; expired: boolean } {
-		/* v8 ignore next -- @preserve */
-		if (raw === null || raw === undefined) {
-			return { value: undefined, expired: false };
-		}
-
-		try {
-			const parsed = JSON.parse(raw as string) as { v: T; e: number | null };
-			if (parsed.v === undefined) {
-				return { value: raw as T, expired: false };
-			}
-
-			if (parsed.e !== null && Date.now() > parsed.e) {
-				return { value: undefined, expired: true };
-			}
-
-			return { value: parsed.v, expired: false };
-		} catch {
-			return { value: raw as T, expired: false };
-		}
 	}
 }
 

--- a/storage/memcache/test/test.ts
+++ b/storage/memcache/test/test.ts
@@ -90,17 +90,12 @@ describe("get", () => {
 		expect(await keyvMemcache.get(faker.string.uuid())).toBeUndefined();
 	});
 
-	test("handles legacy non-JSON data", async () => {
+	test("returns the raw value the server stores", async () => {
 		const key = faker.string.uuid();
-		// Write a raw string directly, bypassing the value envelope.
-		await keyvMemcache.client.set(keyvMemcache.formatKey(key), "raw-legacy");
-		expect(await keyvMemcache.get(key)).toBe("raw-legacy");
-	});
-
-	test("handles legacy JSON without the value envelope", async () => {
-		const key = faker.string.uuid();
-		const value = JSON.stringify({ foo: "bar" });
-		await keyvMemcache.client.set(keyvMemcache.formatKey(key), value);
+		const value = faker.lorem.word();
+		// The adapter stores the value verbatim, with no envelope wrapping.
+		await keyvMemcache.set(key, value);
+		expect(await keyvMemcache.client.get(keyvMemcache.formatKey(key))).toBe(value);
 		expect(await keyvMemcache.get(key)).toBe(value);
 	});
 });
@@ -286,15 +281,17 @@ describe("ttl and expiration", () => {
 
 	test("get returns undefined for a sub-second expired key", async () => {
 		const key = faker.string.uuid();
-		await keyvMemcache.set(key, faker.lorem.word(), 1);
-		await delay(50);
+		// Direct adapter set takes an absolute expiry (Unix ms). A 1s window is the
+		// smallest memcache exptime, so this evicts within ~1s.
+		await keyvMemcache.set(key, faker.lorem.word(), Date.now() + 1000);
+		await delay(1500);
 		expect(await keyvMemcache.get(key)).toBeUndefined();
 	});
 
 	test("has returns false for a sub-second expired key", async () => {
 		const key = faker.string.uuid();
-		await keyvMemcache.set(key, faker.lorem.word(), 1);
-		await delay(50);
+		await keyvMemcache.set(key, faker.lorem.word(), Date.now() + 1000);
+		await delay(1500);
 		expect(await keyvMemcache.has(key)).toBe(false);
 	});
 
@@ -437,4 +434,5 @@ const store = () => keyvMemcache;
 keyvApiTests(test, Keyv, store);
 keyvValueTests(test, Keyv, store);
 // Memcached does not support key enumeration, so the iterator suite is disabled.
-storageTestSuite(test, store, { iterator: false });
+// Memcached `exptime` has 1-second granularity, so use second-scale expiry deadlines.
+storageTestSuite(test, store, { iterator: false, ttlGranularity: "seconds" });

--- a/storage/memcache/test/test.ts
+++ b/storage/memcache/test/test.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from "node:events";
 import { faker } from "@faker-js/faker";
 import { delay, keyvApiTests, keyvValueTests, storageTestSuite } from "@keyv/test-suite";
 import Keyv from "keyv";
-import { beforeEach, describe, expect, test } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 import KeyvMemcache, { createKeyv } from "../src/index.js";
 
 // Handle all the tests with listeners.
@@ -159,6 +159,23 @@ describe("set and setMany", () => {
 		await delay(2000);
 
 		expect(await keyv.get(key1)).toBeUndefined();
+	});
+
+	test("encodes a far-future expires as an absolute exptime (>30 day rule)", async () => {
+		const key = faker.string.uuid();
+		const value = faker.lorem.word();
+		// memcached treats exptime > 2,592,000s as an absolute Unix timestamp in seconds, so an
+		// expiry more than 30 days out must be sent as Math.ceil(expires / 1000), not a relative delta.
+		const expires = Date.now() + 40 * 24 * 60 * 60 * 1000; // 40 days from now
+		const setSpy = vi.spyOn(keyvMemcache.client, "set");
+
+		await keyvMemcache.set(key, value, expires);
+
+		const call = setSpy.mock.calls.find((c) => c[0] === keyvMemcache.formatKey(key));
+		expect(call?.[2]).toBe(Math.ceil(expires / 1000));
+		expect(await keyvMemcache.get(key)).toBe(value);
+
+		setSpy.mockRestore();
 	});
 });
 

--- a/storage/mongo/README.md
+++ b/storage/mongo/README.md
@@ -396,7 +396,7 @@ This is useful for manual cleanup of expired GridFS files, since GridFS does not
 ```js
 const store = new KeyvMongo({ url: 'mongodb://localhost:27017', useGridFS: true });
 
-await store.set('temp', 'data', 1000); // expires in 1 second
+await store.set('temp', 'data', Date.now() + 1000); // adapter takes an absolute expires (Unix ms); expires in ~1 second
 
 // After expiration...
 await store.clearExpired(); // removes expired GridFS files

--- a/storage/mongo/src/index.ts
+++ b/storage/mongo/src/index.ts
@@ -1,6 +1,11 @@
 import { Buffer } from "node:buffer";
 import { Hookified } from "hookified";
-import Keyv, { type KeyvEntry, type KeyvStorageAdapter, type KeyvStorageGetResult } from "keyv";
+import Keyv, {
+	type KeyvStorageAdapter,
+	type KeyvStorageEntry,
+	type KeyvStorageGetResult,
+	keyvStorageCapability,
+} from "keyv";
 import {
 	GridFSBucket,
 	MongoBulkWriteError,
@@ -15,6 +20,11 @@ import type { KeyvMongoConnect, KeyvMongoOptions } from "./types.js";
  * Provides a persistent key-value store using MongoDB as the backend.
  */
 export class KeyvMongo extends Hookified implements KeyvStorageAdapter {
+	/** Declares the v6 absolute-`expires` storage contract via `capabilities.expires`. */
+	public get capabilities() {
+		return keyvStorageCapability(this);
+	}
+
 	/**
 	 * The MongoDB connection URI.
 	 * @default 'mongodb://127.0.0.1:27017'
@@ -343,13 +353,13 @@ export class KeyvMongo extends Hookified implements KeyvStorageAdapter {
 	 * Set a value in the store.
 	 * @param key - The key to set.
 	 * @param value - The value to store.
-	 * @param ttl - Time to live in milliseconds. If specified, the key will expire after this duration.
+	 * @param expires - Absolute expiry as Unix ms since epoch. If specified, the key will expire at this time.
 	 * @returns `true` if the value was set, `false` if an error occurred.
 	 */
 	// biome-ignore lint/suspicious/noExplicitAny: type format
-	public async set(key: string, value: any, ttl?: number): Promise<boolean> {
+	public async set(key: string, value: any, expires?: number): Promise<boolean> {
 		try {
-			const expiresAt = typeof ttl === "number" && ttl > 0 ? new Date(Date.now() + ttl) : null;
+			const expiresAt = typeof expires === "number" ? new Date(expires) : null;
 			const strippedKey = this.removeKeyPrefix(key);
 			const ns = this.getNamespaceValue();
 			const client = await this.connect;
@@ -394,26 +404,26 @@ export class KeyvMongo extends Hookified implements KeyvStorageAdapter {
 	 * Set multiple values in the store at once. In standard mode, uses a single `bulkWrite` operation.
 	 * In GridFS mode, each entry is set individually in parallel.
 	 * @template Value - The type of the stored values.
-	 * @param entries - Array of entries to set. Each entry has a `key`, `value`, and optional `ttl` in milliseconds.
+	 * @param entries - Array of entries to set. Each entry has a `key`, `value`, and optional `expires` (absolute Unix ms).
 	 * @returns Array of booleans (one per entry) indicating which writes succeeded, in input order.
 	 */
-	public async setMany<Value>(entries: KeyvEntry<Value>[]): Promise<boolean[] | undefined> {
+	public async setMany<Value>(entries: KeyvStorageEntry<Value>[]): Promise<boolean[] | undefined> {
 		if (entries.length === 0) {
 			return [];
 		}
 
 		if (this._useGridFS) {
 			const settled = await Promise.allSettled(
-				entries.map(async ({ key, value, ttl }) => this.set(key, value, ttl)),
+				entries.map(async ({ key, value, expires }) => this.set(key, value, expires)),
 			);
 			return settled.map((result) => (result.status === "fulfilled" ? result.value : false));
 		}
 
 		const client = await this.connect;
 		const ns = this.getNamespaceValue();
-		const operations = entries.map(({ key, value, ttl }) => {
+		const operations = entries.map(({ key, value, expires }) => {
 			const strippedKey = this.removeKeyPrefix(key);
-			const expiresAt = typeof ttl === "number" && ttl > 0 ? new Date(Date.now() + ttl) : null;
+			const expiresAt = typeof expires === "number" ? new Date(expires) : null;
 			return {
 				updateOne: {
 					filter: { key: { $eq: strippedKey }, namespace: { $eq: ns } },

--- a/storage/mongo/test/test.ts
+++ b/storage/mongo/test/test.ts
@@ -97,7 +97,7 @@ describe("get", () => {
 	test("returns undefined and deletes an expired entry", async () => {
 		const store = new KeyvMongo({ ...options });
 		const key = faker.string.alphanumeric(10);
-		await store.set(key, "expiring-value", 1);
+		await store.set(key, "expiring-value", Date.now() - 1000);
 		await delay(50);
 		expect(await store.get(key)).toBeUndefined();
 	});
@@ -117,7 +117,7 @@ describe("get", () => {
 	test("returns undefined and deletes an expired entry in GridFS", async () => {
 		const store = new KeyvMongo({ useGridFS: true, ...options });
 		const key = faker.string.alphanumeric(10);
-		await store.set(key, "expiring-value", 1);
+		await store.set(key, "expiring-value", Date.now() - 1000);
 		await delay(50);
 		expect(await store.get(key)).toBeUndefined();
 	});
@@ -164,22 +164,22 @@ describe("set and setMany", () => {
 	test("stores and returns a value in GridFS", async () => {
 		const store = new KeyvMongo({ useGridFS: true, ...options });
 		const key = faker.string.alphanumeric(10);
-		const result = await store.set(key, "keyv1", 0);
+		const result = await store.set(key, "keyv1");
 		expect(result).toBe(true);
 		expect(await store.get(key)).toBe("keyv1");
 	});
 
-	test("stores a value with a ttl in GridFS", async () => {
+	test("stores a value with an expiry in GridFS", async () => {
 		const store = new KeyvMongo({ useGridFS: true, ...options });
 		const key = faker.string.alphanumeric(10);
-		expect(await store.set(key, "keyv1", 0)).toBe(true);
+		expect(await store.set(key, "keyv1", Date.now() + 60000)).toBe(true);
 	});
 
-	test("setMany stores multiple values with a per-entry ttl", async () => {
+	test("setMany stores multiple values with a per-entry expiry", async () => {
 		const store = new KeyvMongo({ ...options });
 		const keys = [faker.string.alphanumeric(10), faker.string.alphanumeric(10)];
 		await store.setMany([
-			{ key: keys[0], value: "val1", ttl: 60000 },
+			{ key: keys[0], value: "val1", expires: Date.now() + 60000 },
 			{ key: keys[1], value: "val2" },
 		]);
 		expect(await store.get(keys[0])).toBe("val1");
@@ -275,13 +275,13 @@ describe("set and setMany", () => {
 		// Mock the set method to throw for the second call.
 		let callCount = 0;
 		const originalSet = store.set.bind(store);
-		store.set = async (key: string, value: any, ttl?: number) => {
+		store.set = async (key: string, value: any, expires?: number) => {
 			callCount++;
 			if (callCount === 2) {
 				throw new Error("GridFS set failure");
 			}
 
-			return originalSet(key, value, ttl);
+			return originalSet(key, value, expires);
 		};
 
 		const result = await store.setMany([
@@ -458,7 +458,7 @@ describe("iterator", () => {
 		await store.clear();
 		const expiredKey = faker.string.alphanumeric(10);
 		const freshKey = faker.string.alphanumeric(10);
-		await store.set(expiredKey, "expired-value", 1);
+		await store.set(expiredKey, "expired-value", Date.now() - 1000);
 		await store.set(freshKey, "fresh-value");
 		await delay(50);
 		const entries: Array<[string, unknown]> = [];
@@ -722,7 +722,7 @@ describe("GridFS maintenance", () => {
 		const store = new KeyvMongo({ useGridFS: true, ...options });
 		await store.clear();
 		const key = faker.string.alphanumeric(10);
-		await store.set(key, "expiring-value", 1);
+		await store.set(key, "expiring-value", Date.now() - 1000);
 		await delay(50);
 		expect(await store.clearExpired()).toBe(true);
 		expect(await store.get(key)).toBeUndefined();

--- a/storage/mysql/src/index.ts
+++ b/storage/mysql/src/index.ts
@@ -1,5 +1,10 @@
 import { Hookified } from "hookified";
-import Keyv, { type KeyvEntry, type KeyvStorageAdapter, type KeyvStorageGetResult } from "keyv";
+import Keyv, {
+	type KeyvStorageAdapter,
+	type KeyvStorageEntry,
+	type KeyvStorageGetResult,
+	keyvStorageCapability,
+} from "keyv";
 import mysql, { type ConnectionOptions } from "mysql2";
 import { endPool, pool } from "./pool.js";
 import type { KeyvMysqlOptions } from "./types.js";
@@ -33,6 +38,11 @@ type QueryType<T> = Promise<
  * Provides a persistent key-value store using MySQL as the backend.
  */
 export class KeyvMysql extends Hookified implements KeyvStorageAdapter {
+	/** Declares the v6 absolute-`expires` storage contract via `capabilities.expires`. */
+	public get capabilities() {
+		return keyvStorageCapability(this);
+	}
+
 	/**
 	 * The MySQL connection URI.
 	 * @default 'mysql://localhost'
@@ -389,18 +399,18 @@ export class KeyvMysql extends Hookified implements KeyvStorageAdapter {
 	 * If the key already exists, it will be updated.
 	 * @param key - The key to set
 	 * @param value - The value to store
+	 * @param expires - Absolute expiry as Unix ms since epoch, or `undefined` for no expiry.
 	 * @returns Promise that resolves when the operation completes
 	 */
 	// biome-ignore lint/suspicious/noExplicitAny: type format
-	public async set(key: string, value: any): Promise<boolean> {
+	public async set(key: string, value: any, expires?: number): Promise<boolean> {
 		try {
 			const strippedKey = this.removeKeyPrefix(key);
 			const ns = this.getNamespaceValue();
-			const expires = this.getExpiresFromValue(value);
 			const sql = `INSERT INTO ${escapeIdentifier(this._table)} (id, value, namespace, expires)
 			VALUES(?, ?, ?, ?)
 			ON DUPLICATE KEY UPDATE value=?, expires=?;`;
-			const insert = [strippedKey, value, ns, expires, value, expires];
+			const insert = [strippedKey, value, ns, expires ?? null, value, expires ?? null];
 			const upsert = mysql.format(sql, insert);
 			await this.query(upsert);
 			return true;
@@ -414,21 +424,21 @@ export class KeyvMysql extends Hookified implements KeyvStorageAdapter {
 
 	/**
 	 * Sets multiple key-value pairs at once.
-	 * @param entries - Array of key-value entry objects
+	 * @param entries - Array of `{ key, value, expires? }` entry objects. `expires` is absolute Unix ms.
 	 * @returns Promise that resolves when the operation completes
 	 */
-	public async setMany<Value>(entries: KeyvEntry<Value>[]): Promise<boolean[] | undefined> {
+	public async setMany<Value>(entries: KeyvStorageEntry<Value>[]): Promise<boolean[] | undefined> {
 		if (entries.length === 0) {
 			return entries.map(() => true);
 		}
 
 		try {
 			const ns = this.getNamespaceValue();
-			const values = entries.map(({ key, value }) => [
+			const values = entries.map(({ key, value, expires }) => [
 				this.removeKeyPrefix(key),
 				value,
 				ns,
-				this.getExpiresFromValue(value),
+				expires ?? null,
 			]);
 			const placeholders = values.map(() => "(?, ?, ?, ?)").join(", ");
 			const flatValues = values.flat();
@@ -637,32 +647,6 @@ export class KeyvMysql extends Hookified implements KeyvStorageAdapter {
 	 */
 	private getNamespaceValue(): string {
 		return this._namespace ?? "";
-	}
-
-	/**
-	 * Extracts the expires timestamp from a serialized value.
-	 * @param value - The serialized value (string or object)
-	 * @returns The expires timestamp in milliseconds, or null if not present
-	 */
-	// biome-ignore lint/suspicious/noExplicitAny: value can be any type
-	private getExpiresFromValue(value: any): number | null {
-		// biome-ignore lint/suspicious/noExplicitAny: parsed data can be any type
-		let data: any;
-		if (typeof value === "string") {
-			try {
-				data = JSON.parse(value);
-			} catch {
-				return null;
-			}
-		} else {
-			data = value;
-		}
-
-		if (data && typeof data === "object" && typeof data.expires === "number") {
-			return data.expires;
-		}
-
-		return null;
 	}
 
 	/**

--- a/storage/mysql/test/test.ts
+++ b/storage/mysql/test/test.ts
@@ -12,7 +12,7 @@ const store = () => new KeyvMysql({ uri, iterationLimit: 2 });
 
 keyvTestSuite(test, Keyv, store);
 keyvIteratorTests(test, Keyv, store);
-storageTestSuite(test, store, { ttl: false });
+storageTestSuite(test, store);
 
 beforeEach(async () => {
 	const keyv = store();
@@ -138,8 +138,9 @@ describe("has and hasMany", () => {
 	test("has returns false and deletes an expired key", async () => {
 		const keyv = new KeyvMysql(uri);
 		const key = faker.string.alphanumeric(10);
-		const expiredValue = JSON.stringify({ value: "old", expires: Date.now() - 1000 });
-		await keyv.set(key, expiredValue);
+		const pastExpires = Date.now() - 1000;
+		const expiredValue = JSON.stringify({ value: "old", expires: pastExpires });
+		await keyv.set(key, expiredValue, pastExpires);
 		expect(await keyv.has(key)).toBe(false);
 		// The expired key should have been deleted.
 		expect(await keyv.get(key)).toBeUndefined();
@@ -150,11 +151,13 @@ describe("has and hasMany", () => {
 		const expiredKey1 = faker.string.alphanumeric(10);
 		const expiredKey2 = faker.string.alphanumeric(10);
 		const validKey = faker.string.alphanumeric(10);
-		const expiredValue = JSON.stringify({ value: "old", expires: Date.now() - 1000 });
-		const validValue = JSON.stringify({ value: "fresh", expires: Date.now() + 60_000 });
-		await keyv.set(expiredKey1, expiredValue);
-		await keyv.set(expiredKey2, expiredValue);
-		await keyv.set(validKey, validValue);
+		const pastExpires = Date.now() - 1000;
+		const futureExpires = Date.now() + 60_000;
+		const expiredValue = JSON.stringify({ value: "old", expires: pastExpires });
+		const validValue = JSON.stringify({ value: "fresh", expires: futureExpires });
+		await keyv.set(expiredKey1, expiredValue, pastExpires);
+		await keyv.set(expiredKey2, expiredValue, pastExpires);
+		await keyv.set(validKey, validValue, futureExpires);
 		const result = await keyv.hasMany([expiredKey1, expiredKey2, validKey]);
 		expect(result).toStrictEqual([false, false, true]);
 		// The expired keys should have been deleted.
@@ -225,8 +228,8 @@ describe("clearExpired", () => {
 		const expired = JSON.stringify({ value: "old", expires: 1 });
 		const valid = JSON.stringify({ value: "new", expires: 9999999999999 });
 		const noExpiry = JSON.stringify({ value: "forever" });
-		await keyv.set(expiredKey, expired);
-		await keyv.set(validKey, valid);
+		await keyv.set(expiredKey, expired, 1);
+		await keyv.set(validKey, valid, 9999999999999);
 		await keyv.set(noExpiryKey, noExpiry);
 		await keyv.clearExpired();
 		expect(await keyv.get(expiredKey)).toBeUndefined();
@@ -238,25 +241,25 @@ describe("clearExpired", () => {
 		const keyv = new KeyvMysql(uri);
 		const key = faker.string.alphanumeric(10);
 		const valid = JSON.stringify({ value: "bar", expires: 9999999999999 });
-		await keyv.set(key, valid);
+		await keyv.set(key, valid, 9999999999999);
 		await keyv.clearExpired();
 		expect(await keyv.get(key)).toBe(valid);
 	});
 });
 
 describe("expires column", () => {
-	test("set extracts and stores expires from the value", async () => {
+	test("set stores the expires passed as the third argument", async () => {
 		const keyv = new KeyvMysql(uri);
 		const key = faker.string.alphanumeric(10);
 		const valueWithExpires = JSON.stringify({ value: "bar", expires: 9999999999999 });
-		await keyv.set(key, valueWithExpires);
+		await keyv.set(key, valueWithExpires, 9999999999999);
 		const rows = await keyv.query<mysql.RowDataPacket[]>(
 			`SELECT expires FROM \`keyv\` WHERE id = '${key}' AND namespace = ''`,
 		);
 		expect(Number(rows[0].expires)).toBe(9999999999999);
 	});
 
-	test("set stores null expires when the value has no expires field", async () => {
+	test("set stores null expires when no expires is passed", async () => {
 		const keyv = new KeyvMysql(uri);
 		const key = faker.string.alphanumeric(10);
 		await keyv.set(key, "plain string value");
@@ -269,24 +272,24 @@ describe("expires column", () => {
 	test("set updates the expires column on upsert", async () => {
 		const keyv = new KeyvMysql(uri);
 		const key = faker.string.alphanumeric(10);
-		await keyv.set(key, JSON.stringify({ value: "bar", expires: 1000 }));
+		await keyv.set(key, JSON.stringify({ value: "bar", expires: 1000 }), 1000);
 		const rows1 = await keyv.query<mysql.RowDataPacket[]>(
 			`SELECT expires FROM \`keyv\` WHERE id = '${key}' AND namespace = ''`,
 		);
 		expect(Number(rows1[0].expires)).toBe(1000);
-		await keyv.set(key, JSON.stringify({ value: "bar", expires: 2000 }));
+		await keyv.set(key, JSON.stringify({ value: "bar", expires: 2000 }), 2000);
 		const rows2 = await keyv.query<mysql.RowDataPacket[]>(
 			`SELECT expires FROM \`keyv\` WHERE id = '${key}' AND namespace = ''`,
 		);
 		expect(Number(rows2[0].expires)).toBe(2000);
 	});
 
-	test("setMany extracts and stores expires for each entry", async () => {
+	test("setMany stores expires for each entry", async () => {
 		const keyv = new KeyvMysql(uri);
 		const key1 = faker.string.alphanumeric(10);
 		const key2 = faker.string.alphanumeric(10);
 		await keyv.setMany([
-			{ key: key1, value: JSON.stringify({ value: "a", expires: 5000 }) },
+			{ key: key1, value: JSON.stringify({ value: "a", expires: 5000 }), expires: 5000 },
 			{ key: key2, value: JSON.stringify({ value: "b" }) },
 		]);
 		const rows = await keyv.query<mysql.RowDataPacket[]>(
@@ -298,7 +301,7 @@ describe("expires column", () => {
 		expect(row2?.expires).toBeNull();
 	});
 
-	test("set stores null expires when the value is a number", async () => {
+	test("set stores null expires when the value is a number and no expires is passed", async () => {
 		const keyv = new KeyvMysql(uri);
 		const key = faker.string.alphanumeric(10);
 		await keyv.set(key, 42);
@@ -308,7 +311,7 @@ describe("expires column", () => {
 		expect(rows[0].expires).toBeNull();
 	});
 
-	test("set stores null expires when the value is null", async () => {
+	test("set stores null expires when the value is null and no expires is passed", async () => {
 		const keyv = new KeyvMysql(uri);
 		const key = faker.string.alphanumeric(10);
 		await keyv.set(key, null);
@@ -332,6 +335,28 @@ describe("expires column", () => {
 		const now = Date.now();
 		expect(expires).toBeGreaterThan(now);
 		expect(expires).toBeLessThanOrEqual(now + 60_000 + 1000);
+	});
+
+	// Regression: before v6 the adapter recovered `expires` by JSON.parsing the stored
+	// value, which silently failed for compressed/encrypted/msgpackr/superjson output and
+	// left the expires column NULL. The contract now passes expires directly.
+	test("populates the expires column for non-JSON encoded values so expiry still works", async () => {
+		const store = new KeyvMysql({ uri, iterationLimit: 2 });
+		const serialization = {
+			stringify: (data: unknown) => `RAW:${JSON.stringify(data)}`,
+			parse: <T>(data: string): T => JSON.parse(String(data).slice(4)) as T,
+		};
+		const keyv = new Keyv({ store, serialization });
+		const key = faker.string.uuid();
+		await keyv.set(key, "value", 100);
+		expect(await keyv.get(key)).toBe("value");
+		await new Promise((resolve) => {
+			setTimeout(resolve, 200);
+		});
+		expect(await keyv.get(key)).toBeUndefined();
+		await store.clearExpired();
+		expect(await store.has(key)).toBe(false);
+		await keyv.disconnect();
 	});
 });
 

--- a/storage/postgres/src/index.ts
+++ b/storage/postgres/src/index.ts
@@ -1,6 +1,11 @@
 import type { ConnectionOptions } from "node:tls";
 import { Hookified } from "hookified";
-import Keyv, { type KeyvEntry, type KeyvStorageAdapter, type KeyvStorageGetResult } from "keyv";
+import Keyv, {
+	type KeyvStorageAdapter,
+	type KeyvStorageEntry,
+	type KeyvStorageGetResult,
+	keyvStorageCapability,
+} from "keyv";
 import type { DatabaseError, PoolConfig } from "pg";
 import { endPool, pool } from "./pool.js";
 import type { KeyvPostgresOptions, Query } from "./types.js";
@@ -20,6 +25,11 @@ function escapeIdentifier(identifier: string): string {
  * Uses the `pg` library for connection pooling and parameterized queries.
  */
 export class KeyvPostgres extends Hookified implements KeyvStorageAdapter {
+	/** Declares the v6 absolute-`expires` storage contract via `capabilities.expires`. */
+	public get capabilities() {
+		return keyvStorageCapability(this);
+	}
+
 	/** Function for executing SQL queries against the PostgreSQL database. */
 	private query: Query;
 
@@ -365,22 +375,22 @@ export class KeyvPostgres extends Hookified implements KeyvStorageAdapter {
 
 	/**
 	 * Sets a key-value pair. Uses an upsert operation via `ON CONFLICT` to insert or update.
-	 * Any TTL is read from the serialized value's `expires` field and stored in the `expires` column.
+	 * The absolute `expires` is stored in the `expires` column.
 	 * @param key - The key to set.
 	 * @param value - The value to store.
+	 * @param expires - Absolute expiry as Unix ms since epoch, or `undefined` for no expiry.
 	 * @returns A promise resolving to `true` on success, or `false` if an error occurred (an
 	 * `error` event is also emitted).
 	 */
 	// biome-ignore lint/suspicious/noExplicitAny: type format
-	public async set(key: string, value: any): Promise<boolean> {
+	public async set(key: string, value: any, expires?: number): Promise<boolean> {
 		try {
 			const strippedKey = this.removeKeyPrefix(key);
-			const expires = this.getExpiresFromValue(value);
 			const upsert = `INSERT INTO ${escapeIdentifier(this._schema)}.${escapeIdentifier(this._table)} (key, value, namespace, expires)
       VALUES($1, $2, $3, $4)
       ON CONFLICT(key, COALESCE(namespace, ''))
       DO UPDATE SET value=excluded.value, expires=excluded.expires;`;
-			await this.query(upsert, [strippedKey, value, this.getNamespaceValue(), expires]);
+			await this.query(upsert, [strippedKey, value, this.getNamespaceValue(), expires ?? null]);
 			return true;
 			/* v8 ignore start -- @preserve */
 		} catch (error) {
@@ -398,15 +408,15 @@ export class KeyvPostgres extends Hookified implements KeyvStorageAdapter {
 	 * @returns A promise resolving to an array of booleans (one per entry). Because the statement
 	 * is atomic, all entries succeed (`true`) or all fail (`false`); on failure an `error` event is emitted.
 	 */
-	public async setMany<Value>(entries: KeyvEntry<Value>[]): Promise<boolean[] | undefined> {
+	public async setMany<Value>(entries: KeyvStorageEntry<Value>[]): Promise<boolean[] | undefined> {
 		try {
 			const keys = [];
 			const values = [];
 			const expiresArray: Array<number | null> = [];
-			for (const { key, value } of entries) {
+			for (const { key, value, expires } of entries) {
 				keys.push(this.removeKeyPrefix(key));
 				values.push(value);
-				expiresArray.push(this.getExpiresFromValue(value));
+				expiresArray.push(expires ?? null);
 			}
 			const upsert = `INSERT INTO ${escapeIdentifier(this._schema)}.${escapeIdentifier(this._table)} (key, value, namespace, expires)
       SELECT k, v, $3, e FROM UNNEST($1::text[], $2::text[], $4::bigint[]) AS t(k, v, e)
@@ -678,32 +688,6 @@ export class KeyvPostgres extends Hookified implements KeyvStorageAdapter {
 	 */
 	private getNamespaceValue(): string | null {
 		return this._namespace ?? null;
-	}
-
-	/**
-	 * Extracts the `expires` timestamp from a serialized value.
-	 * The Keyv core serializes data as JSON like `{"value":"...","expires":1234567890}`.
-	 * Returns the expires value as a number, or null if not present or not parseable.
-	 */
-	// biome-ignore lint/suspicious/noExplicitAny: type format
-	private getExpiresFromValue(value: any): number | null {
-		// biome-ignore lint/suspicious/noExplicitAny: type format
-		let data: any;
-		if (typeof value === "string") {
-			try {
-				data = JSON.parse(value);
-			} catch {
-				return null;
-			}
-		} else {
-			data = value;
-		}
-
-		if (data && typeof data === "object" && typeof data.expires === "number") {
-			return data.expires;
-		}
-
-		return null;
 	}
 
 	/**

--- a/storage/postgres/test/test.ts
+++ b/storage/postgres/test/test.ts
@@ -10,7 +10,9 @@ const store = () => new KeyvPostgres({ uri: postgresUri, iterationLimit: 2 });
 
 keyvTestSuite(test, Keyv, store);
 keyvIteratorTests(test, Keyv, store);
-storageTestSuite(test, store, { ttl: false });
+// The v6 contract passes an absolute `expires` directly, so the adapter now handles
+// storage-level expiry (previously skipped because expiry was parsed from the value).
+storageTestSuite(test, store);
 
 beforeEach(async () => {
 	const keyv = store();
@@ -257,8 +259,9 @@ describe("has and hasMany", () => {
 	test("has returns false and deletes an expired key", async () => {
 		const keyv = new KeyvPostgres({ uri: postgresUri });
 		const key = faker.string.alphanumeric(10);
-		const expiredValue = JSON.stringify({ value: "old", expires: Date.now() - 1000 });
-		await keyv.set(key, expiredValue);
+		const pastExpires = Date.now() - 1000;
+		const expiredValue = JSON.stringify({ value: "old", expires: pastExpires });
+		await keyv.set(key, expiredValue, pastExpires);
 		expect(await keyv.has(key)).toBe(false);
 		// The expired key should have been deleted.
 		expect(await keyv.get(key)).toBeUndefined();
@@ -289,11 +292,13 @@ describe("has and hasMany", () => {
 		const expiredKey1 = faker.string.alphanumeric(10);
 		const expiredKey2 = faker.string.alphanumeric(10);
 		const validKey = faker.string.alphanumeric(10);
-		const expiredValue = JSON.stringify({ value: "old", expires: Date.now() - 1000 });
-		const validValue = JSON.stringify({ value: "fresh", expires: Date.now() + 60_000 });
-		await keyv.set(expiredKey1, expiredValue);
-		await keyv.set(expiredKey2, expiredValue);
-		await keyv.set(validKey, validValue);
+		const pastExpires = Date.now() - 1000;
+		const futureExpires = Date.now() + 60_000;
+		const expiredValue = JSON.stringify({ value: "old", expires: pastExpires });
+		const validValue = JSON.stringify({ value: "fresh", expires: futureExpires });
+		await keyv.set(expiredKey1, expiredValue, pastExpires);
+		await keyv.set(expiredKey2, expiredValue, pastExpires);
+		await keyv.set(validKey, validValue, futureExpires);
 		const result = await keyv.hasMany([expiredKey1, expiredKey2, validKey]);
 		expect(result).toStrictEqual([false, false, true]);
 		// The expired keys should have been deleted.
@@ -319,8 +324,8 @@ describe("clearExpired", () => {
 		const futureExpires = Date.now() + 60_000;
 		const validValue = JSON.stringify({ value: "fresh", expires: futureExpires });
 		const noExpiryValue = JSON.stringify({ value: "forever" });
-		await keyv.set(expiredKey, JSON.stringify({ value: "old", expires: pastExpires }));
-		await keyv.set(validKey, validValue);
+		await keyv.set(expiredKey, JSON.stringify({ value: "old", expires: pastExpires }), pastExpires);
+		await keyv.set(validKey, validValue, futureExpires);
 		await keyv.set(noExpiryKey, noExpiryValue);
 
 		await keyv.clearExpired();
@@ -333,25 +338,49 @@ describe("clearExpired", () => {
 	test("is a no-op when no entries are expired", async () => {
 		const keyv = new KeyvPostgres({ uri: postgresUri });
 		const key = faker.string.alphanumeric(10);
-		const value = JSON.stringify({ value: "ok", expires: Date.now() + 60_000 });
-		await keyv.set(key, value);
+		const futureExpires = Date.now() + 60_000;
+		const value = JSON.stringify({ value: "ok", expires: futureExpires });
+		await keyv.set(key, value, futureExpires);
 
 		await keyv.clearExpired();
 
 		expect(await keyv.get(key)).toBe(value);
 	});
+
+	// Regression: before v6 the adapter recovered `expires` by JSON.parsing the stored
+	// value, which silently failed for compressed/encrypted/msgpackr/superjson output and
+	// left the expires column NULL. The contract now passes expires directly.
+	test("populates the expires column for non-JSON encoded values so expiry still works", async () => {
+		const store = new KeyvPostgres({ uri: postgresUri });
+		const serialization = {
+			stringify: (data: unknown) => `RAW:${JSON.stringify(data)}`,
+			parse: <T>(data: string): T => JSON.parse(String(data).slice(4)) as T,
+		};
+		const keyv = new Keyv({ store, serialization });
+		const key = faker.string.uuid();
+		await keyv.set(key, "value", 100);
+		expect(await keyv.get(key)).toBe("value");
+		await new Promise((resolve) => {
+			setTimeout(resolve, 200);
+		});
+		expect(await keyv.get(key)).toBeUndefined();
+		await store.clearExpired();
+		expect(await store.has(key)).toBe(false);
+		await keyv.disconnect();
+	});
 });
 
 describe("expires column", () => {
-	test("set extracts and stores expires from the value", async () => {
+	test("set stores the provided expires alongside the value", async () => {
 		const keyv = new KeyvPostgres({ uri: postgresUri });
 		const key = faker.string.alphanumeric(10);
-		const value = JSON.stringify({ value: "test-value", expires: Date.now() + 60_000 });
-		await keyv.set(key, value);
+		const futureExpires = Date.now() + 60_000;
+		const value = JSON.stringify({ value: "test-value", expires: futureExpires });
+		await keyv.set(key, value, futureExpires);
 		expect(await keyv.get(key)).toBe(value);
 	});
 
-	test("set stores null expires when the value has no expires field", async () => {
+	test("set stores null expires when no expires is provided", async () => {
 		const keyv = new KeyvPostgres({ uri: postgresUri });
 		const key = faker.string.alphanumeric(10);
 		const value = JSON.stringify({ value: "no-ttl-value" });
@@ -362,23 +391,27 @@ describe("expires column", () => {
 	test("set updates the expires column on upsert", async () => {
 		const keyv = new KeyvPostgres({ uri: postgresUri });
 		const key = faker.string.alphanumeric(10);
-		const value2 = JSON.stringify({ value: "v2", expires: Date.now() + 120_000 });
-		await keyv.set(key, JSON.stringify({ value: "v1", expires: Date.now() + 60_000 }));
-		await keyv.set(key, value2);
+		const firstExpires = Date.now() + 60_000;
+		const secondExpires = Date.now() + 120_000;
+		const value2 = JSON.stringify({ value: "v2", expires: secondExpires });
+		await keyv.set(key, JSON.stringify({ value: "v1", expires: firstExpires }), firstExpires);
+		await keyv.set(key, value2, secondExpires);
 		expect(await keyv.get(key)).toBe(value2);
 	});
 
-	test("setMany extracts and stores expires for each entry", async () => {
+	test("setMany stores the provided expires for each entry", async () => {
 		const keyv = new KeyvPostgres({ uri: postgresUri });
 		const key1 = faker.string.alphanumeric(10);
 		const key2 = faker.string.alphanumeric(10);
 		const key3 = faker.string.alphanumeric(10);
-		const value1 = JSON.stringify({ value: "v1", expires: Date.now() + 60_000 });
-		const value2 = JSON.stringify({ value: "v2", expires: Date.now() + 120_000 });
+		const expires1 = Date.now() + 60_000;
+		const expires2 = Date.now() + 120_000;
+		const value1 = JSON.stringify({ value: "v1", expires: expires1 });
+		const value2 = JSON.stringify({ value: "v2", expires: expires2 });
 		const value3 = JSON.stringify({ value: "v3" });
 		await keyv.setMany([
-			{ key: key1, value: value1 },
-			{ key: key2, value: value2 },
+			{ key: key1, value: value1, expires: expires1 },
+			{ key: key2, value: value2, expires: expires2 },
 			{ key: key3, value: value3 },
 		]);
 		expect(await keyv.get(key1)).toBe(value1);
@@ -426,9 +459,11 @@ describe("clearExpiredInterval", () => {
 		const keyv = new KeyvPostgres({ uri: postgresUri, clearExpiredInterval: 100 });
 		const expiredKey = faker.string.alphanumeric(10);
 		const validKey = faker.string.alphanumeric(10);
-		const validValue = JSON.stringify({ value: "fresh", expires: Date.now() + 60_000 });
-		await keyv.set(expiredKey, JSON.stringify({ value: "old", expires: Date.now() - 60_000 }));
-		await keyv.set(validKey, validValue);
+		const pastExpires = Date.now() - 60_000;
+		const futureExpires = Date.now() + 60_000;
+		const validValue = JSON.stringify({ value: "fresh", expires: futureExpires });
+		await keyv.set(expiredKey, JSON.stringify({ value: "old", expires: pastExpires }), pastExpires);
+		await keyv.set(validKey, validValue, futureExpires);
 
 		// Wait for the interval to fire.
 		await new Promise((resolve) => {

--- a/storage/redis/README.md
+++ b/storage/redis/README.md
@@ -11,7 +11,7 @@ Redis storage adapter for [Keyv](https://github.com/jaredwray/keyv).
 
 # Features
 * Built on top of [@redis/client](https://npmjs.com/package/@redis/client).
-* TTL is handled directly by Redis.
+* TTL is handled directly by Redis via absolute `PXAT` expiry, with an automatic relative `PX` fallback for servers older than 6.2 (see [Expiration and TTL](#expiration-and-ttl)).
 * Supports Redis Clusters.
 * Url connection string support or pass in your Redis Options
 * Easily add in your own Redis client.
@@ -32,6 +32,7 @@ Redis storage adapter for [Keyv](https://github.com/jaredwray/keyv).
 * [Fixing Double Prefixing of Keys](#fixing-double-prefixing-of-keys)
 * [Using Generic Types](#using-generic-types)
 * [Performance Considerations](#performance-considerations)
+* [Expiration and TTL](#expiration-and-ttl)
 * [High Memory Usage on Redis Server](#high-memory-usage-on-redis-server)
 * [Gracefully Handling Errors and Timeouts](#gracefully-handling-errors-and-timeouts)
 * [Using Cacheable with Redis](#using-cacheable-with-redis)
@@ -312,6 +313,21 @@ With namespaces being prefix based it is critical to understand some of the perf
 * `setMany`, `getMany`, `deleteMany` - These methods are more efficient than their singular counterparts. These will be used by default in the `Keyv` library such as when using `keyv.delete(string[])` it will use `deleteMany()`.
 
 If you want to see even better performance please see the [Using Cacheable with Redis](#using-cacheable-with-redis) section as it has non-blocking and in-memory primary caching that goes along well with this library and Keyv.
+
+# Expiration and TTL
+
+Keyv hands this adapter an **absolute** expiry — a Unix timestamp in milliseconds — computed once on the Keyv host. The adapter writes it to Redis with `SET ... PXAT`, the absolute-expiry option. Because the deadline is absolute, it is immune to clock skew and to any latency between Keyv computing the expiry and Redis receiving the command: a key set to expire at `T` expires at `T` no matter how long the write takes to arrive.
+
+`PXAT` was added in **Redis 6.2**. For older servers the adapter automatically falls back to the relative `PX` option (the remaining lifetime in milliseconds):
+
+* On the **first** expiring write, the adapter runs `INFO server` once, parses `redis_version`, and caches whether the server is 6.2+. Every later write reuses that cached answer, so detection costs one `INFO` round-trip per connection, not per write.
+* **6.2 or newer** → the write uses `PXAT: expires` (absolute).
+* **Older than 6.2** → the write uses `PX: max(0, expires - Date.now())` (relative, computed at write time). An expiry already in the past becomes `PX: 0`.
+* If the version **cannot be determined** — for example a cluster where `INFO` isn't directly available, or a transient error reading it — the adapter assumes `PXAT` is supported, since such deployments are overwhelmingly modern. The cached result means it won't keep retrying `INFO` on every write.
+
+The same detection and fallback apply to `setMany`, including the per-hash-slot grouping used in cluster mode. No configuration is required; you always call `keyv.set(key, value, ttl)` with a relative millisecond `ttl` (or rely on the `ttl` option) and the adapter chooses the correct Redis option for your server.
+
+The relative `PX` fallback re-derives the remaining lifetime store-side, so on pre-6.2 servers a large write-to-Redis latency could in theory shorten the effective TTL by that latency. On 6.2+ (`PXAT`) there is no such window. If you need the skew-immune absolute behaviour, run Redis 6.2 or later.
 
 # High Memory Usage on Redis Server
 

--- a/storage/redis/src/index.ts
+++ b/storage/redis/src/index.ts
@@ -400,7 +400,10 @@ export default class KeyvRedis<T> extends Hookified implements KeyvStorageAdapte
 	 * @param usePxat - whether the server supports PXAT (from {@link supportsPxat})
 	 */
 	private expiryOptions(expires: number, usePxat: boolean): { PXAT: number } | { PX: number } {
-		return usePxat ? { PXAT: expires } : { PX: Math.max(0, expires - Date.now()) };
+		// Redis rejects `SET ... PX 0` ("invalid expire time"), so floor the relative fallback at
+		// 1ms for an already-elapsed deadline — the key is written and reaped almost immediately,
+		// matching how an absolute PXAT in the past behaves (and the memcache exptime floor).
+		return usePxat ? { PXAT: expires } : { PX: Math.max(1, expires - Date.now()) };
 	}
 
 	/**

--- a/storage/redis/src/index.ts
+++ b/storage/redis/src/index.ts
@@ -371,7 +371,7 @@ export default class KeyvRedis<T> extends Hookified implements KeyvStorageAdapte
 		try {
 			key = this.createKeyPrefix(key, this._namespace);
 
-			if (expires !== undefined) {
+			if (typeof expires === "number") {
 				await client.set(key, value, { PXAT: expires });
 			} else {
 				await client.set(key, value);
@@ -422,7 +422,7 @@ export default class KeyvRedis<T> extends Hookified implements KeyvStorageAdapte
 							entry: { key, value, expires },
 						} of slotEntries) {
 							const prefixedKey = this.createKeyPrefix(key, this._namespace);
-							if (expires !== undefined) {
+							if (typeof expires === "number") {
 								multi.set(prefixedKey, value as string, { PXAT: expires });
 							} else {
 								multi.set(prefixedKey, value as string);
@@ -440,7 +440,7 @@ export default class KeyvRedis<T> extends Hookified implements KeyvStorageAdapte
 				const multi = client.multi();
 				for (const { key, value, expires } of entries) {
 					const prefixedKey = this.createKeyPrefix(key, this._namespace);
-					if (expires !== undefined) {
+					if (typeof expires === "number") {
 						multi.set(prefixedKey, value as string, { PXAT: expires });
 					} else {
 						multi.set(prefixedKey, value as string);

--- a/storage/redis/src/index.ts
+++ b/storage/redis/src/index.ts
@@ -17,7 +17,7 @@ import {
 } from "@redis/client";
 import calculateSlot from "cluster-key-slot";
 import { Hookified } from "hookified";
-import type { KeyvEntry, KeyvStorageAdapter } from "keyv";
+import { type KeyvStorageAdapter, type KeyvStorageEntry, keyvStorageCapability } from "keyv";
 import {
 	defaultReconnectStrategy,
 	type KeyvRedisEntry,
@@ -43,6 +43,11 @@ export {
 };
 
 export default class KeyvRedis<T> extends Hookified implements KeyvStorageAdapter {
+	/** Declares the v6 absolute-`expires` storage contract via `capabilities.expires`. */
+	public get capabilities() {
+		return keyvStorageCapability(this);
+	}
+
 	/**
 	 * The underlying Redis client, cluster, or sentinel connection used for all storage operations.
 	 */
@@ -354,20 +359,20 @@ export default class KeyvRedis<T> extends Hookified implements KeyvStorageAdapte
 	}
 
 	/**
-	 * Set a key value pair in the store. TTL is in milliseconds.
+	 * Set a key value pair in the store. Expiry is an absolute Unix timestamp in milliseconds.
 	 * @param {string} key - the key to set
 	 * @param {string} value - the value to set
-	 * @param {number} [ttl] - the time to live in milliseconds
+	 * @param {number} [expires] - absolute expiry as Unix ms since epoch, or undefined for no expiry
 	 * @returns {Promise<boolean>} - true if the value was set, false if an error occurred and throwOnErrors is false
 	 */
-	public async set(key: string, value: string, ttl?: number): Promise<boolean> {
+	public async set(key: string, value: string, expires?: number): Promise<boolean> {
 		const client = await this.getClient();
 
 		try {
 			key = this.createKeyPrefix(key, this._namespace);
 
-			if (ttl) {
-				await client.set(key, value, { PX: ttl });
+			if (expires !== undefined) {
+				await client.set(key, value, { PXAT: expires });
 			} else {
 				await client.set(key, value);
 			}
@@ -385,11 +390,11 @@ export default class KeyvRedis<T> extends Hookified implements KeyvStorageAdapte
 	}
 
 	/**
-	 * Will set many key value pairs in the store. TTL is in milliseconds. This will be done as a single transaction.
-	 * @param {KeyvEntry[]} entries - the key value pairs to set with optional ttl
+	 * Will set many key value pairs in the store. Expiry is an absolute Unix timestamp in milliseconds. This will be done as a single transaction.
+	 * @param {KeyvStorageEntry[]} entries - the key value pairs to set with optional absolute expires
 	 * @returns {Promise<boolean[] | undefined>} - array of booleans indicating whether each entry was successfully set
 	 */
-	public async setMany<Value>(entries: KeyvEntry<Value>[]): Promise<boolean[] | undefined> {
+	public async setMany<Value>(entries: KeyvStorageEntry<Value>[]): Promise<boolean[] | undefined> {
 		try {
 			const results = new Array<boolean>(entries.length).fill(false);
 
@@ -398,7 +403,7 @@ export default class KeyvRedis<T> extends Hookified implements KeyvStorageAdapte
 				await this.getClient();
 
 				// Group entries by slot to avoid CROSSSLOT errors, tracking original indices
-				const slotMap = new Map<number, Array<{ entry: KeyvEntry<Value>; index: number }>>();
+				const slotMap = new Map<number, Array<{ entry: KeyvStorageEntry<Value>; index: number }>>();
 				for (let i = 0; i < entries.length; i++) {
 					const entry = entries[i];
 					const prefixedKey = this.createKeyPrefix(entry.key, this._namespace);
@@ -414,11 +419,11 @@ export default class KeyvRedis<T> extends Hookified implements KeyvStorageAdapte
 						const client = await this.getSlotMaster(slot);
 						const multi = client.multi();
 						for (const {
-							entry: { key, value, ttl },
+							entry: { key, value, expires },
 						} of slotEntries) {
 							const prefixedKey = this.createKeyPrefix(key, this._namespace);
-							if (ttl) {
-								multi.set(prefixedKey, value as string, { PX: ttl });
+							if (expires !== undefined) {
+								multi.set(prefixedKey, value as string, { PXAT: expires });
 							} else {
 								multi.set(prefixedKey, value as string);
 							}
@@ -433,10 +438,10 @@ export default class KeyvRedis<T> extends Hookified implements KeyvStorageAdapte
 				// Non-cluster mode can use a single multi
 				const client = (await this.getClient()) as RedisClientType;
 				const multi = client.multi();
-				for (const { key, value, ttl } of entries) {
+				for (const { key, value, expires } of entries) {
 					const prefixedKey = this.createKeyPrefix(key, this._namespace);
-					if (ttl) {
-						multi.set(prefixedKey, value as string, { PX: ttl });
+					if (expires !== undefined) {
+						multi.set(prefixedKey, value as string, { PXAT: expires });
 					} else {
 						multi.set(prefixedKey, value as string);
 					}

--- a/storage/redis/src/index.ts
+++ b/storage/redis/src/index.ts
@@ -359,6 +359,63 @@ export default class KeyvRedis<T> extends Hookified implements KeyvStorageAdapte
 	}
 
 	/**
+	 * Whether the connected server supports the absolute-expiry `PXAT` option (Redis 6.2+).
+	 * Detected lazily on first expiring write and cached. `undefined` until detected.
+	 */
+	private _pxatSupported?: boolean;
+
+	/**
+	 * Lazily detect whether the server supports `SET ... PXAT` (Redis 6.2+), caching the result.
+	 * Falls back to assuming support (PXAT) when the version cannot be determined (e.g. clusters
+	 * where `INFO` isn't directly available, or a transient error) — those deployments are modern.
+	 * @param client - the Redis client/cluster/sentinel connection to introspect
+	 * @returns {Promise<boolean>} true if PXAT may be used, false to fall back to relative PX
+	 */
+	private async supportsPxat(client: RedisClientConnectionType): Promise<boolean> {
+		if (this._pxatSupported !== undefined) {
+			return this._pxatSupported;
+		}
+
+		try {
+			const info = String(await (client as RedisClientType).info("server"));
+			const match = /redis_version:(\d+)\.(\d+)/.exec(info);
+			if (match) {
+				const major = Number(match[1]);
+				const minor = Number(match[2]);
+				this._pxatSupported = major > 6 || (major === 6 && minor >= 2);
+			} else {
+				this._pxatSupported = true;
+			}
+		} catch {
+			this._pxatSupported = true;
+		}
+
+		return this._pxatSupported;
+	}
+
+	/**
+	 * Build the `SET` expiry option for an absolute `expires`. Prefers the skew-immune absolute
+	 * `PXAT`; falls back to a relative `PX` (remaining ms) for servers older than 6.2.
+	 * @param expires - absolute expiry as Unix ms since epoch
+	 * @param usePxat - whether the server supports PXAT (from {@link supportsPxat})
+	 */
+	private expiryOptions(expires: number, usePxat: boolean): { PXAT: number } | { PX: number } {
+		return usePxat ? { PXAT: expires } : { PX: Math.max(0, expires - Date.now()) };
+	}
+
+	/**
+	 * Resolve the `SET` expiry option for a single write, detecting PXAT support as needed.
+	 * @param client - the Redis client/cluster/sentinel connection
+	 * @param expires - absolute expiry as Unix ms since epoch
+	 */
+	private async buildExpiryOptions(
+		client: RedisClientConnectionType,
+		expires: number,
+	): Promise<{ PXAT: number } | { PX: number }> {
+		return this.expiryOptions(expires, await this.supportsPxat(client));
+	}
+
+	/**
 	 * Set a key value pair in the store. Expiry is an absolute Unix timestamp in milliseconds.
 	 * @param {string} key - the key to set
 	 * @param {string} value - the value to set
@@ -372,7 +429,7 @@ export default class KeyvRedis<T> extends Hookified implements KeyvStorageAdapte
 			key = this.createKeyPrefix(key, this._namespace);
 
 			if (typeof expires === "number") {
-				await client.set(key, value, { PXAT: expires });
+				await client.set(key, value, await this.buildExpiryOptions(client, expires));
 			} else {
 				await client.set(key, value);
 			}
@@ -417,13 +474,14 @@ export default class KeyvRedis<T> extends Hookified implements KeyvStorageAdapte
 				await Promise.all(
 					Array.from(slotMap.entries(), async ([slot, slotEntries]) => {
 						const client = await this.getSlotMaster(slot);
+						const usePxat = await this.supportsPxat(client);
 						const multi = client.multi();
 						for (const {
 							entry: { key, value, expires },
 						} of slotEntries) {
 							const prefixedKey = this.createKeyPrefix(key, this._namespace);
 							if (typeof expires === "number") {
-								multi.set(prefixedKey, value as string, { PXAT: expires });
+								multi.set(prefixedKey, value as string, this.expiryOptions(expires, usePxat));
 							} else {
 								multi.set(prefixedKey, value as string);
 							}
@@ -437,11 +495,12 @@ export default class KeyvRedis<T> extends Hookified implements KeyvStorageAdapte
 			} else {
 				// Non-cluster mode can use a single multi
 				const client = (await this.getClient()) as RedisClientType;
+				const usePxat = await this.supportsPxat(client);
 				const multi = client.multi();
 				for (const { key, value, expires } of entries) {
 					const prefixedKey = this.createKeyPrefix(key, this._namespace);
 					if (typeof expires === "number") {
-						multi.set(prefixedKey, value as string, { PXAT: expires });
+						multi.set(prefixedKey, value as string, this.expiryOptions(expires, usePxat));
 					} else {
 						multi.set(prefixedKey, value as string);
 					}

--- a/storage/redis/src/types.ts
+++ b/storage/redis/src/types.ts
@@ -79,9 +79,9 @@ export type KeyvRedisEntry<T> = {
 	 */
 	value: T;
 	/**
-	 * Time to live in milliseconds.
+	 * Absolute expiry as Unix ms since epoch, or `undefined` for no expiry.
 	 */
-	ttl?: number;
+	expires?: number;
 };
 
 export enum RedisErrorMessages {

--- a/storage/redis/test/cluster.test.ts
+++ b/storage/redis/test/cluster.test.ts
@@ -482,7 +482,7 @@ describe("KeyvRedis Cluster", () => {
 			await keyvRedis.disconnect();
 		});
 
-		test("setMany with TTL should work with cluster mode", async () => {
+		test("setMany with expires should work with cluster mode", async () => {
 			const cluster = createCluster(defaultClusterOptions);
 			const keyvRedis = new KeyvRedis(cluster);
 
@@ -490,7 +490,7 @@ describe("KeyvRedis Cluster", () => {
 			const entries = Array.from({ length: 3 }, () => ({
 				key: faker.string.uuid(),
 				value: faker.lorem.word(),
-				ttl: 5000,
+				expires: Date.now() + 5000,
 			}));
 
 			// Should not throw CROSSSLOT error

--- a/storage/redis/test/delete.test.ts
+++ b/storage/redis/test/delete.test.ts
@@ -185,7 +185,7 @@ describe("delete", () => {
 		await keyvRedis.setMany([
 			{ key: key1, value: val1 },
 			{ key: key2, value: val2 },
-			{ key: key3, value: val3, ttl: 100 },
+			{ key: key3, value: val3, expires: Date.now() + 100 },
 		]);
 		await keyvRedis.deleteMany([key2, key3]);
 		const value = await keyvRedis.get(key1);
@@ -209,7 +209,7 @@ describe("delete", () => {
 		await keyvRedis.setMany([
 			{ key: key1, value: val1 },
 			{ key: key2, value: val2 },
-			{ key: key3, value: val3, ttl: 100 },
+			{ key: key3, value: val3, expires: Date.now() + 100 },
 		]);
 		await keyvRedis.deleteMany([key2, key3]);
 		const value = await keyvRedis.get(key1);

--- a/storage/redis/test/get.test.ts
+++ b/storage/redis/test/get.test.ts
@@ -146,7 +146,7 @@ describe("get", () => {
 		await keyvRedis.setMany([
 			{ key: key1, value: val1 },
 			{ key: key2, value: val2 },
-			{ key: key3, value: faker.lorem.word(), ttl: 100 },
+			{ key: key3, value: faker.lorem.word(), expires: Date.now() + 100 },
 		]);
 		await delay(300);
 		const values = await keyvRedis.getMany([key1, key2, key3]);

--- a/storage/redis/test/has.test.ts
+++ b/storage/redis/test/has.test.ts
@@ -167,7 +167,7 @@ describe("has", () => {
 		await keyvRedis.setMany([
 			{ key: key1, value: value1 },
 			{ key: key2, value: value2 },
-			{ key: key3, value: value3, ttl: 100 },
+			{ key: key3, value: value3, expires: Date.now() + 100 },
 		]);
 		await delay(300);
 		const exists = await keyvRedis.hasMany([key1, key2, key3]);

--- a/storage/redis/test/namespace.test.ts
+++ b/storage/redis/test/namespace.test.ts
@@ -159,7 +159,7 @@ describe("Namespace", () => {
 		await keyvRedis.setMany([
 			{ key: key1, value: val1 },
 			{ key: key2, value: val2 },
-			{ key: key3, value: val3, ttl: 100 },
+			{ key: key3, value: val3, expires: Date.now() + 100 },
 		]);
 		const value = await keyvRedis.get(key1);
 		expect(value).toBe(val1);
@@ -184,7 +184,7 @@ describe("Namespace", () => {
 		await keyvRedis.setMany([
 			{ key: key1, value: val1 },
 			{ key: key2, value: val2 },
-			{ key: key3, value: val3, ttl: 100 },
+			{ key: key3, value: val3, expires: Date.now() + 100 },
 		]);
 		await delay(300);
 		const exists = await keyvRedis.hasMany([key1, key2, key3]);
@@ -205,7 +205,7 @@ describe("Namespace", () => {
 		await keyvRedis.setMany([
 			{ key: key1, value: val1 },
 			{ key: key2, value: val2 },
-			{ key: key3, value: val3, ttl: 100 },
+			{ key: key3, value: val3, expires: Date.now() + 100 },
 		]);
 		await keyvRedis.deleteMany([key2, key3]);
 		const value = await keyvRedis.get(key1);

--- a/storage/redis/test/set.test.ts
+++ b/storage/redis/test/set.test.ts
@@ -70,15 +70,15 @@ describe("set", () => {
 		expect(didError).toBe(true);
 	});
 
-	test("should set a value with ttl", async () => {
+	test("should set a value with expires", async () => {
 		const keyvRedis = new KeyvRedis(redisUri);
 		const data = {
 			key: faker.string.alphanumeric(10),
 			value: faker.lorem.sentence(),
-			ttl: 100, // 100 milliseconds
+			expires: Date.now() + 100, // 100 milliseconds from now
 		};
 
-		await keyvRedis.set(data.key, data.value, data.ttl);
+		await keyvRedis.set(data.key, data.value, data.expires);
 
 		const result = await keyvRedis.get(data.key);
 
@@ -157,10 +157,10 @@ describe("set", () => {
 		vi.spyOn(keyvRedis.client, "multi").mockRestore();
 	});
 
-	test("should be able to set a ttl", async () => {
+	test("should be able to set an expires", async () => {
 		const keyvRedis = new KeyvRedis();
 		const key = faker.string.uuid();
-		await keyvRedis.set(key, faker.lorem.word(), 100);
+		await keyvRedis.set(key, faker.lorem.word(), Date.now() + 100);
 		await delay(300);
 		const value = await keyvRedis.get(key);
 		expect(value).toBeUndefined();
@@ -177,7 +177,7 @@ describe("set", () => {
 		await keyvRedis.setMany([
 			{ key: key1, value: val1 },
 			{ key: key2, value: val2 },
-			{ key: key3, value: faker.lorem.word(), ttl: 100 },
+			{ key: key3, value: faker.lorem.word(), expires: Date.now() + 100 },
 		]);
 		const value = await keyvRedis.get(key1);
 		expect(value).toBe(val1);

--- a/storage/redis/test/set.test.ts
+++ b/storage/redis/test/set.test.ts
@@ -112,6 +112,33 @@ describe("set", () => {
 		setSpy.mockRestore();
 	});
 
+	test("should not send PX 0 on the PX fallback for an already-expired write", async () => {
+		const keyvRedis = new KeyvRedis(redisUri);
+		// Force the pre-6.2 fallback path; an absolute expiry already in the past must floor to
+		// PX >= 1, not PX 0 (which Redis rejects as an invalid expire time).
+		(keyvRedis as unknown as { _pxatSupported: boolean })._pxatSupported = false;
+		const setSpy = vi.spyOn(keyvRedis.client, "set");
+
+		const key = faker.string.alphanumeric(10);
+		let didError = false;
+		try {
+			await keyvRedis.set(key, faker.lorem.word(), Date.now() - 1000);
+		} catch {
+			didError = true;
+		}
+		expect(didError).toBe(false);
+
+		const call = setSpy.mock.calls.find((c) => c[0] === key);
+		const options = call?.[2] as Record<string, number>;
+		expect(options).toHaveProperty("PX");
+		expect(options.PX).toBeGreaterThanOrEqual(1);
+		// PX is floored to 1ms, so the key expires almost immediately rather than living forever.
+		await delay(50);
+		expect(await keyvRedis.get(key)).toBeUndefined();
+
+		setSpy.mockRestore();
+	});
+
 	test("should assume PXAT support when INFO omits the redis_version", async () => {
 		const keyvRedis = new KeyvRedis(redisUri);
 		const client = await keyvRedis.getClient();

--- a/storage/redis/test/set.test.ts
+++ b/storage/redis/test/set.test.ts
@@ -112,6 +112,45 @@ describe("set", () => {
 		setSpy.mockRestore();
 	});
 
+	test("should assume PXAT support when INFO omits the redis_version", async () => {
+		const keyvRedis = new KeyvRedis(redisUri);
+		const client = await keyvRedis.getClient();
+		// INFO without a redis_version line → detection can't parse a version, defaults to PXAT.
+		const infoSpy = vi
+			.spyOn(client, "info")
+			.mockResolvedValue("# Server\r\nredis_mode:standalone\r\n");
+		const setSpy = vi.spyOn(client, "set");
+
+		const key = faker.string.alphanumeric(10);
+		await keyvRedis.set(key, faker.lorem.word(), Date.now() + 1000);
+
+		expect((keyvRedis as unknown as { _pxatSupported: boolean })._pxatSupported).toBe(true);
+		const call = setSpy.mock.calls.find((c) => c[0] === key);
+		expect(call?.[2] as Record<string, number>).toHaveProperty("PXAT");
+
+		infoSpy.mockRestore();
+		setSpy.mockRestore();
+		await keyvRedis.disconnect();
+	});
+
+	test("should assume PXAT support when INFO throws", async () => {
+		const keyvRedis = new KeyvRedis(redisUri);
+		const client = await keyvRedis.getClient();
+		const infoSpy = vi.spyOn(client, "info").mockRejectedValue(new Error("INFO unavailable"));
+		const setSpy = vi.spyOn(client, "set");
+
+		const key = faker.string.alphanumeric(10);
+		await keyvRedis.set(key, faker.lorem.word(), Date.now() + 1000);
+
+		expect((keyvRedis as unknown as { _pxatSupported: boolean })._pxatSupported).toBe(true);
+		const call = setSpy.mock.calls.find((c) => c[0] === key);
+		expect(call?.[2] as Record<string, number>).toHaveProperty("PXAT");
+
+		infoSpy.mockRestore();
+		setSpy.mockRestore();
+		await keyvRedis.disconnect();
+	});
+
 	test("should throw on redis client set error when throwOnErrors is true", async () => {
 		const keyvRedis = new KeyvRedis(redisUri, { throwOnErrors: true });
 

--- a/storage/redis/test/set.test.ts
+++ b/storage/redis/test/set.test.ts
@@ -90,6 +90,28 @@ describe("set", () => {
 		expect(expiredResult).toBeUndefined();
 	});
 
+	test("should fall back to relative PX when the server does not support PXAT", async () => {
+		const keyvRedis = new KeyvRedis(redisUri);
+		// Force the pre-6.2 fallback path without needing an old server.
+		(keyvRedis as unknown as { _pxatSupported: boolean })._pxatSupported = false;
+		const setSpy = vi.spyOn(keyvRedis.client, "set");
+
+		const key = faker.string.alphanumeric(10);
+		const value = faker.lorem.word();
+		await keyvRedis.set(key, value, Date.now() + 1000);
+
+		const call = setSpy.mock.calls.find((c) => c[0] === key);
+		const options = call?.[2] as Record<string, number>;
+		expect(options).toHaveProperty("PX");
+		expect(options).not.toHaveProperty("PXAT");
+		expect(options.PX).toBeGreaterThan(0);
+		expect(options.PX).toBeLessThanOrEqual(1000);
+		// And the value still round-trips and expires.
+		expect(await keyvRedis.get(key)).toBe(value);
+
+		setSpy.mockRestore();
+	});
+
 	test("should throw on redis client set error when throwOnErrors is true", async () => {
 		const keyvRedis = new KeyvRedis(redisUri, { throwOnErrors: true });
 

--- a/storage/sqlite/src/index.ts
+++ b/storage/sqlite/src/index.ts
@@ -1,5 +1,10 @@
 import { Hookified } from "hookified";
-import Keyv, { type KeyvEntry, type KeyvStorageAdapter, type KeyvStorageGetResult } from "keyv";
+import Keyv, {
+	type KeyvStorageAdapter,
+	type KeyvStorageEntry,
+	type KeyvStorageGetResult,
+	keyvStorageCapability,
+} from "keyv";
 import { resolveDriver } from "./drivers/index.js";
 import type { SqliteDriver, SqliteDriverName } from "./drivers/types.js";
 import type { Db, DbClose, DbQuery, KeyvSqliteOptions } from "./types.js";
@@ -49,6 +54,11 @@ function escapeIdentifier(identifier: string): string {
  * ```
  */
 export class KeyvSqlite extends Hookified implements KeyvStorageAdapter {
+	/** Declares the v6 absolute-`expires` storage contract via `capabilities.expires`. */
+	public get capabilities() {
+		return keyvStorageCapability(this);
+	}
+
 	/** The namespace used to prefix keys for multi-tenant separation. */
 	private _namespace?: string;
 
@@ -505,23 +515,22 @@ export class KeyvSqlite extends Hookified implements KeyvStorageAdapter {
 
 	/**
 	 * Sets a key-value pair. Uses an upsert operation via `ON CONFLICT` to
-	 * insert a new entry or update an existing one atomically. Automatically
-	 * extracts the `expires` timestamp from the serialized value if present.
+	 * insert a new entry or update an existing one atomically.
 	 * @param {string} key - The key to set. If a namespace is set, the namespace prefix is stripped before storing.
-	 * @param {any} value - The value to store. May be a serialized JSON string containing an `expires` timestamp.
+	 * @param {any} value - The value to store.
+	 * @param {number} [expires] - Absolute expiry as Unix ms since epoch, or `undefined` for no expiry.
 	 * @returns {Promise<boolean>} `true` on success, or `false` if an error occurred (an `error` event is also emitted).
 	 */
 	// biome-ignore lint/suspicious/noExplicitAny: type format
-	public async set(key: string, value: any): Promise<boolean> {
+	public async set(key: string, value: any, expires?: number): Promise<boolean> {
 		try {
 			const strippedKey = this.removeKeyPrefix(key);
 			const ns = this.getNamespaceValue();
-			const expires = this.getExpiresFromValue(value);
 			const upsert = `INSERT INTO ${this.getCleanTableName()} (key, value, namespace, expires)
 			VALUES(?, ?, ?, ?)
 			ON CONFLICT(key, namespace)
 			DO UPDATE SET value=excluded.value, expires=excluded.expires;`;
-			await this.query(upsert, strippedKey, value, ns, expires);
+			await this.query(upsert, strippedKey, value, ns, expires ?? null);
 			return true;
 			/* v8 ignore start -- @preserve */
 		} catch (error) {
@@ -536,11 +545,11 @@ export class KeyvSqlite extends Hookified implements KeyvStorageAdapter {
 	 * More efficient than calling {@link set} in a loop for bulk operations. Entries are batched
 	 * (249 per batch) to stay within SQLite's 999 bind-parameter limit; each batch is atomic.
 	 * @template Value - The type of the stored values.
-	 * @param {KeyvEntry<Value>[]} entries - An array of `{ key, value }` entry objects to store.
+	 * @param {KeyvStorageEntry<Value>[]} entries - An array of `{ key, value, expires? }` entry objects to store.
 	 * @returns {Promise<boolean[] | undefined>} An array of per-entry success booleans in input order.
 	 *   Entries in a failed batch are `false` (an `error` event is emitted for that batch).
 	 */
-	public async setMany<Value>(entries: KeyvEntry<Value>[]): Promise<boolean[] | undefined> {
+	public async setMany<Value>(entries: KeyvStorageEntry<Value>[]): Promise<boolean[] | undefined> {
 		if (entries.length === 0) {
 			return entries.map(() => true);
 		}
@@ -557,11 +566,10 @@ export class KeyvSqlite extends Hookified implements KeyvStorageAdapter {
 			// biome-ignore lint/suspicious/noExplicitAny: type format
 			const params: any[] = [];
 
-			for (const { key, value } of batch) {
+			for (const { key, value, expires } of batch) {
 				const strippedKey = this.removeKeyPrefix(key);
-				const expires = this.getExpiresFromValue(value);
 				placeholders.push("(?, ?, ?, ?)");
-				params.push(strippedKey, value, ns, expires);
+				params.push(strippedKey, value, ns, expires ?? null);
 			}
 
 			const upsert = `INSERT INTO ${this.getCleanTableName()} (key, value, namespace, expires)
@@ -826,37 +834,6 @@ export class KeyvSqlite extends Hookified implements KeyvStorageAdapter {
 	 */
 	private getNamespaceValue(): string {
 		return this._namespace ?? "";
-	}
-
-	/**
-	 * Extracts the `expires` timestamp from a serialized value.
-	 *
-	 * The Keyv core serializes data as JSON like `{"value":"...","expires":1234567890}`.
-	 * This method parses that JSON (or inspects the object directly if the value
-	 * is not a string) and returns the `expires` field if present.
-	 *
-	 * @param {any} value - The serialized value string or object to inspect.
-	 * @returns {number | null} The expires timestamp as a number, or `null` if not present or not parseable.
-	 */
-	// biome-ignore lint/suspicious/noExplicitAny: type format
-	private getExpiresFromValue(value: any): number | null {
-		// biome-ignore lint/suspicious/noExplicitAny: type format
-		let data: any;
-		if (typeof value === "string") {
-			try {
-				data = JSON.parse(value);
-			} catch {
-				return null;
-			}
-		} else {
-			data = value;
-		}
-
-		if (data && typeof data === "object" && typeof data.expires === "number") {
-			return data.expires;
-		}
-
-		return null;
 	}
 
 	/**

--- a/storage/sqlite/test/test.ts
+++ b/storage/sqlite/test/test.ts
@@ -9,7 +9,9 @@ const store = () => new KeyvSqlite({ uri: sqliteUri, busyTimeout: 3000 });
 
 keyvTestSuite(test, Keyv, store);
 keyvIteratorTests(test, Keyv, store);
-storageTestSuite(test, store, { ttl: false });
+// The v6 contract passes an absolute `expires` directly, so the adapter now handles
+// storage-level expiry (previously skipped because expiry was parsed from the value).
+storageTestSuite(test, store);
 
 beforeEach(async () => {
 	const keyv = store();
@@ -251,11 +253,13 @@ describe("getMany", () => {
 		const expiredKey1 = faker.string.uuid();
 		const expiredKey2 = faker.string.uuid();
 		const validKey = faker.string.uuid();
-		const expiredValue = JSON.stringify({ value: "old", expires: Date.now() - 1000 });
-		const validValue = JSON.stringify({ value: "fresh", expires: Date.now() + 60_000 });
-		await keyv.set(expiredKey1, expiredValue);
-		await keyv.set(expiredKey2, expiredValue);
-		await keyv.set(validKey, validValue);
+		const pastExpires = Date.now() - 1000;
+		const futureExpires = Date.now() + 60_000;
+		const expiredValue = JSON.stringify({ value: "old", expires: pastExpires });
+		const validValue = JSON.stringify({ value: "fresh", expires: futureExpires });
+		await keyv.set(expiredKey1, expiredValue, pastExpires);
+		await keyv.set(expiredKey2, expiredValue, pastExpires);
+		await keyv.set(validKey, validValue, futureExpires);
 		const result = await keyv.getMany([expiredKey1, expiredKey2, validKey]);
 		expect(result[0]).toBeUndefined();
 		expect(result[1]).toBeUndefined();
@@ -304,8 +308,9 @@ describe("has and hasMany", () => {
 	test("has returns false and deletes an expired key", async () => {
 		const keyv = store();
 		const key = faker.string.uuid();
-		const expiredValue = JSON.stringify({ value: "old", expires: Date.now() - 1000 });
-		await keyv.set(key, expiredValue);
+		const pastExpires = Date.now() - 1000;
+		const expiredValue = JSON.stringify({ value: "old", expires: pastExpires });
+		await keyv.set(key, expiredValue, pastExpires);
 		expect(await keyv.has(key)).toBe(false);
 		// The expired key should have been deleted.
 		expect(await keyv.get(key)).toBeUndefined();
@@ -316,11 +321,13 @@ describe("has and hasMany", () => {
 		const expiredKey1 = faker.string.uuid();
 		const expiredKey2 = faker.string.uuid();
 		const validKey = faker.string.uuid();
-		const expiredValue = JSON.stringify({ value: "old", expires: Date.now() - 1000 });
-		const validValue = JSON.stringify({ value: "fresh", expires: Date.now() + 60_000 });
-		await keyv.set(expiredKey1, expiredValue);
-		await keyv.set(expiredKey2, expiredValue);
-		await keyv.set(validKey, validValue);
+		const pastExpires = Date.now() - 1000;
+		const futureExpires = Date.now() + 60_000;
+		const expiredValue = JSON.stringify({ value: "old", expires: pastExpires });
+		const validValue = JSON.stringify({ value: "fresh", expires: futureExpires });
+		await keyv.set(expiredKey1, expiredValue, pastExpires);
+		await keyv.set(expiredKey2, expiredValue, pastExpires);
+		await keyv.set(validKey, validValue, futureExpires);
 		const result = await keyv.hasMany([expiredKey1, expiredKey2, validKey]);
 		expect(result).toStrictEqual([false, false, true]);
 		// The expired keys should have been deleted.
@@ -366,11 +373,12 @@ describe("delete and deleteMany", () => {
 describe("clearExpired", () => {
 	test("removes expired entries and keeps valid ones", async () => {
 		const keyv = store();
-		const expiredValue = JSON.stringify({ value: "old", expires: Date.now() - 1000 });
+		const pastExpires = Date.now() - 1000;
+		const expiredValue = JSON.stringify({ value: "old", expires: pastExpires });
 		const validValue = JSON.stringify({ value: "current", expires: null });
 		const expiredKey = faker.string.uuid();
 		const validKey = faker.string.uuid();
-		await keyv.set(expiredKey, expiredValue);
+		await keyv.set(expiredKey, expiredValue, pastExpires);
 		await keyv.set(validKey, validValue);
 		// has() already filters expired entries.
 		expect(await keyv.has(expiredKey)).toBe(false);
@@ -380,13 +388,37 @@ describe("clearExpired", () => {
 		expect(await keyv.has(validKey)).toBe(true);
 	});
 
-	test("handles object values with an expires field without serialization", async () => {
+	test("stores non-string object values with an explicit expires", async () => {
 		const keyv = store();
-		const objValue = { value: faker.lorem.word(), expires: Date.now() + 60_000 };
+		const futureExpires = Date.now() + 60_000;
+		const objValue = { value: faker.lorem.word(), expires: futureExpires };
 		const objKey = faker.string.uuid();
 		// biome-ignore lint/suspicious/noExplicitAny: testing the non-string value path
-		await keyv.set(objKey, objValue as any);
+		await keyv.set(objKey, objValue as any, futureExpires);
 		expect(await keyv.has(objKey)).toBe(true);
+	});
+
+	// Regression: before v6 the adapter recovered `expires` by JSON.parsing the stored
+	// value, which silently failed for compressed/encrypted/msgpackr/superjson output and
+	// left the expires column NULL. The contract now passes expires directly.
+	test("populates the expires column for non-JSON encoded values so expiry still works", async () => {
+		const store = new KeyvSqlite({ uri: sqliteUri, busyTimeout: 3000 });
+		const serialization = {
+			stringify: (data: unknown) => `RAW:${JSON.stringify(data)}`,
+			parse: <T>(data: string): T => JSON.parse(String(data).slice(4)) as T,
+		};
+		const keyv = new Keyv({ store, serialization });
+		const key = faker.string.uuid();
+		await keyv.set(key, "value", 100);
+		expect(await keyv.get(key)).toBe("value");
+		await new Promise((resolve) => {
+			setTimeout(resolve, 200);
+		});
+		// checkExpired defaults to false, so expiry is driven by the store's expires column.
+		expect(await keyv.get(key)).toBeUndefined();
+		await store.clearExpired();
+		expect(await store.has(key)).toBe(false);
+		await keyv.disconnect();
 	});
 });
 
@@ -398,9 +430,10 @@ describe("clearExpiredInterval", () => {
 			clearExpiredInterval: 100,
 		});
 		await keyv.clear();
-		const expiredValue = JSON.stringify({ value: "old", expires: Date.now() - 1000 });
+		const pastExpires = Date.now() - 1000;
+		const expiredValue = JSON.stringify({ value: "old", expires: pastExpires });
 		const autoExpiredKey = faker.string.uuid();
-		await keyv.set(autoExpiredKey, expiredValue);
+		await keyv.set(autoExpiredKey, expiredValue, pastExpires);
 		// has() already filters expired entries.
 		expect(await keyv.has(autoExpiredKey)).toBe(false);
 		// Wait for the cleanup timer to fire (which deletes the row entirely).
@@ -719,8 +752,9 @@ describe("schema migration", () => {
 		const keyv = new KeyvSqlite({ uri: `sqlite://${dbPath}`, busyTimeout: 3000 });
 		expect(await keyv.get("k1")).toBe("v1");
 		// Expires-related features should work.
-		const expiredValue = JSON.stringify({ value: "temp", expires: Date.now() - 1000 });
-		await keyv.set("expiring", expiredValue);
+		const pastExpires = Date.now() - 1000;
+		const expiredValue = JSON.stringify({ value: "temp", expires: pastExpires });
+		await keyv.set("expiring", expiredValue, pastExpires);
 		await keyv.clearExpired();
 		expect(await keyv.has("expiring")).toBe(false);
 		await keyv.disconnect();

--- a/storage/valkey/README.md
+++ b/storage/valkey/README.md
@@ -36,6 +36,7 @@ We are using the [iovalkey](https://www.npmjs.com/package/iovalkey) which is a N
   - [.clear()](#clear)
   - [.iterator()](#iterator)
   - [.disconnect()](#disconnect)
+- [Expiration and TTL](#expiration-and-ttl)
 - [Clustering](#clustering)
 - [License](#license)
 
@@ -309,6 +310,12 @@ Disconnects from the Valkey server.
 ```js
 await store.disconnect();
 ```
+
+## Expiration and TTL
+
+Keyv hands this adapter an **absolute** expiry — a Unix timestamp in milliseconds — computed once on the Keyv host. The adapter writes it with `SET ... PXAT`, the absolute-expiry option, so the deadline is immune to clock skew and to any latency between Keyv computing the expiry and Valkey receiving the command. The same applies to `setMany`, including the per-hash-slot grouping used in cluster mode.
+
+Unlike the [Redis adapter](https://github.com/jaredwray/keyv/tree/main/storage/redis#expiration-and-ttl), there is **no relative `PX` fallback** and none is needed: `PXAT` was added in Redis 6.2, and every Valkey release is forked from Redis 7.2+, so absolute expiry is always available. You always call `keyv.set(key, value, ttl)` with a relative millisecond `ttl` (or rely on the `ttl` option); the adapter converts it to the absolute `PXAT` deadline for you.
 
 ## Clustering
 

--- a/storage/valkey/README.md
+++ b/storage/valkey/README.md
@@ -27,7 +27,7 @@ We are using the [iovalkey](https://www.npmjs.com/package/iovalkey) which is a N
 - [Methods](#methods)
   - [.get(key)](#getkey)
   - [.getMany(keys)](#getmanykeys)
-  - [.set(key, value, ttl?)](#setkey-value-ttl)
+  - [.set(key, value, expires?)](#setkey-value-expires)
   - [.setMany(entries)](#setmanyentries)
   - [.delete(key)](#deletekey)
   - [.deleteMany(keys)](#deletemanykeys)
@@ -232,23 +232,23 @@ Returns an array of values for the given keys. Returns `undefined` for any key t
 const values = await store.getMany(['foo', 'bar']);
 ```
 
-### .set(key, value, ttl?)
+### .set(key, value, expires?)
 
-Sets a value for the given key with an optional TTL in milliseconds.
+Sets a value for the given key with an optional absolute `expires` (Unix ms since epoch). The adapter writes it via `PXAT`. Through Keyv (`keyv.set(key, value, ttl)`) you still pass a relative TTL in milliseconds — Keyv converts it to `expires` for you.
 
 ```js
 await store.set('foo', 'bar');
-await store.set('foo', 'bar', 5000); // expires in 5 seconds
+await store.set('foo', 'bar', Date.now() + 5000); // expires in ~5 seconds
 ```
 
 ### .setMany(entries)
 
-Sets multiple key-value pairs in a single batch operation using `MULTI/EXEC` transactions. Each entry is a `KeyvEntry<Value>` object (`{ key: string, value: Value, ttl?: number }`), where `Value` is inferred from the entries provided. Entries with `undefined` values are skipped. Returns a `boolean[]` with per-entry success tracking by inspecting each command's result. In cluster mode, entries are grouped by hash slot with results mapped back to the original order.
+Sets multiple key-value pairs in a single batch operation using `MULTI/EXEC` transactions. Each entry is a `KeyvStorageEntry<Value>` object (`{ key: string, value: Value, expires?: number }`) where `expires` is an absolute Unix ms timestamp, and `Value` is inferred from the entries provided. Entries with `undefined` values are skipped. Returns a `boolean[]` with per-entry success tracking by inspecting each command's result. In cluster mode, entries are grouped by hash slot with results mapped back to the original order.
 
 ```js
 const results = await store.setMany([
   { key: 'foo', value: 'bar' },
-  { key: 'baz', value: 'qux', ttl: 5000 },
+  { key: 'baz', value: 'qux', expires: Date.now() + 5000 },
 ]); // [true, true]
 ```
 

--- a/storage/valkey/src/index.ts
+++ b/storage/valkey/src/index.ts
@@ -1,7 +1,12 @@
 import calculateSlot from "cluster-key-slot";
 import { Hookified } from "hookified";
 import Redis, { type Cluster } from "iovalkey";
-import Keyv, { type KeyvEntry, type KeyvStorageAdapter, type KeyvStorageGetResult } from "keyv";
+import Keyv, {
+	type KeyvStorageAdapter,
+	type KeyvStorageEntry,
+	type KeyvStorageGetResult,
+	keyvStorageCapability,
+} from "keyv";
 import type { KeyvUriOptions, KeyvValkeyOptions } from "./types.js";
 
 /**
@@ -10,6 +15,11 @@ import type { KeyvUriOptions, KeyvValkeyOptions } from "./types.js";
  * interface with support for namespacing, TTL, batch operations, and async iteration.
  */
 class KeyvValkey extends Hookified implements KeyvStorageAdapter {
+	/** Declares the v6 absolute-`expires` storage contract via `capabilities.expires`. */
+	public get capabilities() {
+		return keyvStorageCapability(this);
+	}
+
 	/**
 	 * The namespace used to prefix keys for multi-tenant separation.
 	 * When set, all keys are scoped under this namespace to prevent collisions
@@ -233,19 +243,19 @@ class KeyvValkey extends Hookified implements KeyvStorageAdapter {
 	}
 
 	/**
-	 * Stores a key-value pair in the Valkey store with an optional TTL (time-to-live).
+	 * Stores a key-value pair in the Valkey store with an optional absolute expiry.
 	 * If the value is `undefined`, the operation is skipped and returns `false`.
 	 * When `useSets` is enabled, the key is also added to the namespace tracking set
 	 * within an atomic transaction.
 	 * @param {string} key - The key under which to store the value.
 	 * @param {any} value - The value to store. If `undefined`, the operation is a no-op.
-	 * @param {number} [ttl] - Optional time-to-live in milliseconds. When provided, the key
-	 *   will automatically expire after this duration.
+	 * @param {number} [expires] - Absolute expiry as Unix ms since epoch, or `undefined` for no expiry.
+	 *   When provided, the key is set to expire at that timestamp via `PXAT`.
 	 * @returns {Promise<boolean>} `true` if the value was stored, `false` if the value was
 	 *   `undefined` or an error occurred while storing.
 	 */
 	// biome-ignore lint/suspicious/noExplicitAny: type format
-	public async set(key: string, value: any, ttl?: number): Promise<boolean> {
+	public async set(key: string, value: any, expires?: number): Promise<boolean> {
 		if (value === undefined) {
 			return false;
 		}
@@ -255,8 +265,8 @@ class KeyvValkey extends Hookified implements KeyvStorageAdapter {
 
 			// biome-ignore lint/suspicious/noExplicitAny: type format
 			const set = async (redis: any) => {
-				if (typeof ttl === "number") {
-					await redis.set(key, value, "PX", ttl);
+				if (typeof expires === "number") {
+					await redis.set(key, value, "PXAT", expires);
 				} else {
 					await redis.set(key, value);
 				}
@@ -287,13 +297,13 @@ class KeyvValkey extends Hookified implements KeyvStorageAdapter {
 	 * CROSSSLOT errors. When `useSets` is enabled, each key is also added to the namespace
 	 * tracking set within the same transaction.
 	 * @template Value - The type of the stored values.
-	 * @param {KeyvEntry<Value>[]} entries - An array of `{ key, value, ttl? }` entries where
-	 *   `ttl` is an optional time-to-live in milliseconds.
+	 * @param {KeyvStorageEntry<Value>[]} entries - An array of `{ key, value, expires? }` entries where
+	 *   `expires` is an optional absolute expiry as Unix ms since epoch.
 	 * @returns {Promise<boolean[] | undefined>} An array of booleans in the same order as the
 	 *   input entries. Each element is `true` if the corresponding entry was stored (entries with
 	 *   `undefined` values are reported as `true`), or `false` if it failed.
 	 */
-	public async setMany<Value>(entries: KeyvEntry<Value>[]): Promise<boolean[] | undefined> {
+	public async setMany<Value>(entries: KeyvStorageEntry<Value>[]): Promise<boolean[] | undefined> {
 		if (entries.length === 0) {
 			return entries.map(() => true);
 		}
@@ -304,11 +314,11 @@ class KeyvValkey extends Hookified implements KeyvStorageAdapter {
 			k: string;
 			// biome-ignore lint/suspicious/noExplicitAny: type format
 			value: any;
-			ttl?: number;
+			expires?: number;
 			originalIndex: number;
 		}> = [];
 		for (let i = 0; i < entries.length; i++) {
-			const { key, value, ttl } = entries[i];
+			const { key, value, expires } = entries[i];
 			if (value === undefined) {
 				results[i] = true;
 				continue;
@@ -317,7 +327,7 @@ class KeyvValkey extends Hookified implements KeyvStorageAdapter {
 			resolvedEntries.push({
 				k: this.getKeyName(key),
 				value,
-				ttl,
+				expires,
 				originalIndex: i,
 			});
 		}
@@ -342,9 +352,9 @@ class KeyvValkey extends Hookified implements KeyvStorageAdapter {
 			await Promise.all(
 				Array.from(slotMap.values(), async (group) => {
 					const trx = this._client.multi();
-					for (const { k, value, ttl } of group) {
-						if (typeof ttl === "number") {
-							trx.set(k, value, "PX", ttl);
+					for (const { k, value, expires } of group) {
+						if (typeof expires === "number") {
+							trx.set(k, value, "PXAT", expires);
 						} else {
 							trx.set(k, value);
 						}

--- a/storage/valkey/test/set.test.ts
+++ b/storage/valkey/test/set.test.ts
@@ -24,11 +24,11 @@ describe("set", () => {
 		await keyv.disconnect();
 	});
 
-	test("should expire a value after its ttl", async () => {
+	test("should expire a value after its expiry", async () => {
 		const keyv = new KeyvValkey(valkeyUri);
 		const key = faker.string.alphanumeric(10);
 		const value = faker.string.alphanumeric(10);
-		await keyv.set(key, value, 100);
+		await keyv.set(key, value, Date.now() + 100);
 		expect(await keyv.get(key)).toBe(value);
 		await delay(200);
 		expect(await keyv.get(key)).toBe(undefined);
@@ -63,11 +63,11 @@ describe("setMany", () => {
 		await keyv.disconnect();
 	});
 
-	test("should expire values with a ttl", async () => {
+	test("should expire values with an expiry", async () => {
 		const keyv = new KeyvValkey(valkeyUri);
 		const key = faker.string.alphanumeric(10);
 		const value = faker.string.alphanumeric(10);
-		await keyv.setMany([{ key, value, ttl: 100 }]);
+		await keyv.setMany([{ key, value, expires: Date.now() + 100 }]);
 		expect(await keyv.get(key)).toBe(value);
 		await delay(200);
 		expect(await keyv.get(key)).toBe(undefined);

--- a/website/site/docs/v5-to-v6.md
+++ b/website/site/docs/v5-to-v6.md
@@ -23,6 +23,7 @@ We are pleased to announce Keyv v6 with major enhancements and some breaking cha
   - [`get` and `getMany` No Longer Support Raw](#get-and-getmany-no-longer-support-raw)
   - [Iterator Changes](#iterator-changes)
   - [Removed `.ttlSupport` from Storage Adapters](#removed-ttlsupport-from-storage-adapters)
+  - [Storage Adapters Receive Absolute `expires` Instead of Relative `ttl`](#storage-adapters-receive-absolute-expires-instead-of-relative-ttl)
   - [Returns `undefined` Instead of `null`](#returns-undefined-instead-of-null)
   - [Compression Adapter Interface Change](#compression-adapter-interface-change)
   - [`@keyv/memcache` Moves from `memjs` to `memcache`](#keyvmemcache-moves-from-memjs-to-memcache)
@@ -67,6 +68,7 @@ We are pleased to announce Keyv v6 with major enhancements and some breaking cha
 | Update `@keyv/postgres`  | COMPLETE |
 | Update `@keyv/redis`  | COMPLETE |
 | Add GitHub Actions release workflow | COMPLETE |
+| Storage adapters receive absolute `expires` instead of relative `ttl` | COMPLETE |
 
 ---
 
@@ -425,6 +427,64 @@ class MyAdapter {
   // ...
 }
 ```
+
+---
+
+### Storage Adapters Receive Absolute `expires` Instead of Relative `ttl`
+
+> **Most users do not need to do anything.** The public Keyv API is unchanged — you still call `keyv.set(key, value, ttl)` with a **relative** TTL in milliseconds, and `KeyvOptions.ttl` is still relative. This change only affects authors of **custom or third-party storage adapters**.
+
+In v5, Keyv passed each storage adapter a **relative** `ttl` (milliseconds from now) on `set`/`setMany`, and adapters re-derived the absolute deadline themselves. Some adapters even recovered the expiry by parsing the already-encoded value (`JSON.parse`), which **silently failed** under compression, encryption, or a non-JSON serializer (`@keyv/serialize-msgpackr`, `@keyv/serialize-superjson`) — leaving the expiry unset so the entry never expired.
+
+In v6, Keyv computes the **absolute** expiry once and passes it across the storage boundary as `expires` (a Unix timestamp in milliseconds). Adapters store it directly and never parse the value to recover it.
+
+**The v6 storage-adapter contract:**
+
+- **`set(key, value, expires?)`** — `expires` is an absolute Unix timestamp in milliseconds. `undefined` means no expiry; a value `<= Date.now()` is already expired.
+- **`setMany(entries)`** — each entry is a `KeyvStorageEntry` (`{ key, value, expires? }`) rather than the public `KeyvEntry` (`{ key, value, ttl? }`).
+- **Declare support** by exposing `capabilities.expires === true`. The `keyvStorageCapability(this)` helper builds the full capability descriptor for you.
+
+**v5 (before):**
+```typescript
+class MyAdapter {
+  // ttl is relative milliseconds, or undefined
+  async set(key: string, value: string, ttl?: number) {
+    const expires = typeof ttl === 'number' ? Date.now() + ttl : undefined;
+    // ...persist value with expires...
+  }
+
+  async setMany(entries: Array<{ key: string; value: string; ttl?: number }>) {
+    // ...derive expires from each ttl...
+  }
+}
+```
+
+**v6 (after):**
+```typescript
+import { keyvStorageCapability, type KeyvStorageAdapter, type KeyvStorageEntry } from 'keyv';
+
+class MyAdapter implements KeyvStorageAdapter {
+  // Advertise the v6 absolute-expires contract.
+  get capabilities() {
+    return keyvStorageCapability(this);
+  }
+
+  // expires is an absolute Unix ms timestamp, or undefined
+  async set(key: string, value: string, expires?: number) {
+    // ...persist value with expires directly — no Date.now() math, no parsing...
+  }
+
+  async setMany(entries: KeyvStorageEntry[]) {
+    // each entry already carries an absolute `expires`
+  }
+}
+```
+
+**Backward compatibility — legacy adapters keep working.** If an adapter does **not** advertise `capabilities.expires`, Keyv treats it as a v5-style adapter and automatically wraps it in `KeyvBridgeAdapter`, which converts the absolute `expires` back to a relative `ttl` before delegating to your `set`/`setMany`. So existing third-party adapters continue to function without code changes. Upgrading to the v6 contract is still recommended: it removes the bridge conversion and eliminates the silent-expiry bug described above.
+
+**Adapters are the expiry authority.** Keyv core does not filter expired reads by default (`checkExpired` defaults to `false`). A v6 adapter must enforce expiry itself — via a native server-side mechanism (e.g. Redis `PXAT`, a SQL `expires` column swept on read, a Mongo TTL index) and/or a client-side check on `get`. Where a backend's expiry is coarser than milliseconds (e.g. Memcached's second-granular `exptime`), document the window and let users opt into `checkExpired: true` for millisecond-precise reads.
+
+> **Why this is better:** the absolute `expires` is computed once on the Keyv host, so it is immune to clock skew and to latency between Keyv and the store; adapters never re-parse encoded values; and the silent-expiry bug under compression/encryption/alternate serializers is gone. See the per-adapter "Expiration and TTL" notes (for example, [`@keyv/redis`](https://github.com/jaredwray/keyv/tree/main/storage/redis#expiration-and-ttl)) for backend-specific details.
 
 ---
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
keyv (breaking) - storage adapters now only use expires instead of ttl