### PR TITLE
release: v6.0.0-beta.4

### DIFF
--- a/compression/compress-brotli/package.json
+++ b/compression/compress-brotli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keyv/compress-brotli",
-	"version": "6.0.0-beta.3",
+	"version": "6.0.0-beta.4",
 	"description": "brotli compression for keyv",
 	"type": "module",
 	"main": "./dist/index.mjs",

--- a/compression/compress-gzip/package.json
+++ b/compression/compress-gzip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keyv/compress-gzip",
-  "version": "6.0.0-beta.3",
+  "version": "6.0.0-beta.4",
   "description": "gzip compression for keyv",
   "type": "module",
   "main": "./dist/index.mjs",

--- a/compression/compress-lz4/package.json
+++ b/compression/compress-lz4/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keyv/compress-lz4",
-	"version": "6.0.0-beta.3",
+	"version": "6.0.0-beta.4",
 	"description": "lz4 compression for Keyv",
 	"type": "module",
 	"main": "./dist/index.mjs",

--- a/core/bigmap/package.json
+++ b/core/bigmap/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keyv/bigmap",
-	"version": "6.0.0-beta.3",
+	"version": "6.0.0-beta.4",
 	"description": "Bigmap for Keyv",
 	"type": "module",
 	"main": "./dist/index.mjs",

--- a/core/keyv/package.json
+++ b/core/keyv/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "keyv",
-	"version": "6.0.0-beta.3",
+	"version": "6.0.0-beta.4",
 	"description": "Simple key-value storage with support for multiple backends",
 	"type": "module",
 	"main": "./dist/index.mjs",

--- a/core/test-suite/package.json
+++ b/core/test-suite/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keyv/test-suite",
-	"version": "6.0.0-beta.3",
+	"version": "6.0.0-beta.4",
 	"description": "Test suite for Keyv API compliancy",
 	"type": "module",
 	"main": "./dist/index.mjs",

--- a/encryption/encrypt-node/package.json
+++ b/encryption/encrypt-node/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keyv/encrypt-node",
-	"version": "6.0.0-beta.3",
+	"version": "6.0.0-beta.4",
 	"description": "Node.js crypto encryption adapter for Keyv",
 	"type": "module",
 	"main": "./dist/index.mjs",

--- a/encryption/encrypt-web/package.json
+++ b/encryption/encrypt-web/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keyv/encrypt-web",
-	"version": "6.0.0-beta.3",
+	"version": "6.0.0-beta.4",
 	"description": "Web Crypto API encryption adapter for Keyv",
 	"type": "module",
 	"main": "./dist/index.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keyv/mono-repo",
-  "version": "6.0.0-beta.3",
+  "version": "6.0.0-beta.4",
   "type": "module",
   "description": "Keyv Mono Repo",
   "repository": "https://github.com/jaredwray/keyv.git",

--- a/serialization/msgpackr/package.json
+++ b/serialization/msgpackr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keyv/serialize-msgpackr",
-  "version": "6.0.0-beta.3",
+  "version": "6.0.0-beta.4",
   "description": "MessagePack serialization adapter for Keyv using msgpackr",
   "type": "module",
   "main": "./dist/index.mjs",

--- a/serialization/superjson/package.json
+++ b/serialization/superjson/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keyv/serialize-superjson",
-  "version": "6.0.0-beta.3",
+  "version": "6.0.0-beta.4",
   "description": "SuperJSON serialization adapter for Keyv",
   "type": "module",
   "main": "./dist/index.mjs",

--- a/storage/dynamo/package.json
+++ b/storage/dynamo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keyv/dynamo",
-  "version": "6.0.0-beta.3",
+  "version": "6.0.0-beta.4",
   "description": "DynamoDB storage adapter for Keyv",
   "type": "module",
   "main": "./dist/index.mjs",

--- a/storage/etcd/package.json
+++ b/storage/etcd/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keyv/etcd",
-	"version": "6.0.0-beta.3",
+	"version": "6.0.0-beta.4",
 	"description": "Etcd storage adapter for Keyv",
 	"type": "module",
 	"main": "./dist/index.mjs",

--- a/storage/memcache/package.json
+++ b/storage/memcache/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keyv/memcache",
-	"version": "6.0.0-beta.3",
+	"version": "6.0.0-beta.4",
 	"description": "Memcache storage adapter for Keyv",
 	"type": "module",
 	"main": "./dist/index.mjs",

--- a/storage/mongo/package.json
+++ b/storage/mongo/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keyv/mongo",
-	"version": "6.0.0-beta.3",
+	"version": "6.0.0-beta.4",
 	"description": "MongoDB storage adapter for Keyv",
 	"type": "module",
 	"main": "./dist/index.mjs",

--- a/storage/mysql/package.json
+++ b/storage/mysql/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keyv/mysql",
-	"version": "6.0.0-beta.3",
+	"version": "6.0.0-beta.4",
 	"description": "MySQL/MariaDB storage adapter for Keyv",
 	"type": "module",
 	"main": "./dist/index.mjs",

--- a/storage/postgres/package.json
+++ b/storage/postgres/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keyv/postgres",
-	"version": "6.0.0-beta.3",
+	"version": "6.0.0-beta.4",
 	"description": "PostgreSQL storage adapter for Keyv",
 	"type": "module",
 	"main": "./dist/index.mjs",

--- a/storage/redis/package.json
+++ b/storage/redis/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keyv/redis",
-	"version": "6.0.0-beta.3",
+	"version": "6.0.0-beta.4",
 	"description": "Redis storage adapter for Keyv",
 	"type": "module",
 	"main": "./dist/index.mjs",

--- a/storage/sqlite/package.json
+++ b/storage/sqlite/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keyv/sqlite",
-	"version": "6.0.0-beta.3",
+	"version": "6.0.0-beta.4",
 	"description": "SQLite storage adapter for Keyv",
 	"type": "module",
 	"main": "./dist/index.mjs",

--- a/storage/valkey/package.json
+++ b/storage/valkey/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keyv/valkey",
-	"version": "6.0.0-beta.3",
+	"version": "6.0.0-beta.4",
 	"description": "Valkey storage adapter for Keyv",
 	"type": "module",
 	"main": "./dist/index.mjs",

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keyv/website",
-  "version": "6.0.0-beta.3",
+  "version": "6.0.0-beta.4",
   "description": "Keyv Website",
   "repository": "https://github.com/jaredwray/keyv.git",
   "author": "Jared Wray <me@jaredwray.com>",


### PR DESCRIPTION
## Release summary
Fixed-version cut bumping all 20 published Keyv packages from `6.0.0-beta.3` to `6.0.0-beta.4`. Version-only change — no source modifications. Finalizes the v6 storage-adapter API (`ttl` → `expires`) and completes the cross-adapter code/test review.

## Packages
This is a fixed-version monorepo (`scripts/version-sync.ts` keeps every package at the root version), so all 20 published packages release together at `6.0.0-beta.4`.

| Scope | Current | New | Bump | Rationale | Commits |
|---|---|---|---|---|---|
| **Keyv monorepo** — all 20 published packages | `6.0.0-beta.3` | `6.0.0-beta.4` | **pre-release** | 1 breaking, 1 feat, 4 fix, rest review/docs | 18 |

<details><summary>Per-area audit (what got touched since <code>v6.0.0-beta.3</code>)</summary>

| Package area | Commits | PRs |
|---|---|---|
| `keyv` (core) | 3 | #1981 (breaking), #1979 (docs), #1963 (badge) |
| `@keyv/etcd` | 3 | #1964, #1966, #1972 |
| `@keyv/dynamo` | 2 | #1965, #1970 |
| `@keyv/mongo` | 2 | #1968, #1976 (+ #1980 folded into #1976) |
| `@keyv/memcache` | 2 | #1967, #1973 |
| `@keyv/bigmap` | 1 | #1977 (feat) |
| `@keyv/mysql` | 1 | #1969 |
| `@keyv/postgres` | 1 | #1971 |
| `@keyv/redis` | 1 | #1974 |
| `@keyv/sqlite` | 1 | #1975 |
| `@keyv/valkey` | 1 | #1978 |
| compress-\*, encrypt-\*, serialize-\*, test-suite | 0 | no changes — republished at the locked version |
| `@keyv/website` | 0 | private — not published |

</details>

---

## Keyv v6.0.0-beta.4 — 2026-06-18

Finalize the v6 storage-adapter API (ttl → expires) and complete the cross-adapter code/test review.

### ⚠ BREAKING CHANGES
- Storage adapters now use `expires` (absolute epoch-ms timestamp) instead of a relative `ttl`. (da9c08f, #1981)
  Migration: if you call a storage adapter directly or implement a custom one, read the absolute `expires` value from the entry envelope instead of accepting a `ttl` argument. The `Keyv` core API is unchanged — it continues to derive `expires` from the value envelope, so typical `keyv.set(key, value, ttl)` usage is unaffected.

### Features
- **bigmap:** wire up Hookified events — `BigMap` now emits `SET`, `DELETE`, and `CLEAR` via the new `BigMapEvents` enum. (b88d03f, #1977)

  ```ts
  import { BigMap, BigMapEvents } from '@keyv/bigmap';

  const map = new BigMap<string>();
  map.on(BigMapEvents.SET, (key, value) => console.log('set', key, value));
  map.on(BigMapEvents.DELETE, (key) => console.log('deleted', key));

  map.set('a', '1');  // → "set a 1"
  map.delete('a');    // → "deleted a"
  ```

  Also renames the exported `MapInterfacee` type to `MapInterface` (typo fix — safe within the v6 beta).

### Bug Fixes
- **etcd:** support the grpc-gateway v2 error format for etcd 3.6 compatibility. (dcb64bd, #1964)
- **dynamo:** strip the namespace prefix in the iterator and align tests/docs. (75198aa, #1965)
- **etcd:** return `undefined` for missing values and align tests/docs. (1e84580, #1966)
- **mysql:** return `undefined` instead of `null`, guard `getMany`, and align tests/docs. (d76926b, #1969)

### Documentation
- **keyv:** fix README API accuracy and strengthen the code/test review. (685bc77, #1979)
- **keyv:** add a jsDelivr badge to the README. (418ce7a, #1963)

### Internal
- **dynamo:** code clean up and minor fixes. (9048a87, #1970)
- **etcd:** code clean up and documentation. (aed5638, #1972)
- **postgres:** code/test review for `@keyv/postgres`. (9fa6847, #1971)
- **redis:** full code and test review cleanup. (480a560, #1974)
- **memcache:** add an error handler. (394e254, #1973)
- **memcache:** uniform test suite, fix namespace docs, validate API. (95612fc, #1967)
- **mongo:** uniform test suite, fix README API docs. (0240400, #1968)
- **mongo:** documentation and fixes (includes #1980 review follow-ups). (f31850d, #1976)
- **sqlite:** full code and test review cleanup. (8539cfd, #1975)
- **valkey:** full code and test review. (e8a3ffa, #1978)

### Contributors
- @jaredwray (18)

### Full List of Changes
- feat: adding in jsDelivr badge for Keyv by @jaredwray in #1963
- etcd - fix: support grpc-gateway v2 error format for etcd 3.6 compatibility by @jaredwray in #1964
- dynamo - fix: strip namespace prefix in iterator and align tests/docs by @jaredwray in #1965
- etcd - fix: return undefined for missing values and align tests/docs by @jaredwray in #1966
- memcache - test: uniform test suite, fix namespace docs, validate API by @jaredwray in #1967
- mongo - test: uniform test suite, fix README API docs by @jaredwray in #1968
- mysql - fix: return undefined not null, guard getMany, and align tests/docs by @jaredwray in #1969
- dynamo - chore: code clean up and minor fixes by @jaredwray in #1970
- etcd - chore: code clean up and documentation by @jaredwray in #1972
- postgres - refactor: code/test review for @keyv/postgres by @jaredwray in #1971
- redis - chore: full code and test review cleanup by @jaredwray in #1974
- memcache - chore: adding in error handler by @jaredwray in #1973
- sqlite - refactor: full code and test review cleanup by @jaredwray in #1975
- keyv - docs: fix README API accuracy and strengthen code/test review by @jaredwray in #1979
- valkey - refactor: full code and test review by @jaredwray in #1978
- bigmap - feat: wire up hookified events and complete code/test review by @jaredwray in #1977
- mongo - chore: documentation and fixes by @jaredwray in #1976
- keyv (breaking) - storage adapters now only use expires instead of ttl by @jaredwray in #1981

**Full diff:** https://github.com/jaredwray/keyv/compare/v6.0.0-beta.3...v6.0.0-beta.4

---

## Verification
- [x] `pnpm install --frozen-lockfile` succeeds
- [x] `pnpm build` succeeds — all 19 code packages emit `dist` artifacts
- [x] Service-free packages pass `pnpm test` locally — `keyv` (325 + 4 todo), `test-suite` (93), `sqlite` (149), `bigmap` (54), `encrypt-node` (22), `encrypt-web` (20), `serialize-superjson` (23), `serialize-msgpackr` (22), `compress-gzip` (9), `compress-lz4` (8), `compress-brotli`
- [ ] Service-backed adapters (redis, mongo, mysql, postgres, etcd, memcache, valkey, dynamo) need Docker — **validated by this PR's CI**, not locally
- [x] No changes outside the version bump — 21 manifests, lockfile unchanged

## Post-merge
Merge, then create a GitHub Release at tag `v6.0.0-beta.4` — the `release.yaml` workflow publishes every package to npm under the `beta` dist-tag via OIDC trusted publishing. (`LATEST_MAJOR=5` keeps v5 on the `latest` tag.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C5entroufkbxrgPMpkUd3S

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5entroufkbxrgPMpkUd3S)_