### PR TITLE
mono - chore: upgrade js-yaml to v5 (breaking)

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,10 +30,9 @@
   "devDependencies": {
     "@biomejs/biome": "^2.5.1",
     "@faker-js/faker": "^10.5.0",
-    "@types/js-yaml": "^4.0.9",
     "@types/node": "^24.13.1",
     "@vitest/coverage-v8": "^4.1.9",
-    "js-yaml": "^4.2.0",
+    "js-yaml": "^5.2.0",
     "rimraf": "^6.1.3",
     "tsd": "^0.33.0",
     "tsdown": "^0.22.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       '@faker-js/faker':
         specifier: ^10.5.0
         version: 10.5.0
-      '@types/js-yaml':
-        specifier: ^4.0.9
-        version: 4.0.9
       '@types/node':
         specifier: ^24.13.1
         version: 24.13.1
@@ -27,8 +24,8 @@ importers:
         specifier: ^4.1.9
         version: 4.1.9(vitest@4.1.9)
       js-yaml:
-        specifier: ^4.2.0
-        version: 4.2.0
+        specifier: ^5.2.0
+        version: 5.2.0
       rimraf:
         specifier: ^6.1.3
         version: 6.1.3
@@ -1588,12 +1585,6 @@ packages:
   '@napi-rs/triples@1.2.0':
     resolution: {integrity: sha512-HAPjR3bnCsdXBsATpDIP5WCrw0JcACwhhrwIAQhiR46n+jm+a2F8kBsfseAuWtSyQ+H3Yebt2k43B5dy+04yMA==}
 
-  '@napi-rs/wasm-runtime@1.1.4':
-    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
-    peerDependencies:
-      '@emnapi/core': ^1.7.1
-      '@emnapi/runtime': ^1.7.1
-
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
     peerDependencies:
@@ -2071,9 +2062,6 @@ packages:
     resolution: {integrity: sha512-mSMM0QtEPdMd+rdMDd17yCUYD4yI3pKHap89+jEZrZ3KIO5PhDofBjER0OtgHdvOXF74KMLO3fyD6k3Hz0v03A==}
     engines: {node: '>=14.17'}
 
-  '@tybys/wasm-util@0.10.1':
-    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
-
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
@@ -2103,9 +2091,6 @@ packages:
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
-
-  '@types/js-yaml@4.0.9':
-    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
 
   '@types/jsesc@2.5.1':
     resolution: {integrity: sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==}
@@ -3141,6 +3126,10 @@ packages:
 
   js-yaml@4.2.0:
     resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+    hasBin: true
+
+  js-yaml@5.2.0:
+    resolution: {integrity: sha512-YeLUMlvR4Ou1B119LIaM0r65JvbOBooJDc9yEu0dClb/uSC5P4FrLU8OCCz/HXWvtPoIrR0dRzABTjo1sTN9Bw==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -5361,13 +5350,6 @@ snapshots:
 
   '@napi-rs/triples@1.2.0': {}
 
-  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
-    dependencies:
-      '@emnapi/core': 1.11.1
-      '@emnapi/runtime': 1.11.1
-      '@tybys/wasm-util': 0.10.1
-    optional: true
-
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
       '@emnapi/core': 1.11.1
@@ -5508,7 +5490,7 @@ snapshots:
 
   '@rolldown/binding-wasm32-wasi@1.0.0-rc.12(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -5685,11 +5667,6 @@ snapshots:
 
   '@tsd/typescript@5.9.2': {}
 
-  '@tybys/wasm-util@0.10.1':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
   '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
@@ -5728,8 +5705,6 @@ snapshots:
   '@types/hast@3.0.4':
     dependencies:
       '@types/unist': 3.0.3
-
-  '@types/js-yaml@4.0.9': {}
 
   '@types/jsesc@2.5.1': {}
 
@@ -6812,6 +6787,10 @@ snapshots:
   js-tokens@4.0.0: {}
 
   js-yaml@4.2.0:
+    dependencies:
+      argparse: 2.0.1
+
+  js-yaml@5.2.0:
     dependencies:
       argparse: 2.0.1
 

--- a/scripts/license-sync.ts
+++ b/scripts/license-sync.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 
 const rootDir = path.resolve(import.meta.dirname, "..");
 

--- a/scripts/release-publish.ts
+++ b/scripts/release-publish.ts
@@ -86,7 +86,7 @@ import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 
 // Monorepo root, resolved relative to this file (scripts/ lives one level down).
 const rootDir = path.resolve(import.meta.dirname, "..");

--- a/scripts/version-sync.ts
+++ b/scripts/version-sync.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 
 const rootDir = path.resolve(import.meta.dirname, "..");
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage. — N/A, dependency-only change; existing script tests pass (`pnpm test:scripts`, 20/20).

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Chore — major upgrade of `js-yaml` (4 → 5). `js-yaml` is used only by dev/release scripts to parse `pnpm-workspace.yaml`; no shipped package code imports it.

## Versions
- `js-yaml` 4.2.0 → 5.2.0
- `@types/js-yaml` 4.0.9 → **removed** (v5 ships its own type definitions)

## Breaking notes
js-yaml v5 is rewritten in TypeScript and exposes **flat named exports with no default export**. Code changes required:
- `scripts/version-sync.ts`, `scripts/license-sync.ts`, `scripts/release-publish.ts`: changed `import yaml from "js-yaml"` → `import * as yaml from "js-yaml"` (namespace import). The `yaml.load(...)` call sites are unchanged.
- Removed the standalone `@types/js-yaml` dependency now that types are bundled.

Other v5 behavior changes (default schema is now `CORE_SCHEMA` without `!!merge`; `load()` throws on empty input) do **not** affect this repo — the only usage is `yaml.load()` on a non-empty `pnpm-workspace.yaml` with no merge keys or custom tags.

## Tests
- [x] `pnpm test:scripts` passes (20/20)
- [x] `pnpm version:sync` and `pnpm license:sync` run cleanly (correctly parse the workspace: `21 skipped`, no diffs)

Third PR in the dependency-management dev phase (js-yaml major, isolated per the breaking-change rule).


---
_Generated by [Claude Code](https://claude.ai/code/session_01WVzS34CgyLpVDdJ9urfWxZ)_