### PR TITLE
mono - chore: upgrade GitHub Actions (breaking)

### DIFF
--- a/.github/workflows/browser-compat.yaml
+++ b/.github/workflows/browser-compat.yaml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 15
     name: browser
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6

--- a/.github/workflows/bun-test.yaml
+++ b/.github/workflows/bun-test.yaml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 30
     name: bun
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/cloudflare-keyv-integration.yaml
+++ b/.github/workflows/cloudflare-keyv-integration.yaml
@@ -31,7 +31,7 @@ jobs:
     timeout-minutes: 15
     name: cloudflare-keyv-integration
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 30
     name: Node 24
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6

--- a/.github/workflows/deploy-website.yaml
+++ b/.github/workflows/deploy-website.yaml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Install pnpm
       uses: pnpm/action-setup@v6

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 15
     name: Build
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6
@@ -43,7 +43,7 @@ jobs:
     timeout-minutes: 30
     name: Test
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6
@@ -87,7 +87,7 @@ jobs:
       # ever removed from the script.
       NPM_CONFIG_PROVENANCE: "true"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -20,7 +20,7 @@ jobs:
         node: [ '22', '24', '26' ]
     name: Node ${{ matrix.node }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage. — N/A, CI configuration change.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Chore — upgrades GitHub Actions workflow `uses:` references.

## Versions
- `actions/checkout` `@v6` → `@v7` (major, 9 references across all workflows)

All other actions are already on their latest major and unchanged: `actions/setup-node@v6` (v6.4.0), `pnpm/action-setup@v6` (v6.0.9), `codecov/codecov-action@v7` (v7.0.0), `oven-sh/setup-bun@v2` (v2.2.0), `cloudflare/wrangler-action@v4` (v4.0.0).

## Breaking notes
`actions/checkout@v7`'s breaking change blocks fork-PR checkout under `pull_request_target` / `workflow_run` events and moves the action to ESM. None of this repo's workflows use those triggers (only `push`, `pull_request`, `workflow_dispatch`, `release`), so the upgrade is behavior-neutral here. Pin style (`@vX` major tag) is preserved.

## Checks
- [x] All 7 workflow YAML files parse successfully after the change

Final PR in the dependency-management **dev phase** (GitHub Actions group).


---
_Generated by [Claude Code](https://claude.ai/code/session_01WVzS34CgyLpVDdJ9urfWxZ)_