### PR TITLE
redis - chore: upgrade @redis/client

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -530,8 +530,8 @@ importers:
   storage/redis:
     dependencies:
       '@redis/client':
-        specifier: ^6.0.0
-        version: 6.0.0(@opentelemetry/api@1.9.1)
+        specifier: ^6.0.1
+        version: 6.0.1(@opentelemetry/api@1.9.1)
       cluster-key-slot:
         specifier: ^1.1.2
         version: 1.1.2
@@ -1640,8 +1640,8 @@ packages:
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
 
-  '@redis/client@6.0.0':
-    resolution: {integrity: sha512-NS4iIT25r24sAjNQ2nSRdCW5jPJoV0rxkBee27oTeR+RXaOu89cjIsrww5rPBaYVGVdL1QCx9uz9141gZiSKdQ==}
+  '@redis/client@6.0.1':
+    resolution: {integrity: sha512-SwYl64hKHE/NeO2VSSG1y/4zIm0cNepyOZtQrOpLiNRHmH2FdWBOecNzsLiXCQdFCF9MCyoPXwAbaG2iMO0A7Q==}
     engines: {node: '>= 20.0.0'}
     peerDependencies:
       '@node-rs/xxhash': ^1.1.0
@@ -5378,7 +5378,7 @@ snapshots:
     dependencies:
       quansync: 1.0.0
 
-  '@redis/client@6.0.0(@opentelemetry/api@1.9.1)':
+  '@redis/client@6.0.1(@opentelemetry/api@1.9.1)':
     dependencies:
       cluster-key-slot: 1.1.2
     optionalDependencies:

--- a/storage/redis/package.json
+++ b/storage/redis/package.json
@@ -49,7 +49,7 @@
 	},
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
-		"@redis/client": "^6.0.0",
+		"@redis/client": "^6.0.1",
 		"cluster-key-slot": "^1.1.2",
 		"hookified": "^3.0.0"
 	},


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage. — N/A, dependency-only change.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Chore — upgrades the `@redis/client` driver for `@keyv/redis`.

## Versions
- `@redis/client` 6.0.0 → 6.0.1 (`@keyv/redis`)

## Tests
- [x] `pnpm build` passes for `@keyv/redis`
- [x] `biome check` passes
- [ ] Redis integration tests require a Redis service (Docker) not available in this environment — covered by CI

Runtime phase — database driver (`@redis/client`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01WVzS34CgyLpVDdJ9urfWxZ)_