### PR TITLE
memcache - chore: upgrade memcache

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -409,8 +409,8 @@ importers:
         specifier: workspace:^
         version: link:../../core/keyv
       memcache:
-        specifier: ^1.7.0
-        version: 1.7.0
+        specifier: ^1.8.0
+        version: 1.8.0
     devDependencies:
       '@keyv/compress-gzip':
         specifier: workspace:^
@@ -3299,8 +3299,9 @@ packages:
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
-  memcache@1.7.0:
-    resolution: {integrity: sha512-rGmUvvjb1gavZWldGT/EsouB8Z+GFgxbwZ7CeEsvi9YRphA8jdOWE6tvbTC22AOSBvce8AXu0L92q13djNH/2g==}
+  memcache@1.8.0:
+    resolution: {integrity: sha512-7/Er0dGDPK6BBf/Gmmw/hLfq1+6l9FUt91PNfufNmHXOJgWJjEIglhplKMaZDJuhNVtIBn/Ab+CwCNxX+bYkIg==}
+    engines: {node: '>=22', pnpm: '>=11'}
 
   memory-pager@1.5.0:
     resolution: {integrity: sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==}
@@ -7063,10 +7064,10 @@ snapshots:
 
   mdurl@2.0.0: {}
 
-  memcache@1.7.0:
+  memcache@1.8.0:
     dependencies:
       hashery: 2.0.0
-      hookified: 2.2.0
+      hookified: 3.0.0
 
   memory-pager@1.5.0: {}
 

--- a/storage/memcache/package.json
+++ b/storage/memcache/package.json
@@ -50,7 +50,7 @@
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
 		"hookified": "^3.0.0",
-		"memcache": "^1.7.0"
+		"memcache": "^1.8.0"
 	},
 	"peerDependencies": {
 		"keyv": "workspace:^"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage. — N/A, dependency-only change.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Chore — upgrades the `memcache` client for `@keyv/memcache`.

## Versions
- `memcache` 1.7.0 → 1.8.0 (`@keyv/memcache`)

## Tests
- [x] `pnpm build` passes for `@keyv/memcache`
- [x] `biome check` passes
- [ ] Memcached integration tests require a Memcached service (Docker) not available in this environment — covered by CI

Runtime phase — database driver (`memcache`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01WVzS34CgyLpVDdJ9urfWxZ)_