### PR TITLE
mono - chore: upgrade hookified

### DIFF
--- a/core/bigmap/package.json
+++ b/core/bigmap/package.json
@@ -49,7 +49,7 @@
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
 		"hashery": "^2.0.0",
-		"hookified": "^3.0.0"
+		"hookified": "^3.0.1"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.5.1",

--- a/core/keyv/package.json
+++ b/core/keyv/package.json
@@ -59,7 +59,7 @@
 	},
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
-		"hookified": "^3.0.0"
+		"hookified": "^3.0.1"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,8 +129,8 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0
       hookified:
-        specifier: ^3.0.0
-        version: 3.0.0
+        specifier: ^3.0.1
+        version: 3.0.1
       keyv:
         specifier: workspace:^
         version: link:../keyv
@@ -166,8 +166,8 @@ importers:
   core/keyv:
     dependencies:
       hookified:
-        specifier: ^3.0.0
-        version: 3.0.0
+        specifier: ^3.0.1
+        version: 3.0.1
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.5.1
@@ -355,8 +355,8 @@ importers:
   storage/cloudflare-kv:
     dependencies:
       hookified:
-        specifier: ^3.0.0
-        version: 3.0.0
+        specifier: ^3.0.1
+        version: 3.0.1
       keyv:
         specifier: workspace:^
         version: link:../../core/keyv
@@ -377,8 +377,8 @@ importers:
         specifier: ^3.1075.0
         version: 3.1075.0(@aws-sdk/client-dynamodb@3.1075.0)
       hookified:
-        specifier: ^3.0.0
-        version: 3.0.0
+        specifier: ^3.0.1
+        version: 3.0.1
       keyv:
         specifier: workspace:^
         version: link:../../core/keyv
@@ -390,8 +390,8 @@ importers:
   storage/etcd:
     dependencies:
       hookified:
-        specifier: ^3.0.0
-        version: 3.0.0
+        specifier: ^3.0.1
+        version: 3.0.1
       keyv:
         specifier: workspace:^
         version: link:../../core/keyv
@@ -403,8 +403,8 @@ importers:
   storage/memcache:
     dependencies:
       hookified:
-        specifier: ^3.0.0
-        version: 3.0.0
+        specifier: ^3.0.1
+        version: 3.0.1
       keyv:
         specifier: workspace:^
         version: link:../../core/keyv
@@ -422,8 +422,8 @@ importers:
   storage/mongo:
     dependencies:
       hookified:
-        specifier: ^3.0.0
-        version: 3.0.0
+        specifier: ^3.0.1
+        version: 3.0.1
       keyv:
         specifier: workspace:^
         version: link:../../core/keyv
@@ -456,8 +456,8 @@ importers:
   storage/mysql:
     dependencies:
       hookified:
-        specifier: ^3.0.0
-        version: 3.0.0
+        specifier: ^3.0.1
+        version: 3.0.1
       mysql2:
         specifier: ^3.22.5
         version: 3.22.5(@types/node@24.13.1)
@@ -493,8 +493,8 @@ importers:
   storage/postgres:
     dependencies:
       hookified:
-        specifier: ^3.0.0
-        version: 3.0.0
+        specifier: ^3.0.1
+        version: 3.0.1
       keyv:
         specifier: workspace:^
         version: link:../../core/keyv
@@ -536,8 +536,8 @@ importers:
         specifier: ^1.1.2
         version: 1.1.2
       hookified:
-        specifier: ^3.0.0
-        version: 3.0.0
+        specifier: ^3.0.1
+        version: 3.0.1
       keyv:
         specifier: workspace:^
         version: link:../../core/keyv
@@ -555,8 +555,8 @@ importers:
         specifier: ^12.11.1
         version: 12.11.1
       hookified:
-        specifier: ^3.0.0
-        version: 3.0.0
+        specifier: ^3.0.1
+        version: 3.0.1
       keyv:
         specifier: workspace:^
         version: link:../../core/keyv
@@ -583,8 +583,8 @@ importers:
         specifier: ^1.1.0
         version: 1.1.2
       hookified:
-        specifier: ^3.0.0
-        version: 3.0.0
+        specifier: ^3.0.1
+        version: 3.0.1
       iovalkey:
         specifier: ^0.3.3
         version: 0.3.3
@@ -2910,6 +2910,10 @@ packages:
 
   hookified@3.0.0:
     resolution: {integrity: sha512-x+jzDjd9CWxdgl6u/K4pjnvw7PZx6ZSpiPGAV43uXlJiJy7r2jIEUxxU1Cv7+rwy1GK5Qt5S+Jp7n81DpcUvTA==}
+    engines: {node: '>=22.18.0'}
+
+  hookified@3.0.1:
+    resolution: {integrity: sha512-mtpUIV7U9reosQ16+OHWBd0Ca07fs1ryChQjBPuUMZnrRdLTCW+kEfkTcFudkaevp3gVe5H9FxDCBxYIdO+QQA==}
     engines: {node: '>=22.18.0'}
 
   hosted-git-info@2.8.9:
@@ -6572,6 +6576,8 @@ snapshots:
   hookified@2.2.0: {}
 
   hookified@3.0.0: {}
+
+  hookified@3.0.1: {}
 
   hosted-git-info@2.8.9: {}
 

--- a/storage/cloudflare-kv/package.json
+++ b/storage/cloudflare-kv/package.json
@@ -54,7 +54,7 @@
   },
   "homepage": "https://github.com/jaredwray/keyv",
   "dependencies": {
-    "hookified": "^3.0.0"
+    "hookified": "^3.0.1"
   },
   "devDependencies": {
     "@keyv/test-suite": "workspace:^",

--- a/storage/dynamo/package.json
+++ b/storage/dynamo/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.1075.0",
     "@aws-sdk/lib-dynamodb": "^3.1075.0",
-    "hookified": "^3.0.0"
+    "hookified": "^3.0.1"
   },
   "devDependencies": {
     "@keyv/test-suite": "workspace:^"

--- a/storage/etcd/package.json
+++ b/storage/etcd/package.json
@@ -49,7 +49,7 @@
 	},
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
-		"hookified": "^3.0.0"
+		"hookified": "^3.0.1"
 	},
 	"devDependencies": {
 		"@keyv/test-suite": "workspace:^"

--- a/storage/memcache/package.json
+++ b/storage/memcache/package.json
@@ -49,7 +49,7 @@
 	},
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
-		"hookified": "^3.0.0",
+		"hookified": "^3.0.1",
 		"memcache": "^1.8.0"
 	},
 	"peerDependencies": {

--- a/storage/mongo/package.json
+++ b/storage/mongo/package.json
@@ -50,7 +50,7 @@
 	},
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
-		"hookified": "^3.0.0",
+		"hookified": "^3.0.1",
 		"mongodb": "^7.4.0"
 	},
 	"devDependencies": {

--- a/storage/mysql/package.json
+++ b/storage/mysql/package.json
@@ -51,7 +51,7 @@
 	},
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
-		"hookified": "^3.0.0",
+		"hookified": "^3.0.1",
 		"mysql2": "^3.22.5"
 	},
 	"devDependencies": {

--- a/storage/postgres/package.json
+++ b/storage/postgres/package.json
@@ -51,7 +51,7 @@
 	},
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
-		"hookified": "^3.0.0",
+		"hookified": "^3.0.1",
 		"pg": "^8.22.0"
 	},
 	"peerDependencies": {

--- a/storage/redis/package.json
+++ b/storage/redis/package.json
@@ -51,7 +51,7 @@
 	"dependencies": {
 		"@redis/client": "^6.0.1",
 		"cluster-key-slot": "^1.1.2",
-		"hookified": "^3.0.0"
+		"hookified": "^3.0.1"
 	},
 	"peerDependencies": {
 		"keyv": "workspace:^"

--- a/storage/sqlite/package.json
+++ b/storage/sqlite/package.json
@@ -53,7 +53,7 @@
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
 		"better-sqlite3": "^12.11.1",
-		"hookified": "^3.0.0"
+		"hookified": "^3.0.1"
 	},
 	"peerDependencies": {
 		"keyv": "workspace:^"

--- a/storage/valkey/package.json
+++ b/storage/valkey/package.json
@@ -54,7 +54,7 @@
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
 		"cluster-key-slot": "^1.1.0",
-		"hookified": "^3.0.0",
+		"hookified": "^3.0.1",
 		"iovalkey": "^0.3.3"
 	},
 	"devDependencies": {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage. — N/A, dependency-only change; existing suites pass.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Chore — bumps the shared `hookified` runtime dependency across every package that depends on it (keyv core, bigmap, and all storage adapters).

## Versions
- `hookified` 3.0.0 → 3.0.1 (12 packages)

## Tests
- [x] `pnpm test:ci` passes for `core/keyv` (329 tests) and `core/bigmap` (54 tests) — both consume hookified directly
- [x] `biome check` passes
- [ ] Service-backed adapter tests run in CI (Docker services)

Runtime phase — shared runtime dependency (`hookified`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01WVzS34CgyLpVDdJ9urfWxZ)_