### PR TITLE
test-suite - chore: upgrade bignumber.js

### DIFF
--- a/core/test-suite/package.json
+++ b/core/test-suite/package.json
@@ -57,7 +57,7 @@
 	"dependencies": {
 		"@faker-js/faker": "^10.5.0",
 		"@vitest/coverage-v8": "^4.1.9",
-		"bignumber.js": "^11.1.3",
+		"bignumber.js": "^11.1.4",
 		"json-bigint": "^1.0.0",
 		"timekeeper": "^2.3.1",
 		"vitest": "^4.1.9"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -215,8 +215,8 @@ importers:
         specifier: ^4.1.9
         version: 4.1.9(vitest@4.1.9)
       bignumber.js:
-        specifier: ^11.1.3
-        version: 11.1.3
+        specifier: ^11.1.4
+        version: 11.1.4
       json-bigint:
         specifier: ^1.0.0
         version: 1.0.0
@@ -2314,8 +2314,8 @@ packages:
     resolution: {integrity: sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==}
     engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x || 26.x}
 
-  bignumber.js@11.1.3:
-    resolution: {integrity: sha512-+esZiNSo6VgFokTsYX6mYqNJfFd/IczzZCd4Z7cR8e+AQWhvIcj6nqQ1h9814D9u/TApU0jjTVmfWL0Pd1ZBdA==}
+  bignumber.js@11.1.4:
+    resolution: {integrity: sha512-AJ9dSeaUGj2xu7tEwmdqb51dqdb633xo4njI9K8ZFfcLrNr0XN8/EPkkZUNaF9fkCblGt2zVwZymesUdGynEkQ==}
 
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
@@ -5886,7 +5886,7 @@ snapshots:
       bindings: 1.5.0
       prebuild-install: 7.1.2
 
-  bignumber.js@11.1.3: {}
+  bignumber.js@11.1.4: {}
 
   bignumber.js@9.3.1: {}
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage. — N/A, dependency-only change; full test suite passes.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Chore — upgrades `bignumber.js` for `@keyv/test-suite`.

## Versions
- `bignumber.js` 11.1.3 → 11.1.4 (`@keyv/test-suite`)

## Tests
- [x] `pnpm test:ci` passes for `@keyv/test-suite` (biome + 93 tests; no external service needed)

Runtime phase — standalone runtime dependency (`bignumber.js`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01WVzS34CgyLpVDdJ9urfWxZ)_