### PR TITLE
bigmap - chore: upgrade hashery (breaking)

### DIFF
--- a/core/bigmap/package.json
+++ b/core/bigmap/package.json
@@ -48,7 +48,7 @@
 	},
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
-		"hashery": "^2.0.0",
+		"hashery": "^3.0.0",
 		"hookified": "^3.0.1"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,8 +126,8 @@ importers:
   core/bigmap:
     dependencies:
       hashery:
-        specifier: ^2.0.0
-        version: 2.0.0
+        specifier: ^3.0.0
+        version: 3.0.0
       hookified:
         specifier: ^3.0.1
         version: 3.0.1
@@ -6453,7 +6453,7 @@ snapshots:
 
   hashery@3.0.0:
     dependencies:
-      hookified: 3.0.0
+      hookified: 3.0.1
 
   hasown@2.0.2:
     dependencies:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage. — N/A, dependency-only change; full test suite passes.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Chore — major upgrade of `hashery` (2 → 3) for `@keyv/bigmap`.

## Versions
- `hashery` 2.0.0 → 3.0.0 (`@keyv/bigmap`)

## Breaking notes
hashery v3's breaking changes are runtime/toolchain only — **no public API changes**:
- Minimum Node.js raised to **≥22.18**. keyv already requires this (`.nvmrc` = 24, root `engines.node` = `>= 22.18.0`).
- Internal `hookified` bumped to 3.x. keyv is already on `hookified@3.0.1`.

`@keyv/bigmap` only **re-exports** the `Hashery` class (`export { Hashery } from "hashery"`), and the class API is unchanged, so no code changes are required.

## Tests
- [x] `pnpm build` passes for `@keyv/bigmap`
- [x] `pnpm test:ci` passes (biome + 54 tests)
- [x] Sanity-checked the re-exported API: `new Hashery().toNumberSync(...)` and `new Hashery({ defaultAlgorithmSync: "fnv1" })` work as documented in the README

Runtime phase — breaking major (`hashery`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01WVzS34CgyLpVDdJ9urfWxZ)_