### PR TITLE
compress-gzip - chore: upgrade pako (breaking)

### DIFF
--- a/compression/compress-gzip/package.json
+++ b/compression/compress-gzip/package.json
@@ -50,8 +50,7 @@
   },
   "homepage": "https://github.com/jaredwray/keyv",
   "dependencies": {
-    "@types/pako": "^2.0.4",
-    "pako": "^2.1.0"
+    "pako": "^3.0.0"
   },
   "peerDependencies": {
     "keyv": "workspace:^"

--- a/compression/compress-gzip/src/index.ts
+++ b/compression/compress-gzip/src/index.ts
@@ -17,7 +17,7 @@ export class KeyvGzip implements KeyvCompressionAdapter {
 
 	async decompress(value: string): Promise<string> {
 		const buffer = Buffer.from(value, "base64");
-		return inflate(buffer, { ...this._options, to: "string" });
+		return inflate(buffer, { ...this._options, toText: true });
 	}
 }
 

--- a/compression/compress-gzip/src/types.ts
+++ b/compression/compress-gzip/src/types.ts
@@ -1,7 +1,7 @@
-import type { DeflateFunctionOptions, InflateOptions } from "pako";
+import type { DeflateOptions, InflateOptions } from "pako";
 
-type PakoDeflateOptions = DeflateFunctionOptions;
+type PakoDeflateOptions = DeflateOptions;
 
-type PakoInflateOptions = InflateOptions & { to?: "string" };
+type PakoInflateOptions = InflateOptions & { toText?: boolean };
 
 export type Options = PakoDeflateOptions & PakoInflateOptions;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,15 +69,12 @@ importers:
 
   compression/compress-gzip:
     dependencies:
-      '@types/pako':
-        specifier: ^2.0.4
-        version: 2.0.4
       keyv:
         specifier: workspace:^
         version: link:../../core/keyv
       pako:
-        specifier: ^2.1.0
-        version: 2.1.0
+        specifier: ^3.0.0
+        version: 3.0.0
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.5.1
@@ -2112,9 +2109,6 @@ packages:
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
 
-  '@types/pako@2.0.4':
-    resolution: {integrity: sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==}
-
   '@types/pg@8.20.0':
     resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
 
@@ -3606,8 +3600,8 @@ packages:
     resolution: {integrity: sha512-ua1L4OgXSBdsu1FPb7F3tYH0F48a6kxvod4pLUlGY9COeJAJQNX/sNH2IiEmsxw7lqYiAwrdHMjz1FctOsyDQg==}
     engines: {node: '>=18'}
 
-  pako@2.1.0:
-    resolution: {integrity: sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==}
+  pako@3.0.0:
+    resolution: {integrity: sha512-TGPtlCI1pSUSbkOIxOUUHNrBa0muz4mAp32cYUF3RoSa5c73jiQTKOKo22gaa4DxLggQrda/DAdax5QkcHPvYA==}
 
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
@@ -5697,8 +5691,6 @@ snapshots:
 
   '@types/normalize-package-data@2.4.4': {}
 
-  '@types/pako@2.0.4': {}
-
   '@types/pg@8.20.0':
     dependencies:
       '@types/node': 24.13.1
@@ -7541,7 +7533,7 @@ snapshots:
       registry-url: 6.0.1
       semver: 7.8.5
 
-  pako@2.1.0: {}
+  pako@3.0.0: {}
 
   parse-entities@4.0.2:
     dependencies:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage. — N/A, dependency-only change; full test suite passes.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Chore — major upgrade of `pako` (2 → 3) for `@keyv/compress-gzip`.

## Versions
- `pako` 2.1.0 → 3.0.0 (`@keyv/compress-gzip`)
- `@types/pako` 2.0.4 → **removed** (v3 ships its own type definitions)

## Breaking notes
pako v3 changes required these code updates:
- **`{ to: "string" }` → `{ toText: true }`**: the string-output inflate option was renamed. Updated `src/index.ts` (`decompress`).
- **Option type rename**: `DeflateFunctionOptions` → `DeflateOptions` to match v3's bundled types. Updated `src/types.ts`, and `InflateOptions & { to?: "string" }` → `InflateOptions & { toText?: boolean }`.
- **Default export removed**: no change needed — the adapter already used named imports (`import { deflate, inflate } from "pako"`).
- **`legacyHash` default flipped**: affects only the *compressed output bytes* (still a valid DEFLATE stream), so values compressed by earlier versions remain decompressible. Round-trip verified by the test suite.

## Tests
- [x] `pnpm build` passes for `@keyv/compress-gzip`
- [x] `pnpm test:ci` passes (biome + 9 tests, incl. compress/decompress round-trip)

Runtime phase — final breaking major (`pako`). This completes the dependency-maintenance runtime phase.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WVzS34CgyLpVDdJ9urfWxZ)_