### PR TITLE
mono - chore: upgrade code quality dependencies and pin pnpm to v10

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "author": "Jared Wray <me@jaredwray.com>",
   "license": "MIT",
   "private": true,
+  "packageManager": "pnpm@10.34.4",
   "scripts": {
     "build:keyv:serialize": "pnpm recursive --filter=@keyv/serialize run build",
     "build:keyv": "pnpm recursive --filter=keyv run build",

--- a/package.json
+++ b/package.json
@@ -19,13 +19,13 @@
     "clean": "rimraf node_modules pnpm-lock.yaml && pnpm recursive run clean"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.3.13",
+    "@biomejs/biome": "^2.5.1",
     "@types/node": "^24.10.1",
-    "@vitest/coverage-v8": "^4.0.18",
+    "@vitest/coverage-v8": "^4.1.9",
     "rimraf": "^6.1.2",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3",
-    "vitest": "^4.0.18"
+    "vitest": "^4.1.9"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/packages/bigmap/package.json
+++ b/packages/bigmap/package.json
@@ -51,12 +51,12 @@
 		"hookified": "^1.15.0"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^2.3.11",
-		"@faker-js/faker": "^10.2.0",
-		"@vitest/coverage-v8": "^4.0.17",
+		"@biomejs/biome": "^2.5.1",
+		"@faker-js/faker": "^10.5.0",
+		"@vitest/coverage-v8": "^4.1.9",
 		"rimraf": "^6.1.2",
 		"tsd": "^0.33.0",
-		"vitest": "^4.0.17"
+		"vitest": "^4.1.9"
 	},
 	"peerDependencies": {
 		"keyv": "workspace:^"

--- a/packages/compress-brotli/package.json
+++ b/packages/compress-brotli/package.json
@@ -57,11 +57,11 @@
 		"keyv": "workspace:^"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^2.3.13",
+		"@biomejs/biome": "^2.5.1",
 		"@keyv/test-suite": "workspace:^",
-		"@vitest/coverage-v8": "^4.0.18",
+		"@vitest/coverage-v8": "^4.1.9",
 		"rimraf": "^6.1.2",
-		"vitest": "^4.0.18"
+		"vitest": "^4.1.9"
 	},
 	"tsd": {
 		"directory": "test"

--- a/packages/compress-gzip/package.json
+++ b/packages/compress-gzip/package.json
@@ -58,12 +58,12 @@
     "keyv": "workspace:^"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.3.13",
+    "@biomejs/biome": "^2.5.1",
     "@keyv/test-suite": "workspace:^",
-    "@vitest/coverage-v8": "^4.0.18",
+    "@vitest/coverage-v8": "^4.1.9",
     "rimraf": "^6.1.2",
     "tsd": "^0.33.0",
-    "vitest": "^4.0.18"
+    "vitest": "^4.1.9"
   },
   "tsd": {
     "directory": "test"

--- a/packages/compress-lz4/package.json
+++ b/packages/compress-lz4/package.json
@@ -59,11 +59,11 @@
 		"keyv": "workspace:^"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^2.3.8",
+		"@biomejs/biome": "^2.5.1",
 		"@keyv/test-suite": "workspace:^",
-		"@vitest/coverage-v8": "^4.0.14",
+		"@vitest/coverage-v8": "^4.1.9",
 		"rimraf": "^6.1.2",
-		"vitest": "^4.0.14"
+		"vitest": "^4.1.9"
 	},
 	"tsd": {
 		"directory": "test"

--- a/packages/dynamo/package.json
+++ b/packages/dynamo/package.json
@@ -54,10 +54,10 @@
     "@aws-sdk/lib-dynamodb": "^3.958.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.3.10",
+    "@biomejs/biome": "^2.5.1",
     "@keyv/test-suite": "workspace:^",
-    "@vitest/coverage-v8": "^4.0.16",
-    "vitest": "^4.0.16"
+    "@vitest/coverage-v8": "^4.1.9",
+    "vitest": "^4.1.9"
   },
   "peerDependencies": {
     "keyv": "workspace:^"

--- a/packages/etcd/package.json
+++ b/packages/etcd/package.json
@@ -52,12 +52,12 @@
 		"etcd3": "^1.1.2"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^2.3.10",
+		"@biomejs/biome": "^2.5.1",
 		"@keyv/test-suite": "workspace:^",
-		"@vitest/coverage-v8": "^4.0.16",
+		"@vitest/coverage-v8": "^4.1.9",
 		"rimraf": "^6.1.2",
 		"typescript": "^5.9.3",
-		"vitest": "^4.0.16"
+		"vitest": "^4.1.9"
 	},
 	"peerDependencies": {
 		"keyv": "workspace:^"

--- a/packages/keyv/package.json
+++ b/packages/keyv/package.json
@@ -62,8 +62,8 @@
 		"@keyv/serialize": "workspace:^"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^2.3.13",
-		"@faker-js/faker": "^10.2.0",
+		"@biomejs/biome": "^2.5.1",
+		"@faker-js/faker": "^10.5.0",
 		"@keyv/compress-brotli": "workspace:^",
 		"@keyv/compress-gzip": "workspace:^",
 		"@keyv/compress-lz4": "workspace:^",
@@ -71,13 +71,13 @@
 		"@keyv/mongo": "workspace:^",
 		"@keyv/sqlite": "workspace:^",
 		"@keyv/test-suite": "workspace:^",
-		"@vitest/coverage-v8": "^4.0.18",
+		"@vitest/coverage-v8": "^4.1.9",
 		"lru.min": "^1.1.1",
 		"quick-lru": "^7.0.0",
 		"rimraf": "^6.1.2",
 		"timekeeper": "^2.3.1",
 		"tsd": "^0.33.0",
-		"vitest": "^4.0.18"
+		"vitest": "^4.1.9"
 	},
 	"tsd": {
 		"directory": "test"

--- a/packages/keyv/src/event-manager.ts
+++ b/packages/keyv/src/event-manager.ts
@@ -50,7 +50,9 @@ class EventManager {
 	public off(event: string, listener: EventListener): void {
 		const listeners = this._eventListeners.get(event) ?? [];
 		const index = listeners.findIndex(
-			(v) => v === listener || (v._originalListener === listener && listener !== undefined),
+			(v) =>
+				v === listener ||
+				(v._originalListener === listener && listener !== undefined),
 		);
 		if (index !== -1) {
 			listeners.splice(index, 1);

--- a/packages/memcache/package.json
+++ b/packages/memcache/package.json
@@ -57,16 +57,16 @@
 		"keyv": "workspace:^"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^2.3.10",
+		"@biomejs/biome": "^2.5.1",
 		"@keyv/compress-gzip": "workspace:^",
 		"@keyv/test-suite": "workspace:^",
 		"@types/memjs": "^1.3.3",
-		"@vitest/coverage-v8": "^4.0.16",
+		"@vitest/coverage-v8": "^4.1.9",
 		"rimraf": "^6.1.2",
 		"tsd": "^0.33.0",
 		"tsup": "^8.5.1",
 		"typescript": "^5.9.3",
-		"vitest": "^4.0.16"
+		"vitest": "^4.1.9"
 	},
 	"tsd": {
 		"directory": "test"

--- a/packages/mongo/package.json
+++ b/packages/mongo/package.json
@@ -53,12 +53,12 @@
 		"mongodb": "^7.0.0"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^2.3.10",
+		"@biomejs/biome": "^2.5.1",
 		"@keyv/test-suite": "workspace:^",
-		"@vitest/coverage-v8": "^4.0.16",
+		"@vitest/coverage-v8": "^4.1.9",
 		"rimraf": "^6.1.2",
 		"tsd": "^0.33.0",
-		"vitest": "^4.0.16"
+		"vitest": "^4.1.9"
 	},
 	"peerDependencies": {
 		"keyv": "workspace:^"

--- a/packages/mysql/package.json
+++ b/packages/mysql/package.json
@@ -54,14 +54,14 @@
 		"mysql2": "^3.16.1"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^2.3.11",
+		"@biomejs/biome": "^2.5.1",
 		"@keyv/test-suite": "workspace:^",
-		"@vitest/coverage-v8": "^4.0.17",
+		"@vitest/coverage-v8": "^4.1.9",
 		"keyv": "workspace:^",
 		"rimraf": "^6.1.2",
 		"ts-node": "^10.9.2",
 		"tsd": "^0.33.0",
-		"vitest": "^4.0.17"
+		"vitest": "^4.1.9"
 	},
 	"tsd": {
 		"directory": "test"

--- a/packages/postgres/package.json
+++ b/packages/postgres/package.json
@@ -57,14 +57,14 @@
 		"keyv": "workspace:^"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^2.3.11",
-		"@faker-js/faker": "^10.2.0",
+		"@biomejs/biome": "^2.5.1",
+		"@faker-js/faker": "^10.5.0",
 		"@keyv/test-suite": "workspace:^",
 		"@types/pg": "^8.16.0",
-		"@vitest/coverage-v8": "^4.0.17",
+		"@vitest/coverage-v8": "^4.1.9",
 		"rimraf": "^6.1.2",
 		"tsd": "^0.33.0",
-		"vitest": "^4.0.17"
+		"vitest": "^4.1.9"
 	},
 	"tsd": {
 		"directory": "test"

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -57,14 +57,14 @@
 		"keyv": "workspace:^"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^2.3.11",
-		"@faker-js/faker": "^10.2.0",
+		"@biomejs/biome": "^2.5.1",
+		"@faker-js/faker": "^10.5.0",
 		"@keyv/test-suite": "workspace:^",
-		"@vitest/coverage-v8": "^4.0.16",
+		"@vitest/coverage-v8": "^4.1.9",
 		"rimraf": "^6.1.2",
 		"timekeeper": "^2.3.1",
 		"tsd": "^0.33.0",
-		"vitest": "^4.0.16"
+		"vitest": "^4.1.9"
 	},
 	"tsd": {
 		"directory": "test"

--- a/packages/redis/src/index.ts
+++ b/packages/redis/src/index.ts
@@ -31,15 +31,15 @@ import {
 } from "./types.js";
 
 export {
+	defaultReconnectStrategy,
+	type KeyvRedisEntry,
 	type KeyvRedisOptions,
 	type KeyvRedisPropertyOptions,
-	type KeyvRedisEntry,
-	RedisErrorMessages,
-	defaultReconnectStrategy,
+	type RedisClientConnectionType,
 	type RedisConnectionClientType,
 	type RedisConnectionClusterType,
 	type RedisConnectionSentinelType,
-	type RedisClientConnectionType,
+	RedisErrorMessages,
 };
 
 export default class KeyvRedis<T>

--- a/packages/serialize/package.json
+++ b/packages/serialize/package.json
@@ -45,14 +45,14 @@
   },
   "homepage": "https://github.com/jaredwray/keyv",
   "devDependencies": {
-    "@biomejs/biome": "^2.3.13",
+    "@biomejs/biome": "^2.5.1",
     "@keyv/test-suite": "workspace:^",
-    "@vitest/coverage-v8": "^4.0.18",
+    "@vitest/coverage-v8": "^4.1.9",
     "keyv": "workspace:^",
     "rimraf": "^6.1.2",
     "tsd": "^0.33.0",
     "typescript": "^5.9.3",
-    "vitest": "^4.0.18"
+    "vitest": "^4.1.9"
   },
   "tsd": {
     "directory": "test"

--- a/packages/sqlite/package.json
+++ b/packages/sqlite/package.json
@@ -56,13 +56,13 @@
 		"keyv": "workspace:^"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^2.3.11",
-		"@faker-js/faker": "^10.2.0",
+		"@biomejs/biome": "^2.5.1",
+		"@faker-js/faker": "^10.5.0",
 		"@keyv/test-suite": "workspace:^",
-		"@vitest/coverage-v8": "^4.0.17",
+		"@vitest/coverage-v8": "^4.1.9",
 		"rimraf": "^6.1.2",
 		"tsd": "^0.33.0",
-		"vitest": "^4.0.17"
+		"vitest": "^4.1.9"
 	},
 	"tsd": {
 		"directory": "test"

--- a/packages/test-suite/package.json
+++ b/packages/test-suite/package.json
@@ -52,18 +52,18 @@
 	},
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
-		"@faker-js/faker": "^10.2.0",
-		"@vitest/coverage-v8": "^4.0.15",
+		"@faker-js/faker": "^10.5.0",
+		"@vitest/coverage-v8": "^4.1.9",
 		"bignumber.js": "^9.3.1",
 		"json-bigint": "^1.0.0",
 		"timekeeper": "^2.3.1",
-		"vitest": "^4.0.15"
+		"vitest": "^4.1.9"
 	},
 	"peerDependencies": {
 		"keyv": "workspace:^"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^2.3.8",
+		"@biomejs/biome": "^2.5.1",
 		"@keyv/serialize": "workspace:^",
 		"@types/json-bigint": "^1.0.4",
 		"lz4-napi": "^2.9.0",

--- a/packages/valkey/package.json
+++ b/packages/valkey/package.json
@@ -56,14 +56,14 @@
 		"iovalkey": "^0.3.3"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^2.3.8",
+		"@biomejs/biome": "^2.5.1",
 		"@keyv/test-suite": "workspace:^",
-		"@vitest/coverage-v8": "^4.0.15",
+		"@vitest/coverage-v8": "^4.1.9",
 		"keyv": "workspace:^",
 		"rimraf": "^6.1.2",
 		"timekeeper": "^2.3.1",
 		"tsd": "^0.33.0",
-		"vitest": "^4.0.15"
+		"vitest": "^4.1.9"
 	},
 	"tsd": {
 		"directory": "test"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage. — N/A: dependency-only chore, no source behaviour changed; the existing suites were run to confirm no regressions (see Verification).

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

`chore` — dependency management for the **v5** branch. First dev-phase group (code quality tooling) from the agentic `dependency-management-node` workflow, plus the requested pnpm v10 pin. **No API-breaking changes to the Keyv libraries** (v5).

## Summary
Upgrade testing/linting/formatting tooling across every workspace package, and pin the package manager to the latest pnpm v10.

## Versions
Code quality tooling (all workspace packages):
- `@biomejs/biome` `^2.3.x` → `^2.5.1`
- `vitest` `^4.0.x` → `^4.1.9`
- `@vitest/coverage-v8` `^4.0.x` → `^4.1.9`
- `@faker-js/faker` `^10.2.0` → `^10.5.0`

Package manager:
- Pinned `packageManager` to `pnpm@10.34.4` (latest v10; stays off the pnpm 11 major)

Targets are the exact "Latest" from `pnpm outdated`, so they respect the workspace `minimumReleaseAge` gate (2.5.2 was held back as too fresh, resolving to 2.5.1).

## Formatting
biome 2.5.1 tightened two rules; applied its autofix (whitespace / export order only — no logic or public API change):
- `packages/keyv/src/event-manager.ts` — line wrap in `off()`
- `packages/redis/src/index.ts` — alphabetised the `export { … }` block

## Verification
Ran locally (no CI runs on `v5` PRs — every workflow triggers only on `main`):
- `@keyv/serialize` — build ✓, lint ✓, **18/18** tests, 100% coverage
- `keyv` (core) — build ✓, lint ✓, **385/387** tests, 99.45% coverage
  - the 2 skipped need a live memcached on `localhost:11211` (unavailable in this sandbox — `ECONNREFUSED`); provably environmental, not related to the upgrade
- `@keyv/compress-brotli` 18/18, `@keyv/compress-gzip` 13/13, `@keyv/bigmap` 39/39 — build + lint + tests ✓
- `pnpm install` clean under the pinned `pnpm@10.34.4`

## Notes / follow-ups (not in this PR)
- **Pre-existing** on `v5`: `@keyv/redis` DTS build fails at `src/index.ts:915` (`Promise<RedisClientType>` cast) because a fresh lockfile resolves `@redis/client` to `5.12.1` in-range. Reproduces on clean `v5` with my changes reverted — tracked separately from this dep group.
- Remaining dependency-management groups (deferred, one PR each): GitHub Actions (`checkout@v3`, `codeql-action@v2`), TypeScript 6 (major), then the runtime phase (`@redis/client` 6, `hookified` 3, `hashery` 3, `pako` 3, `bignumber.js` 11, and in-range runtime bumps).
- `@types/node` is `^24` while `.nvmrc` is `20` — a pre-existing mismatch left untouched here; worth reconciling as a project decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XKr5Rbh6z1JRwZNnMSVYQD

---
_Generated by [Claude Code](https://claude.ai/code/session_01XKr5Rbh6z1JRwZNnMSVYQD)_