### PR TITLE
mono - chore: upgrade GitHub Actions to latest majors (breaking)

### DIFF
--- a/.github/workflows/bun-test.yaml
+++ b/.github/workflows/bun-test.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     name: bun
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     name: Node 24
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
       
@@ -40,7 +40,7 @@ jobs:
         run: pnpm test
 
       - name: Code Coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_KEY }}
           verbose: true

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,11 +38,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v7
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -53,7 +53,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -67,4 +67,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v4

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -15,11 +15,11 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
 
     # Test
     - name: Use Node.js 22
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: 22
 
@@ -36,7 +36,7 @@ jobs:
       run: pnpm website:build
 
     - name: Publish to Cloudflare Pages
-      uses: cloudflare/wrangler-action@v3
+      uses: cloudflare/wrangler-action@v4
       with:
         apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         command: pages deploy packages/website/dist --project-name=keyv --branch=main

--- a/.github/workflows/nodejs-20-test.yaml
+++ b/.github/workflows/nodejs-20-test.yaml
@@ -18,9 +18,9 @@ jobs:
         node: [ '20' ]
     name: Node ${{ matrix.node }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
       

--- a/.github/workflows/nodejs-22-test.yaml
+++ b/.github/workflows/nodejs-22-test.yaml
@@ -18,9 +18,9 @@ jobs:
         node: [ '22' ]
     name: Node ${{ matrix.node }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
       

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,9 +18,9 @@ jobs:
         node: [ '24' ]
     name: Node ${{ matrix.node }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
       


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage. — N/A: CI-workflow-only change, no source touched.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

`chore` — the **GitHub Actions** group of the agentic `dependency-management-node` workflow for the **v5** branch. CI-infrastructure only; **no change to any published Keyv library or its public API.**

## Summary
Upgrade every `uses:` GitHub Actions reference to its latest major version, preserving the existing major-alias pin style.

## Versions
- `actions/checkout` `v3`/`v4` → **`v7`**
- `actions/setup-node` `v4` → **`v6`**
- `github/codeql-action/*` (init, autobuild, analyze) `v2` → **`v4`** — v2 is end-of-life
- `codecov/codecov-action` `v5` → **`v7`**
- `cloudflare/wrangler-action` `v3` → **`v4`**
- `oven-sh/setup-bun` `v2` — already latest major, unchanged

17 references across 7 workflow files.

## Checks
- [x] All workflow YAML validated (parses cleanly) after the edits
- [x] `wrangler-action@v4` compatibility confirmed — the deploy step already uses modern `command: pages deploy … --project-name=keyv` syntax and the `apiToken` input, both supported in v4
- [ ] CI not run on this PR — every workflow triggers only on `main`, so none execute on a `v5` PR

## Breaking notes
Marked `(breaking)` because action **majors** changed. Impact is limited to CI/release infrastructure (no runtime or library-API effect). Because these can't be exercised by CI on `v5`, validate them when `v5` merges to `main` or via `workflow_dispatch`. Points to watch:
- `codeql-action` v2→v4 — v2 is being sunset by GitHub; v4 is the supported line for the `init`/`autobuild`/`analyze` flow.
- `codecov-action` v5→v7 — token-based upload already configured; inputs unchanged.
- `wrangler-action` v3→v4 — deploy-website only; runs on release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XKr5Rbh6z1JRwZNnMSVYQD

---
_Generated by [Claude Code](https://claude.ai/code/session_01XKr5Rbh6z1JRwZNnMSVYQD)_