### PR TITLE
mono - chore: release - keyv@5.6.1 and @keyv/sqlite@4.1.0 (v5 line)

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,0 +1,20 @@
+# Changelog
+
+Release notes for the **v5 maintenance line** of Keyv, one Markdown file per
+release cut.
+
+`main` (v6) produces its changelog through its own release tooling. The `v5`
+branch does not, so releases here are written by hand in this folder. Each file
+documents a single release cut and may span more than one workspace package —
+each package keeps its own semver (e.g. a cut can ship `keyv@5.6.1` and
+`@keyv/sqlite@4.1.0` together).
+
+Publishing is handled by the manual **`release`** GitHub Actions workflow
+(`.github/workflows/release.yaml`), run from the `v5` branch after the release PR
+merges. That workflow publishes every workspace package whose local `version` is
+ahead of npm, under the dist-tag `scripts/release.mjs` computes, via OIDC trusted
+publishing — it never bumps versions itself.
+
+## Releases
+
+- [v5.6.1](./v5.6.1.md) — 2026-07-03 · `keyv@5.6.1`, `@keyv/sqlite@4.1.0`

--- a/changelog/v5.6.1.md
+++ b/changelog/v5.6.1.md
@@ -1,0 +1,113 @@
+# Keyv v5 — 2026-07-03
+
+Maintenance release on the **v5 line**. It ships one core bug fix and a
+security-driven update to the SQLite adapter.
+
+| Package | Version | Bump |
+| --- | --- | --- |
+| `keyv` | 5.6.0 → **5.6.1** | patch |
+| `@keyv/sqlite` | 4.0.8 → **4.1.0** | minor |
+
+Every other workspace package is unchanged since its last release and is not part
+of this cut. Publishing is performed by the manual `release` workflow
+(`.github/workflows/release.yaml`, OIDC trusted publishing) run from the `v5`
+branch after this release merges — it publishes each package whose local version
+is ahead of npm, under the dist-tag the release script computes (`latest` while
+the v5 line still owns it).
+
+---
+
+## keyv@5.6.1 — 2026-07-03
+
+Fixes a listener leak in the v5 `EventManager`.
+
+### Bug Fixes
+
+- listener leak when using `once` and `off` (#1937)
+
+  A `once` listener wraps the caller's callback before it is stored, so
+  `off(originalListener)` could not find the wrapper and the listener was never
+  removed — leaking listeners over time (e.g. `cacheable-request` re-registering
+  per request). The wrapper now keeps a reference to the original listener and
+  `off` matches on it. The max-listener warning message was also made easier to
+  trace.
+
+  ```js
+  const keyv = new Keyv();
+  const onError = (err) => console.error(err);
+
+  keyv.once("error", onError);
+  keyv.off("error", onError); // 5.6.0: no-op (leaked) → 5.6.1: removed correctly
+  ```
+
+### Contributors
+
+- @YUCLing (1)
+
+### Full List of Changes
+
+- keyv - fix(v5): listener leak when using once and off by @YUCLing in #1937
+
+**Full diff:** https://github.com/jaredwray/keyv/compare/2db4ff1...9d22d53
+
+---
+
+## @keyv/sqlite@4.1.0 — 2026-07-03
+
+Adds opt-in WAL mode and upgrades the `sqlite3` driver to a non-vulnerable major.
+
+### Features
+
+- WAL (Write-Ahead Logging) mode support via a new `wal` option (#1826)
+
+  Opt in for better read/write concurrency on file-backed databases. Disabled by
+  default, so existing behavior is unchanged.
+
+  ```js
+  import KeyvSqlite from "@keyv/sqlite";
+
+  const store = new KeyvSqlite({ uri: "sqlite://./data.sqlite", wal: true });
+  ```
+
+- warn and skip WAL when `wal: true` is set on an in-memory database (#1832)
+
+  SQLite silently keeps in-memory databases in `memory` journal mode, so the
+  adapter now logs a warning and skips the `PRAGMA journal_mode=WAL` call instead
+  of appearing to enable WAL when it cannot.
+
+### Bug Fixes
+
+- upgrade `sqlite3` from `^5.1.7` to `^6.0.1` to drop a vulnerable dependency
+  chain (#1941)
+
+  `sqlite3@5.1.7` pulled in `@tootallnate/once` (GHSA-vpq2-c234-7xj6) and a
+  vulnerable `node-tar` range. `sqlite3@6.x` makes `node-gyp` an optional peer and
+  resolves a patched `tar`, removing the vulnerable packages. The `KeyvSqlite` API
+  and behavior are unchanged.
+
+  > **Heads up — Node floor raised.** `sqlite3@6.x` requires **Node ≥ 20.17.0**,
+  > so `@keyv/sqlite`'s `engines.node` moves from `>= 18` to `>= 20.17.0`. Node 18
+  > reached end-of-life in April 2025.
+
+### Contributors
+
+- @jaredwray (2)
+- @snomiao (1)
+
+### Full List of Changes
+
+- sqlite - feat: Add WAL (Write-Ahead Logging) mode support by @snomiao in #1826
+- sqlite - feat: Add warning for WAL mode with in-memory SQLite databases by @jaredwray in #1832
+- sqlite - fix: upgrade sqlite3 to ^6.0.1 to resolve dependency vulnerabilities by @jaredwray in #1941
+
+**Full diff:** https://github.com/jaredwray/keyv/compare/3858c44...9d22d53
+
+---
+
+## Repository / release infrastructure
+
+Shipped on the `v5` branch alongside this cut but not published as npm packages:
+
+- mono - feat: v5 release pipeline with OIDC trusted publishing and v6 version ceiling (#2004)
+- mono - chore: upgrade GitHub Actions to latest majors (#2003)
+- mono - chore: upgrade code quality dependencies and pin pnpm to v10 (#2002)

--- a/packages/keyv/package.json
+++ b/packages/keyv/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "keyv",
-	"version": "5.6.0",
+	"version": "5.6.1",
 	"description": "Simple key-value storage with support for multiple backends",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage. — _This is a release cut: it changes only the `keyv` version and adds `changelog/`. No source changes here; the released fixes/features were each tested at 100% coverage in their originating PRs (#1937, #1826, #1832, #1941)._

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Release / chore — a version-bump + changelog cut for the **v5 maintenance line**. It does not publish; publishing is the manual `release` workflow run after merge.

---

## Release summary

Releasing **2 packages** on the v5 line: `keyv@5.6.1` (patch), `@keyv/sqlite@4.1.0` (minor).

| Package | Current | New | Bump | Rationale |
|---|---|---|---|---|
| `keyv` | 5.6.0 | **5.6.1** | **patch** | 1 fix — listener leak (#1937) |
| `@keyv/sqlite` | 4.0.8 | **4.1.0** | **minor** | 2 feat (WAL) + 1 fix (sqlite3 v6) — manifest already at 4.1.0 |
| _14 adapters/utils_ | — | — | _skipped_ | up-to-date with npm; only the mono tooling chore touched them |
| `@keyv/website` | 1.0.0 | — | _private_ | not published |

<sub>Skipped (already published): `@keyv/serialize`, `@keyv/test-suite`, `@keyv/redis`, `@keyv/valkey`, `@keyv/mongo`, `@keyv/mysql`, `@keyv/postgres`, `@keyv/etcd`, `@keyv/memcache`, `@keyv/dynamo`, `@keyv/bigmap`, `@keyv/compress-brotli`, `@keyv/compress-gzip`, `@keyv/compress-lz4`.</sub>

Why these two: `keyv`'s listener-leak fix (#1937) merged **after** 5.6.0 was published, so it is unreleased on npm; `@keyv/sqlite`'s manifest was already bumped to 4.1.0 (WAL + sqlite3 v6) but never published (npm `latest` is still 4.0.8).

---

## keyv@5.6.1 — 2026-07-03

Fixes a listener leak in the v5 `EventManager`.

### Bug Fixes
- listener leak when using `once` and `off` (#1937)

  A `once` listener wraps the caller's callback before it is stored, so `off(originalListener)` could not find the wrapper and the listener was never removed. The wrapper now keeps a reference to the original listener and `off` matches on it.

  ```js
  const keyv = new Keyv();
  const onError = (err) => console.error(err);
  keyv.once("error", onError);
  keyv.off("error", onError); // 5.6.0: no-op (leaked) → 5.6.1: removed correctly
  ```

### Contributors
- @YUCLing (1)

### Full List of Changes
- keyv - fix(v5): listener leak when using once and off by @YUCLing in #1937

**Full diff:** https://github.com/jaredwray/keyv/compare/2db4ff1...9d22d53

## @keyv/sqlite@4.1.0 — 2026-07-03

Adds opt-in WAL mode and upgrades the `sqlite3` driver to a non-vulnerable major.

### Features
- WAL (Write-Ahead Logging) mode support via a new `wal` option (#1826)

  ```js
  import KeyvSqlite from "@keyv/sqlite";
  const store = new KeyvSqlite({ uri: "sqlite://./data.sqlite", wal: true });
  ```
- warn and skip WAL when `wal: true` is set on an in-memory database (#1832)

### Bug Fixes
- upgrade `sqlite3` from `^5.1.7` to `^6.0.1` to drop a vulnerable dependency chain (`@tootallnate/once` GHSA-vpq2-c234-7xj6, vulnerable `node-tar`) (#1941)

  > **Heads up — Node floor raised.** `sqlite3@6.x` requires **Node ≥ 20.17.0**, so `@keyv/sqlite`'s `engines.node` moves from `>= 18` to `>= 20.17.0`. Node 18 reached end-of-life in April 2025. The `KeyvSqlite` API is unchanged.

### Contributors
- @jaredwray (2)
- @snomiao (1)

### Full List of Changes
- sqlite - feat: Add WAL (Write-Ahead Logging) mode support by @snomiao in #1826
- sqlite - feat: Add warning for WAL mode with in-memory SQLite databases by @jaredwray in #1832
- sqlite - fix: upgrade sqlite3 to ^6.0.1 to resolve dependency vulnerabilities by @jaredwray in #1941

**Full diff:** https://github.com/jaredwray/keyv/compare/3858c44...9d22d53

---

## Changelog

Because the v5 branch has no automated changelog (unlike `main`/v6), this PR adds a `changelog/` folder as the convention for the line:
- `changelog/v5.6.1.md` — the notes above.
- `changelog/README.md` — what the folder is and how v5 publishing works.

## Verification
- [x] `node scripts/release.mjs --json` → plan publishes **exactly** `keyv@5.6.1` and `@keyv/sqlite@4.1.0` (both `tag=latest`, moving `latest` forward), and skips the other 14 as "already published".
- [x] `keyv/package.json` and `sqlite/package.json` parse as valid JSON; both versions are below the `< 6.0.0` major ceiling.
- [x] Only the `keyv` version and the new `changelog/` markdown change — no source/runtime files touched.

> Note: the v5 test workflows (`tests.yaml`, `nodejs-*-test.yaml`) trigger on `main` only, so this PR into `v5` gets no automatic CI. The change has no runtime surface (a version string + markdown), and each released fix/feature was already tested in its originating PR.

## Post-merge
No publish happens on merge. After merging into `v5`, publish manually:
**Actions → `release` → Run workflow → set "Use workflow from" to `v5`** → leave **Dry run** checked to preview the plan, then uncheck it to publish `keyv@5.6.1` and `@keyv/sqlite@4.1.0` via OIDC trusted publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fTuBdDBUJyQTRe1qQWjPh

---
_Generated by [Claude Code](https://claude.ai/code/session_017fTuBdDBUJyQTRe1qQWjPh)_