### PR TITLE
keyv - feat: warn when removed v5 serialize/deserialize options are passed

### DIFF
--- a/core/keyv/src/keyv.ts
+++ b/core/keyv/src/keyv.ts
@@ -27,6 +27,7 @@ import {
 	calculateExpires,
 	deleteExpiredKeys,
 	deprecatedHookAliases,
+	deprecatedOptionMessages,
 	isDataExpired,
 	resolveTtl,
 	ttlFromExpires,
@@ -63,6 +64,7 @@ export class Keyv<GenericValue = any> extends Hookified {
 		});
 
 		this.deprecatedHooks = buildDeprecatedHooks();
+		this.warnDeprecatedOptions(mergedOptions);
 		this._compression = mergedOptions.compression;
 		this._encryption = mergedOptions.encryption;
 		this.initSerialization(mergedOptions);
@@ -1201,6 +1203,22 @@ export class Keyv<GenericValue = any> extends Hookified {
 		}
 
 		return merged;
+	}
+
+	/**
+	 * Warns about constructor options that were removed in Keyv v6 (see
+	 * {@link deprecatedOptionMessages}). Without this, passing a removed option such as the
+	 * old `serialize`/`deserialize` is silently ignored, which looks like the option simply
+	 * "not working" rather than no longer existing. A `console.warn` is used because at
+	 * construction time no `warn` event listener can have been attached yet.
+	 */
+	private warnDeprecatedOptions(options: KeyvOptions): void {
+		const record = options as Record<string, unknown>;
+		for (const [option, message] of deprecatedOptionMessages) {
+			if (record[option] !== undefined) {
+				console.warn(`[keyv] ${message}`);
+			}
+		}
 	}
 
 	/**

--- a/core/keyv/src/keyv.ts
+++ b/core/keyv/src/keyv.ts
@@ -1213,6 +1213,13 @@ export class Keyv<GenericValue = any> extends Hookified {
 	 * construction time no `warn` event listener can have been attached yet.
 	 */
 	private warnDeprecatedOptions(options: KeyvOptions): void {
+		// A deprecation notice must never break construction, so bail out in restricted
+		// runtimes (sandboxes, minimal embedded engines) where `console` or `console.warn`
+		// may be stripped or undefined.
+		if (typeof console === "undefined" || typeof console.warn !== "function") {
+			return;
+		}
+
 		const record = options as Record<string, unknown>;
 		for (const [option, message] of deprecatedOptionMessages) {
 			if (record[option] !== undefined) {

--- a/core/keyv/src/utils.ts
+++ b/core/keyv/src/utils.ts
@@ -135,3 +135,22 @@ export function buildDeprecatedHooks(): Map<string, string> {
 		["postDeleteMany", "Use KeyvHooks.AFTER_DELETE_MANY ('after:deleteMany') instead"],
 	]);
 }
+
+/**
+ * Constructor options that were removed in Keyv v6, mapped to migration guidance.
+ * These are surfaced as a console warning at construction so that passing one is no
+ * longer a silent no-op. The old `serialize`/`deserialize` functions were replaced by
+ * a single `serialization` adapter exposing `stringify`/`parse`; because the built-in
+ * serializer already behaves like `JSON.stringify`/`JSON.parse`, a dropped `serialize`
+ * option produces identical output and looks like it "isn't working".
+ */
+export const deprecatedOptionMessages = new Map<string, string>([
+	[
+		"serialize",
+		"The 'serialize' option was removed in Keyv v6 and is being ignored. Use the 'serialization' option instead (an adapter with 'stringify' and 'parse' methods, e.g. KeyvJsonSerializer).",
+	],
+	[
+		"deserialize",
+		"The 'deserialize' option was removed in Keyv v6 and is being ignored. Use the 'serialization' option instead (an adapter with 'stringify' and 'parse' methods, e.g. KeyvJsonSerializer).",
+	],
+]);

--- a/core/keyv/test/keyv.test.ts
+++ b/core/keyv/test/keyv.test.ts
@@ -1,6 +1,11 @@
 import { faker } from "@faker-js/faker";
-import { beforeEach, describe, expect, test, vi } from "vitest";
-import Keyv, { KeyvBridgeAdapter, KeyvMemoryAdapter, KeyvSanitize } from "../src/index.js";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import Keyv, {
+	KeyvBridgeAdapter,
+	KeyvMemoryAdapter,
+	type KeyvOptions,
+	KeyvSanitize,
+} from "../src/index.js";
 import { KeyvStats } from "../src/stats.js";
 import { createMockCompression, createStore, delay } from "./test-utils.js";
 
@@ -218,6 +223,68 @@ describe("serialization", () => {
 			},
 		});
 		expect(await keyv3.decode("anything")).toBeUndefined();
+	});
+});
+
+describe("deprecated options", () => {
+	let warnSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		warnSpy.mockRestore();
+	});
+
+	test("warns when the removed 'serialize' option is passed but still round-trips", async () => {
+		const store = new Map();
+		const keyv = new Keyv({ store, serialize: JSON.stringify } as unknown as KeyvOptions);
+
+		expect(warnSpy).toHaveBeenCalledTimes(1);
+		const message = String(warnSpy.mock.calls[0][0]);
+		expect(message).toContain("serialize");
+		expect(message).toContain("serialization");
+
+		// The removed option is ignored, but the built-in serializer keeps get/set working.
+		await keyv.set("foo", { a: 1 });
+		expect(await keyv.get("foo")).toStrictEqual({ a: 1 });
+	});
+
+	test("warns when the removed 'deserialize' option is passed", () => {
+		// eslint-disable-next-line no-new
+		new Keyv({ deserialize: JSON.parse } as unknown as KeyvOptions);
+
+		expect(warnSpy).toHaveBeenCalledTimes(1);
+		expect(String(warnSpy.mock.calls[0][0])).toContain("deserialize");
+	});
+
+	test("warns once per removed option when several are passed together", () => {
+		// eslint-disable-next-line no-new
+		new Keyv({
+			serialize: JSON.stringify,
+			deserialize: JSON.parse,
+		} as unknown as KeyvOptions);
+
+		expect(warnSpy).toHaveBeenCalledTimes(2);
+	});
+
+	test("does not warn for supported options or the v6 'serialization' adapter", () => {
+		const serialization = {
+			stringify: (data: unknown) => JSON.stringify(data),
+			parse: <T>(data: string) => JSON.parse(data) as T,
+		};
+		// eslint-disable-next-line no-new
+		new Keyv({ store: new Map(), serialization, ttl: 100 });
+
+		expect(warnSpy).not.toHaveBeenCalled();
+	});
+
+	test("does not warn when a removed option is explicitly undefined", () => {
+		// eslint-disable-next-line no-new
+		new Keyv({ serialize: undefined } as unknown as KeyvOptions);
+
+		expect(warnSpy).not.toHaveBeenCalled();
 	});
 });
 

--- a/core/keyv/test/keyv.test.ts
+++ b/core/keyv/test/keyv.test.ts
@@ -286,6 +286,17 @@ describe("deprecated options", () => {
 
 		expect(warnSpy).not.toHaveBeenCalled();
 	});
+
+	test("does not throw when console.warn is unavailable (restricted runtime)", () => {
+		// Simulate an environment where console.warn has been stripped.
+		const originalWarn = console.warn;
+		(console as { warn?: unknown }).warn = undefined;
+		try {
+			expect(() => new Keyv({ serialize: JSON.stringify } as unknown as KeyvOptions)).not.toThrow();
+		} finally {
+			console.warn = originalWarn;
+		}
+	});
 });
 
 describe("compression", () => {


### PR DESCRIPTION
Closes #2006

**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature — a developer-experience / migration guard for v6.

---

### Background (#2006)

The reporter passed `serialize: JSON.stringify` / `deserialize: JSON.parse` and concluded the options were "not working." Investigating both branches:

- **v5 (5.6.1, stable):** `serialize`/`deserialize` work as designed — they apply to the whole `{ value, expires }` envelope. Because Keyv's built-in serializer is already effectively `JSON.stringify`/`JSON.parse`, passing those produces **byte-identical** output to the default, so it *looks* like nothing happened even though the value round-trips correctly. No bug on v5.
- **main (6.0.0-beta.x):** `serialize`/`deserialize` were replaced by a single `serialization` adapter (`{ stringify, parse }`). The old option names are no longer read anywhere, so passing them is **silently ignored** — the same confusion, but worse, since they now do nothing at all.

This PR addresses the v6 silent-drop, which is the actionable part.

### What changed

- Added `deprecatedOptionMessages` (in `utils.ts`) mapping each removed-in-v6 constructor option (`serialize`, `deserialize`) to migration guidance pointing at `serialization`.
- `Keyv` now calls `warnDeprecatedOptions()` at construction, emitting a `console.warn` for each removed option that was passed.

`console.warn` is used deliberately: at construction time no `warn` event listener can have been attached yet, so an event would be invisible to exactly the users this is meant to help.

### Behavior

```js
new Keyv({ serialize: JSON.stringify, deserialize: JSON.parse });
// [keyv] The 'serialize' option was removed in Keyv v6 and is being ignored.
//        Use the 'serialization' option instead (an adapter with 'stringify'
//        and 'parse' methods, e.g. KeyvJsonSerializer).
// [keyv] The 'deserialize' option was removed ...  (same guidance)
```

- The removed options remain ignored (no behavior change) — values still round-trip via the default serializer.
- Correct v6 usage (`serialization`, or no removed options) produces **no** warning.
- The old `serialize`/`deserialize` keys are intentionally kept out of `KeyvOptions`, so TypeScript users still get a compile-time error; the runtime warning covers JavaScript users.

### Testing

- New `describe("deprecated options")` block in `core/keyv/test/keyv.test.ts`: warns for `serialize`, for `deserialize`, once-per-option when both are passed, still round-trips, and does **not** warn for supported options / the `serialization` adapter / an explicitly `undefined` value.
- Full package suite: **334 passed**, 100% line coverage. Typecheck, Biome, and `tsdown` build all clean.
- Verified end-to-end against the built `dist` with the reporter's exact usage.

> Note: this does not change v5. If you'd like, I can follow up with a docs/migration-guide note clarifying that serialize/deserialize/serialization all operate on the full `{ value, expires }` envelope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ECSy2QkGcUFhTH3n1zZ2zA

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECSy2QkGcUFhTH3n1zZ2zA)_