### PR TITLE
compress-gzip - fix: store compressed values as base64 instead of byte objects

### DIFF
--- a/packages/compress-gzip/src/index.ts
+++ b/packages/compress-gzip/src/index.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "node:buffer";
 import { defaultDeserialize, defaultSerialize } from "@keyv/serialize";
 import { deflate, inflate } from "pako";
 import type { Options, Serialize } from "./types.js";
@@ -12,7 +13,9 @@ export class KeyvGzip {
 	}
 
 	async compress(value: pako.Data | string, options?: Options) {
-		return deflate(value, options || this.opts);
+		// Wrap in a Buffer so serialization stores the compressed bytes as a
+		// compact `:base64:` string instead of an index-keyed byte object.
+		return Buffer.from(deflate(value, options || this.opts));
 	}
 
 	async decompress(value: pako.Data, options?: Options) {

--- a/packages/compress-gzip/test/test.ts
+++ b/packages/compress-gzip/test/test.ts
@@ -1,5 +1,7 @@
+import { Buffer } from "node:buffer";
 import { keyvCompresstionTests } from "@keyv/test-suite";
 import { Keyv } from "keyv";
+import { deflate } from "pako";
 import * as test from "vitest";
 import KeyvGzip from "../src/index.js";
 
@@ -63,4 +65,43 @@ test.it("decompress should not throw error when empty with gzip", async (t) => {
 test.it("should not throw error when empty", async (t) => {
 	const keyv = new Keyv({ store: new Map() });
 	await t.expect(keyv.get("foo")).resolves.not.toThrowError();
+});
+
+// https://github.com/jaredwray/keyv/issues/2007
+test.it(
+	"compress returns a Buffer so compressed data serializes to base64",
+	async (t) => {
+		const gzip = new KeyvGzip();
+		const compressed = await gzip.compress("whatever");
+		t.expect(Buffer.isBuffer(compressed)).toBe(true);
+	},
+);
+
+// https://github.com/jaredwray/keyv/issues/2007
+test.it(
+	"stores compressed values as base64 strings, not byte objects",
+	async (t) => {
+		const map = new Map();
+		const keyv = new Keyv({ store: map, compression: new KeyvGzip() });
+		await keyv.set("foo", "we are doing things");
+
+		const stored = map.get("keyv:foo") as string;
+		t.expect(stored).toContain(":base64:");
+		t.expect(stored).not.toMatch(/"0":\d+,"1":\d+/);
+		t.expect(await keyv.get("foo")).toBe("we are doing things");
+	},
+);
+
+// Data written before the base64 fix was stored as an index-keyed byte
+// object. Reading it back must keep working.
+test.it("decompresses legacy index-keyed byte object data", async (t) => {
+	const legacyCompressed = deflate("legacy value");
+	const legacyJson = JSON.stringify({
+		value: { ...legacyCompressed },
+		expires: null,
+	});
+
+	const gzip = new KeyvGzip();
+	const { value } = await gzip.deserialize(legacyJson);
+	t.expect(value).toBe("legacy value");
 });

--- a/packages/serialize/src/index.ts
+++ b/packages/serialize/src/index.ts
@@ -18,6 +18,12 @@ const _serialize = (data: any, escapeColonStrings: boolean = true): string => {
 		return JSON.stringify(`:base64:${data.toString("base64")}`);
 	}
 
+	// Plain Uint8Array (e.g. output of compression libraries such as pako)
+	// must be stored as base64 too, not as an index-keyed byte object.
+	if (data instanceof Uint8Array) {
+		return JSON.stringify(`:base64:${Buffer.from(data).toString("base64")}`);
+	}
+
 	if (data?.toJSON) {
 		// biome-ignore lint/suspicious/noExplicitAny: allowed
 		data = data.toJSON() as unknown as Record<string, any>;

--- a/packages/serialize/test/test.ts
+++ b/packages/serialize/test/test.ts
@@ -69,6 +69,29 @@ describe("Serialize package tests", () => {
 		expect(result).toBe(expectedResult);
 	});
 
+	it("defaultSerialize converts Uint8Array to base64 JSON string", () => {
+		const bytes = new Uint8Array([1, 2, 3, 250]);
+		const expectedResult = JSON.stringify(
+			`:base64:${Buffer.from(bytes).toString("base64")}`,
+		);
+		const result = defaultSerialize(bytes);
+		expect(result).toBe(expectedResult);
+
+		const deserialized = defaultDeserialize<Buffer>(result);
+		expect(Buffer.isBuffer(deserialized)).toBe(true);
+		expect([...deserialized]).toEqual([1, 2, 3, 250]);
+	});
+
+	it("defaultSerialize converts nested Uint8Array to base64 JSON string", () => {
+		const bytes = new Uint8Array([120, 156, 21, 137]);
+		const serialized = defaultSerialize({ value: bytes, expires: null });
+		expect(serialized).toContain(":base64:");
+		expect(serialized).not.toContain('"0"');
+
+		const deserialized = defaultDeserialize<{ value: Buffer }>(serialized);
+		expect([...deserialized.value]).toEqual([120, 156, 21, 137]);
+	});
+
 	it("serialization toJSON is called on object", () => {
 		const serialized = defaultSerialize({ value: { toJSON: () => "foo" } });
 		const deserialized = defaultDeserialize<{ value: string }>(serialized);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix for #2007 on the v5 line (already resolved on `main`/v6 by the compression pipeline rework).

## Problem

With `@keyv/compress-gzip`, compressed values are stored as index-keyed byte objects instead of base64 strings:

```json
{"value":{"0":120,"1":156,"2":21,...},"expires":1783779081723}
```

Root cause: pako 2.x removed the `to: "string"` option for `deflate`, so `KeyvGzip.compress()` returns a raw `Uint8Array`. `defaultSerialize` in `@keyv/serialize` only base64-encodes `Buffer`, so the `Uint8Array` falls through to the generic object branch. The result is ~9.5 bytes stored per compressed byte — for typical payloads the "compressed" record is **larger than storing the value uncompressed** (63 B string: 98 B plain vs 552 B gzipped; 12.8 KB JSON: 6,103 B stored vs 887 B as base64). `compress-brotli` and `compress-lz4` are unaffected because they return `Buffer`s.

## Fix

- **compress-gzip**: wrap the deflate output in `Buffer.from()` so the serialized record is a compact `:base64:` string, matching brotli/lz4:
  ```json
  {"value":":base64:eJwViVEKwCAMxa7yrv...","expires":1784059919494}
  ```
- **serialize**: `defaultSerialize` now base64-encodes any plain `Uint8Array`, not just `Buffer` — same behavior as v6's json-serializer — so no future adapter can regress this way.

## Backward compatibility

Legacy records written in the index-keyed format still deserialize correctly (pako's `inflate` accepts array-like input; verified end-to-end through `keyv.get()` and locked in with a regression test).

## Tests

- `compress()` returns a `Buffer`
- stored record contains `:base64:` and no index-keyed bytes, and roundtrips
- legacy index-keyed data still decompresses
- `Uint8Array` roundtrip through `defaultSerialize`/`defaultDeserialize` (top-level and nested)

Ran locally: serialize 20/20, compress-gzip 16/16, compress-brotli 18/18, compress-lz4 10/10, keyv 385/387 (2 failures are memcached/MongoDB connection errors in the sandbox — no Docker services; unrelated to this change).

Note: `keyv.set()` with a non-string value + gzip compression throws on v5 (`strm.input.subarray is not a function`) because the core compresses raw values before serialization and pako only accepts strings/typed arrays. That's a separate pre-existing v5 limitation, fixed architecturally in v6 — not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYp44FrYBuexwfv1R6oxu4

---
_Generated by [Claude Code](https://claude.ai/code/session_01TYp44FrYBuexwfv1R6oxu4)_