### PR TITLE
mysql - fix: resolve TypeScript errors

### DIFF
--- a/storage/mysql/src/index.ts
+++ b/storage/mysql/src/index.ts
@@ -445,7 +445,7 @@ export class KeyvMysql extends Hookified implements KeyvStorageAdapter {
 			const sql = `INSERT INTO ${escapeIdentifier(this._table)} (id, value, namespace, expires)
 			VALUES ${placeholders}
 			ON DUPLICATE KEY UPDATE value=VALUES(value), expires=VALUES(expires);`;
-			const upsert = mysql.format(sql, flatValues);
+			const upsert = mysql.format(sql, flatValues as mysql.SqlValue[]);
 			await this.query(upsert);
 			return entries.map(() => true);
 		} catch (error) {
@@ -729,4 +729,4 @@ export const createKeyv = (options?: KeyvMysqlOptions | string) =>
 	new Keyv({ store: new KeyvMysql(options) });
 
 export default KeyvMysql;
-export type { KeyvMysqlOptions } from "./types";
+export type { KeyvMysqlOptions } from "./types.js";


### PR DESCRIPTION
## Summary

- type the flattened `setMany()` values as mysql2 `SqlValue` entries at the formatting boundary
- add the explicit `.js` extension required by NodeNext for the `KeyvMysqlOptions` type re-export

## Why

A strict TypeScript check failed because the unconstrained bulk-entry generic was not assignable to mysql2's formatter input type, and the relative type export omitted the runtime extension required by NodeNext module resolution. The bundler transpiled successfully, which allowed both errors to go unnoticed.

## Impact

This is a type-only compatibility fix. It does not change the generated SQL or runtime adapter behavior.

## Validation

- `tsc -p storage/mysql/tsconfig.json --noEmit`
- strict TypeScript check covering MySQL tests and migration script
- `tsdown --config storage/mysql/tsdown.config.ts`
- `biome check storage/mysql/src/index.ts`
- MySQL integration suite: 118 tests passed