### PR TITLE
docs: add keyv-s3fifo to third-party storage adapters

### DIFF
--- a/website/site/docs/third-party-storage-adapters.md
+++ b/website/site/docs/third-party-storage-adapters.md
@@ -28,6 +28,7 @@ Any storage adapter that follows the `KeyvStoreAdapter` interface will work seam
 | [keyv-momento](https://github.com/momentohq/node-keyv-adaptor/) | Momento storage adapter for Keyv |
 | [keyv-mssql](https://github.com/pmorgan3/keyv-mssql) | Microsoft SQL Server adapter for Keyv |
 | [keyv-null](https://www.npmjs.com/package/keyv-null) | Null storage adapter for Keyv |
+| [keyv-s3fifo](https://github.com/BJS-kr/fast-s3-fifo-cache) | S3-FIFO storage adapter for Keyv |
 | [keyv-upstash](https://github.com/mahdavipanah/keyv-upstash) | Upstash Redis adapter for Keyv |
 | [quick-lru](https://github.com/sindresorhus/quick-lru) | Simple "Least Recently Used" (LRU) cache |
 


### PR DESCRIPTION
Adds `keyv-s3fifo` to the Third-Party Storage Adapters documentation table.
- **npm**: https://www.npmjs.com/package/keyv-s3fifo
- **Repository**: https://github.com/BJS-kr/fast-s3-fifo-cache