### PR TITLE
mono - chore: upgrade pnpm to 11.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "Jared Wray <me@jaredwray.com>",
   "license": "MIT",
   "private": true,
-  "packageManager": "pnpm@11.5.3+sha512.7ac1c919341c213a34dc0d02afb7143c5c26ac26ee8c4782deea821b8ac64d2134a081fd8941dae6e29bbb48f58dfc2b7fbceeccc07cb2f09d219d342a4969ed",
+  "packageManager": "pnpm@11.18.0+sha512.33d83c77da82f49fba836925c6f1b841181ec3132b670639bd012f7075f5c7cf634c5f870147c19aae7478fac01df09d8892e880454896edd23ee9b33757563c",
   "engines": {
     "node": ">= 22.18.0"
   },


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [ ] Tests for the changes have been added (for bug fixes/features) with 100% code coverage. — n/a, package-manager bump with no source changes.

**What kind of change does this PR introduce?**

Chore — dependency upgrade. Third PR in the dev phase, covering package-manager/monorepo tooling. Follows #2021 and #2022.

## Summary

Bumps the pinned package manager from **pnpm 11.5.3 → 11.18.0** (same major). One-line change to `packageManager`.

## Changes

- `packageManager`: `pnpm@11.5.3` → `pnpm@11.18.0`, applied via `corepack use pnpm@11.18.0` so the `+sha512.…` integrity hash is regenerated rather than hand-edited.

`packageManager` is the single source of truth for the pnpm version here — every workflow uses `pnpm/action-setup@v6` with no `version:` input, so CI picks this up automatically and no workflow edits are needed. `pnpm-lock.yaml` is unchanged; 11.18.0 reported the existing lockfile as already up to date.

Worth noting: 11.18.0 runs a supply-chain policy check over the lockfile that 11.5.3 did not. It passes cleanly here — *"✓ Lockfile passes supply-chain policies (948 entries)"* — so expect that new line in CI install logs.

## Verification

- [x] `pnpm install --frozen-lockfile` on 11.18.0 — lockfile already up to date, no drift
- [x] `pnpm build` — all 20 packages build clean (40 build targets)
- [x] `pnpm test` for the 12 packages that don't need Docker services — 894 tests passed, 4 todo
- [x] `pnpm test:scripts` — 20 tests passed
- [x] `pnpm --version` → 11.18.0 confirmed active for all of the above
- [ ] Docker-backed adapter suites — **not run locally** (no Docker in this sandbox); CI covers those

---
_Generated by [Claude Code](https://claude.ai/code/session_01EhFhwXMXeG5bRV8gV61WL3)_