### PR TITLE
mono - chore: upgrade GitHub Actions (breaking)

### DIFF
--- a/.github/workflows/browser-compat.yaml
+++ b/.github/workflows/browser-compat.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: pnpm/action-setup@v6
 
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: '24'
 

--- a/.github/workflows/bun-test.yaml
+++ b/.github/workflows/bun-test.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: pnpm/action-setup@v6
 
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: '24'
 

--- a/.github/workflows/cloudflare-keyv-integration.yaml
+++ b/.github/workflows/cloudflare-keyv-integration.yaml
@@ -37,7 +37,7 @@ jobs:
         uses: pnpm/action-setup@v6
 
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: "24"
 

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: pnpm/action-setup@v6
 
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 24
 

--- a/.github/workflows/deploy-website.yaml
+++ b/.github/workflows/deploy-website.yaml
@@ -22,7 +22,7 @@ jobs:
       uses: pnpm/action-setup@v6
 
     - name: Use Node.js 24
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@v7
       with:
         node-version: 24
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,7 @@ jobs:
         uses: pnpm/action-setup@v6
 
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: '24'
 
@@ -49,7 +49,7 @@ jobs:
         uses: pnpm/action-setup@v6
 
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: '24'
 
@@ -93,7 +93,7 @@ jobs:
         uses: pnpm/action-setup@v6
 
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -26,7 +26,7 @@ jobs:
         uses: pnpm/action-setup@v6
 
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node }}
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [ ] Tests for the changes have been added (for bug fixes/features) with 100% code coverage. — n/a, CI configuration change with no source changes.

**What kind of change does this PR introduce?**

Chore — CI dependency upgrade. Fourth and final dev-phase PR. Follows #2021, #2022, #2023.

## Summary

Upgrades `actions/setup-node` **v6 → v7** across all 9 references. The other five actions in this repo are already at their latest major and are untouched.

## Changes

- `actions/setup-node@v6` → `@v7` — 9 references across 7 workflow files

Already current, verified against each action's tags and left unchanged:

| Action | Pinned | Latest major |
|---|---|---|
| `actions/checkout` | v7 | v7 ✅ |
| `pnpm/action-setup` | v6 | v6 ✅ |
| `codecov/codecov-action` | v7 | v7 ✅ |
| `oven-sh/setup-bun` | v2 | v2 ✅ |
| `cloudflare/wrangler-action` | v4 | v4 ✅ |

Existing major-only pin style (`@vX`) is preserved throughout — no switch to SHA or patch pins.

## Verification

- [x] All 7 workflow files parse as valid YAML after the edit (checked with `js-yaml`; job/step counts unchanged: 9 `setup-node` steps before and after)
- [x] Latest majors confirmed via `git ls-remote --tags` against each action repository
- [x] `actions/setup-node@v7.0.0` confirmed a stable release, not a pre-release

## Breaking notes

`actions/setup-node` crosses a major. The v7.0.0 notes are terse, but one change is worth your attention because **PR CI cannot exercise it**:

> Removed dummy `NODE_AUTH_TOKEN` export

I read `src/authutil.ts` at the `v7.0.0` tag to pin down the actual behavior:

- Both v6 and v7 write the same placeholder line into `.npmrc`: `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}`
- v6 additionally exported a **dummy** `NODE_AUTH_TOKEN` when the user hadn't set one. v7 exports it **only if already present** in the environment.

This matters for the `publish` job in `release.yaml`, which sets `registry-url` but deliberately sets no token — the step is commented *"Uses OIDC only — no token."* Under v6 that job ran with a garbage token expanded into `.npmrc`; under v7 the placeholder expands to empty instead.

My read is this is **neutral-to-favorable for OIDC trusted publishing** — npm treats an empty `_authToken` as no credential and proceeds to the OIDC exchange, whereas a bogus token is the kind of thing that earns a 401. But that path only runs on a real `release` event, so nothing in this PR's checks proves it. Flagging it explicitly so the first release after this merge gets a look rather than a surprise. If you'd rather de-risk it, the `publish` job's `setup-node` could stay on v6 independently.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EhFhwXMXeG5bRV8gV61WL3)_