### PR TITLE
redis - chore: upgrade @redis/client to 6.1.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -527,8 +527,8 @@ importers:
   storage/redis:
     dependencies:
       '@redis/client':
-        specifier: ^6.0.1
-        version: 6.0.1(@opentelemetry/api@1.9.1)
+        specifier: ^6.1.0
+        version: 6.1.0(@opentelemetry/api@1.9.1)
       cluster-key-slot:
         specifier: ^1.1.2
         version: 1.1.2
@@ -1585,8 +1585,8 @@ packages:
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
 
-  '@redis/client@6.0.1':
-    resolution: {integrity: sha512-SwYl64hKHE/NeO2VSSG1y/4zIm0cNepyOZtQrOpLiNRHmH2FdWBOecNzsLiXCQdFCF9MCyoPXwAbaG2iMO0A7Q==}
+  '@redis/client@6.1.0':
+    resolution: {integrity: sha512-7u1LefkezJF0HESlhO7ZFLEPfyY+NejP3SGv+Z4pGaT3oM5GVVLa0u3f4rDLUrcw+SRo8IlX9Y8JAONeDdg1Ag==}
     engines: {node: '>= 20.0.0'}
     peerDependencies:
       '@node-rs/xxhash': ^1.1.0
@@ -5475,7 +5475,7 @@ snapshots:
     dependencies:
       quansync: 1.0.0
 
-  '@redis/client@6.0.1(@opentelemetry/api@1.9.1)':
+  '@redis/client@6.1.0(@opentelemetry/api@1.9.1)':
     dependencies:
       cluster-key-slot: 1.1.2
     optionalDependencies:

--- a/storage/redis/package.json
+++ b/storage/redis/package.json
@@ -49,7 +49,7 @@
 	},
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
-		"@redis/client": "^6.0.1",
+		"@redis/client": "^6.1.0",
 		"cluster-key-slot": "^1.1.2",
 		"hookified": "^3.0.1"
 	},


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [ ] Tests for the changes have been added (for bug fixes/features) with 100% code coverage. — n/a, dependency bump with no source changes.

**What kind of change does this PR introduce?**

Chore — dependency upgrade. Runtime phase, database drivers. Follows #2025.

## Summary

Upgrades the Redis client used by `@keyv/redis` by one minor.

## Changes

- `@redis/client` 6.0.1 → 6.1.0 — `@keyv/redis`, the only package in the workspace that depends on it

The exact `Latest` value from `pnpm outdated`, so the workspace `minimumReleaseAge` gate (4 days) is respected.

## Verification

- [x] `pnpm build` — full workspace builds clean (40 targets), including `@keyv/redis` CJS + ESM + `.d.ts`
- [x] `biome check --error-on-warnings` clean for `@keyv/redis` (17 files)
- [ ] `@keyv/redis` test suite — **not run locally.** The suite needs live Redis (standalone, plus the cluster and sentinel compose stacks), and this sandbox has no Docker daemon. CI runs these with services started.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EhFhwXMXeG5bRV8gV61WL3)_