### PR TITLE
mysql - chore: upgrade mysql2 to 3.23.2

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -456,8 +456,8 @@ importers:
         specifier: ^3.0.1
         version: 3.0.1
       mysql2:
-        specifier: ^3.22.5
-        version: 3.22.5(@types/node@24.13.1)
+        specifier: ^3.23.2
+        version: 3.23.2(@types/node@24.13.1)
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.5.6
@@ -3673,8 +3673,8 @@ packages:
   msgpackr@2.0.4:
     resolution: {integrity: sha512-o1C5KRmuRt+apqMr1HuGSqWStZoRBUpEsCsl15uM9VdAF1qHLtvMOU2En747EnTyEl6c4pzPewRMFF31s1CNbA==}
 
-  mysql2@3.22.5:
-    resolution: {integrity: sha512-95uZ2TrPWAZdwpB3vvvDbmEMcNG8yIeNCyu6GUcr/QnWEE/wXm7+mhOCsdQfWQDTV7qYT/PDUZ4U4UPP4AsXqQ==}
+  mysql2@3.23.2:
+    resolution: {integrity: sha512-fxh3HpQ8vJtu/Mmnd4Xsur19jGjHGzRLMxptiDtOkbX7EVBgnafGSGDx1WGGVmJLClVh2LeeBMMo24IFv8wCyQ==}
     engines: {node: '>= 8.0'}
     peerDependencies:
       '@types/node': ^24.13.1
@@ -4195,8 +4195,8 @@ packages:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
 
-  sql-escaper@1.3.3:
-    resolution: {integrity: sha512-BsTCV265VpTp8tm1wyIm1xqQCS+Q9NHx2Sr+WcnUrgLrQ6yiDIvHYJV5gHxsj1lMBy2zm5twLaZao8Jd+S8JJw==}
+  sql-escaper@1.5.1:
+    resolution: {integrity: sha512-4toX5E1fQbBrpfXidaHnF0669nkAdETeIPTs2SUjxxD7RRIs9ICG4gtpmfc68JCEKehsdwLFqBu9VlQqZ1P1gg==}
     engines: {bun: '>=1.0.0', deno: '>=2.0.0', node: '>=12.0.0'}
 
   stackback@0.0.2:
@@ -7637,7 +7637,7 @@ snapshots:
     optionalDependencies:
       msgpackr-extract: 3.0.4
 
-  mysql2@3.22.5(@types/node@24.13.1):
+  mysql2@3.23.2(@types/node@24.13.1):
     dependencies:
       '@types/node': 24.13.1
       aws-ssl-profiles: 1.1.2
@@ -7647,7 +7647,7 @@ snapshots:
       long: 5.3.2
       lru.min: 1.1.4
       named-placeholders: 1.1.6
-      sql-escaper: 1.3.3
+      sql-escaper: 1.5.1
 
   named-placeholders@1.1.6:
     dependencies:
@@ -8333,7 +8333,7 @@ snapshots:
 
   split2@4.2.0: {}
 
-  sql-escaper@1.3.3: {}
+  sql-escaper@1.5.1: {}
 
   stackback@0.0.2: {}
 

--- a/storage/mysql/package.json
+++ b/storage/mysql/package.json
@@ -52,7 +52,7 @@
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
 		"hookified": "^3.0.1",
-		"mysql2": "^3.22.5"
+		"mysql2": "^3.23.2"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.5.6",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [ ] Tests for the changes have been added (for bug fixes/features) with 100% code coverage. — n/a, dependency bump with no source changes.

**What kind of change does this PR introduce?**

Chore — dependency upgrade. Runtime phase, database drivers. Follows #2027.

## Summary

Upgrades the MySQL driver used by `@keyv/mysql`.

## Changes

- `mysql2` 3.22.5 → 3.23.2 — `@keyv/mysql`, the only package in the workspace that depends on it

The exact `Latest` value from `pnpm outdated`, so the workspace `minimumReleaseAge` gate (4 days) is respected.

## Verification

- [x] `pnpm build` — full workspace builds clean (40 targets), including `@keyv/mysql` CJS + ESM + `.d.ts`
- [x] `biome check --error-on-warnings` clean for `@keyv/mysql`
- [ ] `@keyv/mysql` test suite — **not run locally.** The suite needs a live MySQL from `scripts/docker-compose.yaml`, and this sandbox has no Docker daemon. CI runs these with services started.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EhFhwXMXeG5bRV8gV61WL3)_