### PR TITLE
valkey - chore: upgrade iovalkey to 0.4.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -583,8 +583,8 @@ importers:
         specifier: ^3.0.1
         version: 3.0.1
       iovalkey:
-        specifier: ^0.3.3
-        version: 0.3.3(supports-color@10.2.2)
+        specifier: ^0.4.0
+        version: 0.4.0(supports-color@10.2.2)
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.5.6
@@ -3138,8 +3138,8 @@ packages:
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
 
-  iovalkey@0.3.3:
-    resolution: {integrity: sha512-4rTJX6Q5wTYEvxboXi8DsEiUo+OvqJGtLYOSGm37KpdRXsG5XJjbVtYKGJpPSWP+QT7rWscA4vsrdmzbEbenpw==}
+  iovalkey@0.4.0:
+    resolution: {integrity: sha512-OSUKxJ+s44CLdUTaicX4+pVrBN/zHKIYwr2oKhRDuczr19FwcSCXEZHzcMUYWZNh1mNSCV9bNJHW/T6cHVm9Aw==}
     engines: {node: '>=18.12.0'}
 
   ipaddr.js@2.4.0:
@@ -6818,7 +6818,7 @@ snapshots:
 
   inline-style-parser@0.2.7: {}
 
-  iovalkey@0.3.3(supports-color@10.2.2):
+  iovalkey@0.4.0(supports-color@10.2.2):
     dependencies:
       '@iovalkey/commands': 0.1.0
       cluster-key-slot: 1.1.2

--- a/storage/valkey/package.json
+++ b/storage/valkey/package.json
@@ -55,7 +55,7 @@
 	"dependencies": {
 		"cluster-key-slot": "^1.1.0",
 		"hookified": "^3.0.1",
-		"iovalkey": "^0.3.3"
+		"iovalkey": "^0.4.0"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.5.6",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [ ] Tests for the changes have been added (for bug fixes/features) with 100% code coverage. — n/a, dependency bump with no source changes.

**What kind of change does this PR introduce?**

Chore — dependency upgrade. Runtime phase, database drivers. Follows #2028.

## Summary

Upgrades the Valkey client used by `@keyv/valkey` from 0.3.3 to 0.4.0.

## Changes

- `iovalkey` 0.3.3 → 0.4.0 — `@keyv/valkey`, the only package in the workspace that depends on it

The exact `Latest` value from `pnpm outdated`, so the workspace `minimumReleaseAge` gate (4 days) is respected. 0.3.3 dated 2025-06-12; 0.4.0 was published 2026-07-27.

## Notes — pre-1.0 minor, so worth a closer look than the others

`iovalkey` is pre-1.0, where a minor bump is allowed to break. I read the v0.4.0 release notes rather than assuming it was routine. Nothing the adapter depends on was removed or renamed — it imports only the default export, `Cluster`, and `RedisOptions` (`src/index.ts:3`, `src/types.ts:1`), and all three still resolve (the `.d.ts` build succeeds).

The one change that touches this adapter's code path: **0.4.0 adds `valkey://` URL scheme support and replaces the deprecated URL parser.** `KeyvValkey` builds its client with `new Redis(options.uri!, options)` (`src/index.ts:100`) when given a URI string, so URL parsing is exactly the surface that moved. Adding a scheme is additive and `redis://` should be unaffected, but the parser swap is where a regression would show up if there is one.

That path is directly exercised by CI: the valkey suite connects via `redis://localhost:6370` against the `valkey/valkey` container, so a `redis://` parsing regression would fail the run rather than slip through.

Other 0.4.0 changes are additive or internal: a `Valkey` constructor added to exports, `RedisOptions.familyFallback` for IPv4/IPv6, command-rewriting in the argument transformer, and cluster recovery/replica-retry fixes.

## Verification

- [x] `pnpm build` — full workspace builds clean (40 targets), including `@keyv/valkey` CJS + ESM + `.d.ts`
- [x] `biome check --error-on-warnings` clean for `@keyv/valkey` (12 files)
- [x] Confirmed the adapter's imported symbols still exist in 0.4.0
- [ ] `@keyv/valkey` test suite — **not run locally.** Needs the live `valkey/valkey` container; this sandbox has no Docker daemon. CI runs it with services started, and it covers the URI path noted above.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EhFhwXMXeG5bRV8gV61WL3)_