### PR TITLE
mono - chore: upgrade hookified to 3.0.2

### DIFF
--- a/core/bigmap/package.json
+++ b/core/bigmap/package.json
@@ -49,7 +49,7 @@
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
 		"hashery": "^3.0.0",
-		"hookified": "^3.0.1"
+		"hookified": "^3.0.2"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.5.6",

--- a/core/keyv/package.json
+++ b/core/keyv/package.json
@@ -59,7 +59,7 @@
 	},
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
-		"hookified": "^3.0.1"
+		"hookified": "^3.0.2"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.5.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,8 +126,8 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       hookified:
-        specifier: ^3.0.1
-        version: 3.0.1
+        specifier: ^3.0.2
+        version: 3.0.2
       keyv:
         specifier: workspace:^
         version: link:../keyv
@@ -163,8 +163,8 @@ importers:
   core/keyv:
     dependencies:
       hookified:
-        specifier: ^3.0.1
-        version: 3.0.1
+        specifier: ^3.0.2
+        version: 3.0.2
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.5.6
@@ -352,8 +352,8 @@ importers:
   storage/cloudflare-kv:
     dependencies:
       hookified:
-        specifier: ^3.0.1
-        version: 3.0.1
+        specifier: ^3.0.2
+        version: 3.0.2
       keyv:
         specifier: workspace:^
         version: link:../../core/keyv
@@ -374,8 +374,8 @@ importers:
         specifier: ^3.1097.0
         version: 3.1097.0(@aws-sdk/client-dynamodb@3.1097.0)
       hookified:
-        specifier: ^3.0.1
-        version: 3.0.1
+        specifier: ^3.0.2
+        version: 3.0.2
       keyv:
         specifier: workspace:^
         version: link:../../core/keyv
@@ -387,8 +387,8 @@ importers:
   storage/etcd:
     dependencies:
       hookified:
-        specifier: ^3.0.1
-        version: 3.0.1
+        specifier: ^3.0.2
+        version: 3.0.2
       keyv:
         specifier: workspace:^
         version: link:../../core/keyv
@@ -400,8 +400,8 @@ importers:
   storage/memcache:
     dependencies:
       hookified:
-        specifier: ^3.0.1
-        version: 3.0.1
+        specifier: ^3.0.2
+        version: 3.0.2
       keyv:
         specifier: workspace:^
         version: link:../../core/keyv
@@ -419,8 +419,8 @@ importers:
   storage/mongo:
     dependencies:
       hookified:
-        specifier: ^3.0.1
-        version: 3.0.1
+        specifier: ^3.0.2
+        version: 3.0.2
       keyv:
         specifier: workspace:^
         version: link:../../core/keyv
@@ -453,8 +453,8 @@ importers:
   storage/mysql:
     dependencies:
       hookified:
-        specifier: ^3.0.1
-        version: 3.0.1
+        specifier: ^3.0.2
+        version: 3.0.2
       mysql2:
         specifier: ^3.23.2
         version: 3.23.2(@types/node@24.13.1)
@@ -490,8 +490,8 @@ importers:
   storage/postgres:
     dependencies:
       hookified:
-        specifier: ^3.0.1
-        version: 3.0.1
+        specifier: ^3.0.2
+        version: 3.0.2
       keyv:
         specifier: workspace:^
         version: link:../../core/keyv
@@ -533,8 +533,8 @@ importers:
         specifier: ^1.1.2
         version: 1.1.2
       hookified:
-        specifier: ^3.0.1
-        version: 3.0.1
+        specifier: ^3.0.2
+        version: 3.0.2
       keyv:
         specifier: workspace:^
         version: link:../../core/keyv
@@ -552,8 +552,8 @@ importers:
         specifier: ^13.0.2
         version: 13.0.2
       hookified:
-        specifier: ^3.0.1
-        version: 3.0.1
+        specifier: ^3.0.2
+        version: 3.0.2
       keyv:
         specifier: workspace:^
         version: link:../../core/keyv
@@ -580,8 +580,8 @@ importers:
         specifier: ^1.1.0
         version: 1.1.2
       hookified:
-        specifier: ^3.0.1
-        version: 3.0.1
+        specifier: ^3.0.2
+        version: 3.0.2
       iovalkey:
         specifier: ^0.4.0
         version: 0.4.0(supports-color@10.2.2)
@@ -3031,8 +3031,8 @@ packages:
   hookified@2.2.0:
     resolution: {integrity: sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==}
 
-  hookified@3.0.1:
-    resolution: {integrity: sha512-mtpUIV7U9reosQ16+OHWBd0Ca07fs1ryChQjBPuUMZnrRdLTCW+kEfkTcFudkaevp3gVe5H9FxDCBxYIdO+QQA==}
+  hookified@3.0.2:
+    resolution: {integrity: sha512-FpIcRHpFlW7yh68lmL0h1/Vodv77TogpHlt4qqakE/0RyQMjgNxs53acH9NJPeyRZutP7GnlqiyqRNejV8/lHQ==}
     engines: {node: '>=22.18.0'}
 
   hosted-git-info@2.8.9:
@@ -6505,7 +6505,7 @@ snapshots:
 
   hashery@3.0.0:
     dependencies:
-      hookified: 3.0.1
+      hookified: 3.0.2
 
   hasown@2.0.2:
     dependencies:
@@ -6627,7 +6627,7 @@ snapshots:
 
   hookified@2.2.0: {}
 
-  hookified@3.0.1: {}
+  hookified@3.0.2: {}
 
   hosted-git-info@2.8.9: {}
 
@@ -7117,7 +7117,7 @@ snapshots:
   memcache@1.9.0:
     dependencies:
       hashery: 3.0.0
-      hookified: 3.0.1
+      hookified: 3.0.2
 
   memory-pager@1.5.0: {}
 

--- a/storage/cloudflare-kv/package.json
+++ b/storage/cloudflare-kv/package.json
@@ -54,7 +54,7 @@
   },
   "homepage": "https://github.com/jaredwray/keyv",
   "dependencies": {
-    "hookified": "^3.0.1"
+    "hookified": "^3.0.2"
   },
   "devDependencies": {
     "@keyv/test-suite": "workspace:^",

--- a/storage/dynamo/package.json
+++ b/storage/dynamo/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.1097.0",
     "@aws-sdk/lib-dynamodb": "^3.1097.0",
-    "hookified": "^3.0.1"
+    "hookified": "^3.0.2"
   },
   "devDependencies": {
     "@keyv/test-suite": "workspace:^"

--- a/storage/etcd/package.json
+++ b/storage/etcd/package.json
@@ -49,7 +49,7 @@
 	},
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
-		"hookified": "^3.0.1"
+		"hookified": "^3.0.2"
 	},
 	"devDependencies": {
 		"@keyv/test-suite": "workspace:^"

--- a/storage/memcache/package.json
+++ b/storage/memcache/package.json
@@ -49,7 +49,7 @@
 	},
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
-		"hookified": "^3.0.1",
+		"hookified": "^3.0.2",
 		"memcache": "^1.9.0"
 	},
 	"peerDependencies": {

--- a/storage/mongo/package.json
+++ b/storage/mongo/package.json
@@ -50,7 +50,7 @@
 	},
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
-		"hookified": "^3.0.1",
+		"hookified": "^3.0.2",
 		"mongodb": "^7.5.0"
 	},
 	"devDependencies": {

--- a/storage/mysql/package.json
+++ b/storage/mysql/package.json
@@ -51,7 +51,7 @@
 	},
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
-		"hookified": "^3.0.1",
+		"hookified": "^3.0.2",
 		"mysql2": "^3.23.2"
 	},
 	"devDependencies": {

--- a/storage/postgres/package.json
+++ b/storage/postgres/package.json
@@ -51,7 +51,7 @@
 	},
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
-		"hookified": "^3.0.1",
+		"hookified": "^3.0.2",
 		"pg": "^8.22.0"
 	},
 	"peerDependencies": {

--- a/storage/redis/package.json
+++ b/storage/redis/package.json
@@ -51,7 +51,7 @@
 	"dependencies": {
 		"@redis/client": "^6.1.0",
 		"cluster-key-slot": "^1.1.2",
-		"hookified": "^3.0.1"
+		"hookified": "^3.0.2"
 	},
 	"peerDependencies": {
 		"keyv": "workspace:^"

--- a/storage/sqlite/package.json
+++ b/storage/sqlite/package.json
@@ -53,7 +53,7 @@
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
 		"better-sqlite3": "^13.0.2",
-		"hookified": "^3.0.1"
+		"hookified": "^3.0.2"
 	},
 	"peerDependencies": {
 		"keyv": "workspace:^"

--- a/storage/valkey/package.json
+++ b/storage/valkey/package.json
@@ -54,7 +54,7 @@
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
 		"cluster-key-slot": "^1.1.0",
-		"hookified": "^3.0.1",
+		"hookified": "^3.0.2",
 		"iovalkey": "^0.4.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [ ] Tests for the changes have been added (for bug fixes/features) with 100% code coverage. — n/a, dependency bump with no source changes.

**What kind of change does this PR introduce?**

Chore — dependency upgrade. Runtime phase, standalone deps. Follows #2032.

## Summary

Bumps `hookified` a patch (3.0.1 → 3.0.2) uniformly across every package that depends on it. `hookified` is the shared event/hooks base class, so all 12 consumers move together to keep the resolved version single.

## Changes

- `hookified` 3.0.1 → 3.0.2 — 12 packages: `keyv`, `@keyv/bigmap`, and the 10 storage adapters (`cloudflare-kv`, `dynamo`, `etcd`, `memcache`, `mongo`, `mysql`, `postgres`, `redis`, `sqlite`, `valkey`)

The exact `Latest` value from `pnpm outdated`, so the workspace `minimumReleaseAge` gate (4 days) is respected.

## Verification

- [x] `pnpm build` — full workspace builds clean (40 targets)
- [x] `pnpm test` for the 4 packages that don't need Docker services — **686 tests passed**, 4 todo (`keyv` 333, `@keyv/bigmap` 54, `@keyv/sqlite` 149, `@keyv/cloudflare-kv` 154). `keyv` and `bigmap` exercise hookified's hook/event machinery directly.
- [ ] Docker-backed adapter suites (dynamo, etcd, memcache, mongo, mysql, postgres, redis, valkey) — **not run locally**; no Docker in this sandbox. CI runs these with services started.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EhFhwXMXeG5bRV8gV61WL3)_