### PR TITLE
bigmap - chore: upgrade hashery to 3.0.1

### DIFF
--- a/core/bigmap/package.json
+++ b/core/bigmap/package.json
@@ -48,7 +48,7 @@
 	},
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
-		"hashery": "^3.0.0",
+		"hashery": "^3.0.1",
 		"hookified": "^3.0.2"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,8 +123,8 @@ importers:
   core/bigmap:
     dependencies:
       hashery:
-        specifier: ^3.0.0
-        version: 3.0.0
+        specifier: ^3.0.1
+        version: 3.0.1
       hookified:
         specifier: ^3.0.2
         version: 3.0.2
@@ -2970,6 +2970,10 @@ packages:
 
   hashery@3.0.0:
     resolution: {integrity: sha512-0Qf1UYWmzQ7IgJbciYmxfbH3TXGR8CJQx7syxue+XptHPXYiEO1lmkYQen2PBWLikgei0kwylMZHoUmP8G96lg==}
+    engines: {node: '>=22.18'}
+
+  hashery@3.0.1:
+    resolution: {integrity: sha512-jfLVt3/SEkJzW/OCSK7Bxdl+FpXYDpEE84QOU4wzKRpO7rNoafNK718Z71GPQR/ozfQmKxXS++MhbrL/eKaTow==}
     engines: {node: '>=22.18'}
 
   hasown@2.0.2:
@@ -6504,6 +6508,10 @@ snapshots:
       hookified: 2.2.0
 
   hashery@3.0.0:
+    dependencies:
+      hookified: 3.0.2
+
+  hashery@3.0.1:
     dependencies:
       hookified: 3.0.2
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [ ] Tests for the changes have been added (for bug fixes/features) with 100% code coverage. — n/a, dependency bump with no source changes.

**What kind of change does this PR introduce?**

Chore — dependency upgrade. Runtime phase, standalone deps. Follows #2033.

## Summary

Bumps `hashery` a patch in `@keyv/bigmap`.

## Changes

- `hashery` 3.0.0 → 3.0.1 — `@keyv/bigmap`, the only package in the workspace that depends on it

The exact `Latest` value from `pnpm outdated`, so the workspace `minimumReleaseAge` gate (4 days) is respected.

## Verification

- [x] `pnpm build` — full workspace builds clean (40 targets)
- [x] `pnpm --filter @keyv/bigmap test` — **54 tests passed**, biome clean (`@keyv/bigmap` is in-memory with no Docker dependency, so its suite runs locally)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EhFhwXMXeG5bRV8gV61WL3)_