### PR TITLE
test-suite - chore: upgrade bignumber.js to 11.1.5

### DIFF
--- a/core/test-suite/package.json
+++ b/core/test-suite/package.json
@@ -57,7 +57,7 @@
 	"dependencies": {
 		"@faker-js/faker": "^10.5.0",
 		"@vitest/coverage-v8": "^4.1.10",
-		"bignumber.js": "^11.1.4",
+		"bignumber.js": "^11.1.5",
 		"json-bigint": "^1.0.0",
 		"timekeeper": "^2.3.1",
 		"vitest": "^4.1.10"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -212,8 +212,8 @@ importers:
         specifier: ^4.1.10
         version: 4.1.10(vitest@4.1.10)
       bignumber.js:
-        specifier: ^11.1.4
-        version: 11.1.4
+        specifier: ^11.1.5
+        version: 11.1.5
       json-bigint:
         specifier: ^1.0.0
         version: 1.0.0
@@ -2472,8 +2472,8 @@ packages:
     resolution: {integrity: sha512-jW6oufeDhXZaiX9Lw5A+oerVClx4iFrI6uDj1zu7SqUAjak9vbJvA0NEcKLNxHiQHb6kYCoFzzXYV0YOauhV3g==}
     engines: {node: '>=22'}
 
-  bignumber.js@11.1.4:
-    resolution: {integrity: sha512-AJ9dSeaUGj2xu7tEwmdqb51dqdb633xo4njI9K8ZFfcLrNr0XN8/EPkkZUNaF9fkCblGt2zVwZymesUdGynEkQ==}
+  bignumber.js@11.1.5:
+    resolution: {integrity: sha512-6WmzCNtUnfKpbozq+hOgWaZMMzORmYBwF1xZScyoIX3QRYWeKTtxxwDOW5tIz7C9BdjkIYHGTcelCLkXg0mndw==}
 
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
@@ -5975,7 +5975,7 @@ snapshots:
     dependencies:
       node-addon-api: 8.9.0
 
-  bignumber.js@11.1.4: {}
+  bignumber.js@11.1.5: {}
 
   bignumber.js@9.3.1: {}
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [ ] Tests for the changes have been added (for bug fixes/features) with 100% code coverage. — n/a, dependency bump with no source changes.

**What kind of change does this PR introduce?**

Chore — dependency upgrade. Runtime phase, standalone deps. Follows #2034.

## Summary

Bumps `bignumber.js` a patch in `@keyv/test-suite`.

## Changes

- `bignumber.js` 11.1.4 → 11.1.5 — `@keyv/test-suite`, the only package in the workspace that depends on it. It backs the big-number value round-trip compliance tests that every storage adapter runs.

The exact `Latest` value from `pnpm outdated`, so the workspace `minimumReleaseAge` gate (4 days) is respected.

## Verification

- [x] `pnpm build` — full workspace builds clean (40 targets), including `@keyv/test-suite` (which the adapters import)
- [x] `pnpm test` for the 3 local consumers of `@keyv/test-suite` — **536 tests passed**, 4 todo (`keyv` 333, `@keyv/bigmap` 54, `@keyv/sqlite` 149); these exercise the compliance suite that uses `bignumber.js`
- [ ] Docker-backed adapter suites — **not run locally**; no Docker in this sandbox. CI runs the full compliance suite against each adapter with services started.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EhFhwXMXeG5bRV8gV61WL3)_