### PR TITLE
mono - chore: upgrade lz4-napi to 2.9.1

### DIFF
--- a/compression/compress-lz4/package.json
+++ b/compression/compress-lz4/package.json
@@ -52,7 +52,7 @@
 	},
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
-		"lz4-napi": "^2.9.0"
+		"lz4-napi": "^2.9.1"
 	},
 	"peerDependencies": {
 		"keyv": "workspace:^"

--- a/core/test-suite/package.json
+++ b/core/test-suite/package.json
@@ -68,7 +68,7 @@
 	"devDependencies": {
 		"@biomejs/biome": "^2.5.6",
 		"@types/json-bigint": "^1.0.4",
-		"lz4-napi": "^2.9.0",
+		"lz4-napi": "^2.9.1",
 		"rimraf": "^6.1.3"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,8 +101,8 @@ importers:
         specifier: workspace:^
         version: link:../../core/keyv
       lz4-napi:
-        specifier: ^2.9.0
-        version: 2.9.0
+        specifier: ^2.9.1
+        version: 2.9.1
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.5.6
@@ -234,8 +234,8 @@ importers:
         specifier: ^1.0.4
         version: 1.0.4
       lz4-napi:
-        specifier: ^2.9.0
-        version: 2.9.0
+        specifier: ^2.9.1
+        version: 2.9.1
       rimraf:
         specifier: ^6.1.3
         version: 6.1.3
@@ -662,84 +662,111 @@ packages:
     resolution: {integrity: sha512-sj9DWTJ2Ze0WR9qsiOPqoqzNx3OxL6iMxHImbhvoe9qOspekbzxNDMiJ4TIGfYHYh9w4OmBjz3prvqhzTi96+Q==}
     engines: {node: '>=18'}
 
-  '@antoniomuso/lz4-napi-android-arm-eabi@2.9.0':
-    resolution: {integrity: sha512-aeT/9SoWq7rnmzssWuCKUPaxVt3fzE9q+xq/ZHbnUSmrm8/EhLOACMvQeCOnL0IZsmPh8EpuwIE1TZyM9iQPRA==}
+  '@antoniomuso/lz4-napi-android-arm-eabi@2.9.1':
+    resolution: {integrity: sha512-KcRvkSOymDvxFDT9AGFBc7g+J/Xv4qExMMHhtxjZ45qE2sEIVCXoSFmyLDiVVKztkVzoV24VXPPRLOa4WQOi2Q==}
     engines: {node: '>= 10'}
     cpu: [arm]
     os: [android]
 
-  '@antoniomuso/lz4-napi-android-arm64@2.9.0':
-    resolution: {integrity: sha512-ibQ0qiEvmljXAM97IgOZfh+PeiSQ0Rqf2HErJlZPVm2v4GVJoB67v21v1TUydqNNV5L8bwufVoZ90nheL8X9ZA==}
+  '@antoniomuso/lz4-napi-android-arm64@2.9.1':
+    resolution: {integrity: sha512-BNiddtI+5Z83w1jIufTFhTPrtxMVKb0UPezTq47XIE/7vkB6y5mHSWSlcHqEIFFIg2/PVdqyqec1CXv0bkpCPA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [android]
 
-  '@antoniomuso/lz4-napi-darwin-arm64@2.9.0':
-    resolution: {integrity: sha512-1su4K1MWa4bcWoZlHajv+luGmFDV1JwIsvjtDF+0HhUveSDPP+8A4Z34zOZidURIr08Sl7M7ViPth6ZQ9SqnAA==}
+  '@antoniomuso/lz4-napi-darwin-arm64@2.9.1':
+    resolution: {integrity: sha512-nhLu+8g8Q6Yqd0rxRn4JkCMJBUs6mByiyT3Mhha2EgorsA2txx18JKm9qLhnXpDgFGWc94tLEVHqzDk0tLD9yA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@antoniomuso/lz4-napi-darwin-x64@2.9.0':
-    resolution: {integrity: sha512-8Lnbm2MkdJtiJ/nbcRS9zRyGp3G0sG6D+Y/x1vTP8nZs3/f8tBwYNsjxCQyyXNNyHcYWwVGbk68onP/pyDljOA==}
+  '@antoniomuso/lz4-napi-darwin-x64@2.9.1':
+    resolution: {integrity: sha512-DqkN1D/IrqOaUBppCP7BrF9j5Usb6RqFyz16kf3SHPDxLG7pmemgwXmGWpcNrKQfp4Shx1VkbFWA61gMyE1+uw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@antoniomuso/lz4-napi-freebsd-x64@2.9.0':
-    resolution: {integrity: sha512-k04EMVOjntKDPrdR4Tf8WyNseuk9PTtSGw8WHyp4CTjoR1s+YJxtp9SMnThe5o2q0TATwk8WGYb/Howrp5OMxw==}
+  '@antoniomuso/lz4-napi-freebsd-x64@2.9.1':
+    resolution: {integrity: sha512-ORtZ27l+j0yDgPMgt9q/j10LCchtKS44gFohEWl8fokgr5rzDAYAtMyQZzHV8sqE2LUWHAU3Gk6Wh9s1GRl9ow==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [freebsd]
 
-  '@antoniomuso/lz4-napi-linux-arm-gnueabihf@2.9.0':
-    resolution: {integrity: sha512-H92F8zPZmgy2r8IhCWh3qIBfLp2BQ5cp18RoDXhtGFWwkh+5gVWrZp11IVznrsdgB0QeW0VR7dAMMHg3WLOPfA==}
+  '@antoniomuso/lz4-napi-linux-arm-gnueabihf@2.9.1':
+    resolution: {integrity: sha512-GBZgQ/rY0AzjZA4jOKFXmLQKVPGXglVZ3U7SLcCu2nmuHTO73vsqiPeAHnYu7/org1km7yw3ii6XFlBRzyNKIA==}
     engines: {node: '>= 10'}
     cpu: [arm]
     os: [linux]
 
-  '@antoniomuso/lz4-napi-linux-arm64-gnu@2.9.0':
-    resolution: {integrity: sha512-25crh0qs/3Rj3fMI8ulYD0DoaKsidUhMBki2aeO69ZK+F8bmQ/e2++FlgJ6f3EgMP5CNxJtnZXKhPOraQWjwAw==}
+  '@antoniomuso/lz4-napi-linux-arm64-gnu@2.9.1':
+    resolution: {integrity: sha512-9lvGts14KHNT4pc9lKYUPI1PRdBkfbyT4HCjyDk8fJJzEG9ryvLvyhTeFr/IVpJOFmkSodZw1nxJMQDT5+zvlQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@antoniomuso/lz4-napi-linux-arm64-musl@2.9.0':
-    resolution: {integrity: sha512-eJtHp38zuLaYI0/cOV/BKcNQiXUBo4GPx53FTf0Y307yUjLsn48LNeN0vD28Ct9YrbUae3bQvMD5AD86She0ww==}
+  '@antoniomuso/lz4-napi-linux-arm64-musl@2.9.1':
+    resolution: {integrity: sha512-SsidKyLRHGB/rrgic+N7ZxFjjl+Cbav2sbuSj4AJsc37oVhyjzbiI5EEL9Rl+zL4ajL0d3utG3UbIUooThhykQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@antoniomuso/lz4-napi-linux-x64-gnu@2.9.0':
-    resolution: {integrity: sha512-mDjS4dyjRKaZQcAP71SphkYH5r3kufB30ih/VETVu/br2toCfBk6Zr1xhL1r+L7FaVAFzF62B7h30CiqrN0Awg==}
+  '@antoniomuso/lz4-napi-linux-ppc64-gnu@2.9.1':
+    resolution: {integrity: sha512-1Joz9RmBLiLIfI5Gk/wmJI/WwQy74prKDhLcCPFoa/FcTOJavJAopAzs1MQdnM7nGklEPOpKZWmKHZz1yQ4LMQ==}
+    engines: {node: '>= 10'}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@antoniomuso/lz4-napi-linux-riscv64-gnu@2.9.1':
+    resolution: {integrity: sha512-3z6jSvhEpnSMlubcHwSn6W8Xziq5LYSuIcSpSo7wTEOopnr6GNnKcH2uTPFsRiqC/aC2TLpm17ktXbYTrYL7jg==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@antoniomuso/lz4-napi-linux-s390x-gnu@2.9.1':
+    resolution: {integrity: sha512-wtQg/ikF1JutKdWfUdGXvR0LG+eG49mS01luwJXG6sg40DX737T3BAsbjM9Fccvif5jQwC+KmzP8+tvxy2eMtQ==}
+    engines: {node: '>= 10'}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@antoniomuso/lz4-napi-linux-x64-gnu@2.9.1':
+    resolution: {integrity: sha512-Vw7vb3i1Q6QU2sI5GdgZdi4cVwN2xZ44Gw/WawIxCno1gX39VIF/j8T1pYwS7Dc67NeoA37LsYIPb3h49CiRRA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@antoniomuso/lz4-napi-linux-x64-musl@2.9.0':
-    resolution: {integrity: sha512-pvU7Z7qjkjn17NkddBtBQ7C2iRqjtZ7WJ3Jqrjtj4XxolY3Q0HaYMvWjkWhzb9AKGZbj5y+EHYtbVoZJ2TSQhQ==}
+  '@antoniomuso/lz4-napi-linux-x64-musl@2.9.1':
+    resolution: {integrity: sha512-oZVrvOPjnI7c07v1lx6HMLFi8xlW9WS0pHmkaisldybNUWmNI6vR44KoqBctGCFplvF5YVMK2xPs3W04UGzF8w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@antoniomuso/lz4-napi-win32-arm64-msvc@2.9.0':
-    resolution: {integrity: sha512-aioLlbpJl0QPEXLXhh2bzyitc3T7Jot3f1ap6WdKiRa+CIjMHXw1nxJXy07MLXif10r+qVZr86ic8dvwErgqEQ==}
+  '@antoniomuso/lz4-napi-openharmony-arm64@2.9.1':
+    resolution: {integrity: sha512-mkDQv6C0JbMbCDn070Dv67SWfkDy8uD6DkqUT373LHjdaEXj/0eK2gAVykKyPdnC1RBhONgUCaV4HQOp63oH8Q==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@antoniomuso/lz4-napi-win32-arm64-msvc@2.9.1':
+    resolution: {integrity: sha512-EBsN9YzV3xpSPr6h/t6ntBetpdtO0nZw9o4sZ1vNOfLJ8FMdHxHiY7FonzhEyTnc4N3x3yMqPudD6zLVy/oNXg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@antoniomuso/lz4-napi-win32-ia32-msvc@2.9.0':
-    resolution: {integrity: sha512-VaF4XMTdYb59TsPsiqnWwsNaWKHhgxF33z5p4zg4n0tp20eWozl76hn8B+aXthSs40W0W1N97QhxxV4oXGd8cg==}
+  '@antoniomuso/lz4-napi-win32-ia32-msvc@2.9.1':
+    resolution: {integrity: sha512-Fqe2JmcfjvVrC+BHjHPzoiIzNgjHpQvDO7duMbJh5fW9VvF7pKkjRAPDwhtFhkU/fBLVQywq5WbsFqtJ3pYG/w==}
     engines: {node: '>= 10'}
     cpu: [ia32]
     os: [win32]
 
-  '@antoniomuso/lz4-napi-win32-x64-msvc@2.9.0':
-    resolution: {integrity: sha512-wfA8ShO3eGLxJ1LDwXJo87XL2D4NkMJV1pfHPvLZpD0MWb9u8VfgS+gKK5YhT7XKjzVdeIna9jgFdn2HBnZBxA==}
+  '@antoniomuso/lz4-napi-win32-x64-msvc@2.9.1':
+    resolution: {integrity: sha512-N6bAJ4pcYfbiuysHNyEl6uVnYxl0CBboPeA6Iz1GQWJb6mp8J/z4+E8bTvasMuRhIhEW5F6X+oJIwmOwSzHoIQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -1526,18 +1553,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@napi-rs/triples@1.2.0':
-    resolution: {integrity: sha512-HAPjR3bnCsdXBsATpDIP5WCrw0JcACwhhrwIAQhiR46n+jm+a2F8kBsfseAuWtSyQ+H3Yebt2k43B5dy+04yMA==}
-
   '@napi-rs/wasm-runtime@1.2.0':
     resolution: {integrity: sha512-kDoONqMa+VnZ4vvvu/ZUurpJ4gkZU57e7g69qpNgWhYcZFPUHZM2CEMKm+cG6ufDVALbjMvfmMjFVqaK7uEMnA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=23.5.0}
     peerDependencies:
       '@emnapi/core': ^2.0.0-alpha.3
       '@emnapi/runtime': ^2.0.0-alpha.3
-
-  '@node-rs/helper@1.6.0':
-    resolution: {integrity: sha512-2OTh/tokcLA1qom1zuCJm2gQzaZljCCbtX1YCrwRVd/toz7KxaDRFeLTAPwhs8m9hWgzrBn5rShRm6IaZofCPw==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -3322,9 +3343,9 @@ packages:
     resolution: {integrity: sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==}
     engines: {bun: '>=1.0.0', deno: '>=1.30.0', node: '>=8.0.0'}
 
-  lz4-napi@2.9.0:
-    resolution: {integrity: sha512-ZOWqxBMIK5768aD20tYn5B6Pp9WPM9UG/LHk8neG9p0gC1DtjdzhTtlkxhAjvTRpmJvMtnnqLKlT+COlqAt9cQ==}
-    engines: {node: '>= 10'}
+  lz4-napi@2.9.1:
+    resolution: {integrity: sha512-VjY1TAUQa3bo8j4vCcpQ0RBXh4mbC1OFHWH9rpOvx8qLYwaZTEzwxW/648ufD2cmz5/pFfPLDkX6N8+TqI9BYQ==}
+    engines: {node: '>= 18'}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -4637,43 +4658,55 @@ snapshots:
     dependencies:
       json-schema: 0.4.0
 
-  '@antoniomuso/lz4-napi-android-arm-eabi@2.9.0':
+  '@antoniomuso/lz4-napi-android-arm-eabi@2.9.1':
     optional: true
 
-  '@antoniomuso/lz4-napi-android-arm64@2.9.0':
+  '@antoniomuso/lz4-napi-android-arm64@2.9.1':
     optional: true
 
-  '@antoniomuso/lz4-napi-darwin-arm64@2.9.0':
+  '@antoniomuso/lz4-napi-darwin-arm64@2.9.1':
     optional: true
 
-  '@antoniomuso/lz4-napi-darwin-x64@2.9.0':
+  '@antoniomuso/lz4-napi-darwin-x64@2.9.1':
     optional: true
 
-  '@antoniomuso/lz4-napi-freebsd-x64@2.9.0':
+  '@antoniomuso/lz4-napi-freebsd-x64@2.9.1':
     optional: true
 
-  '@antoniomuso/lz4-napi-linux-arm-gnueabihf@2.9.0':
+  '@antoniomuso/lz4-napi-linux-arm-gnueabihf@2.9.1':
     optional: true
 
-  '@antoniomuso/lz4-napi-linux-arm64-gnu@2.9.0':
+  '@antoniomuso/lz4-napi-linux-arm64-gnu@2.9.1':
     optional: true
 
-  '@antoniomuso/lz4-napi-linux-arm64-musl@2.9.0':
+  '@antoniomuso/lz4-napi-linux-arm64-musl@2.9.1':
     optional: true
 
-  '@antoniomuso/lz4-napi-linux-x64-gnu@2.9.0':
+  '@antoniomuso/lz4-napi-linux-ppc64-gnu@2.9.1':
     optional: true
 
-  '@antoniomuso/lz4-napi-linux-x64-musl@2.9.0':
+  '@antoniomuso/lz4-napi-linux-riscv64-gnu@2.9.1':
     optional: true
 
-  '@antoniomuso/lz4-napi-win32-arm64-msvc@2.9.0':
+  '@antoniomuso/lz4-napi-linux-s390x-gnu@2.9.1':
     optional: true
 
-  '@antoniomuso/lz4-napi-win32-ia32-msvc@2.9.0':
+  '@antoniomuso/lz4-napi-linux-x64-gnu@2.9.1':
     optional: true
 
-  '@antoniomuso/lz4-napi-win32-x64-msvc@2.9.0':
+  '@antoniomuso/lz4-napi-linux-x64-musl@2.9.1':
+    optional: true
+
+  '@antoniomuso/lz4-napi-openharmony-arm64@2.9.1':
+    optional: true
+
+  '@antoniomuso/lz4-napi-win32-arm64-msvc@2.9.1':
+    optional: true
+
+  '@antoniomuso/lz4-napi-win32-ia32-msvc@2.9.1':
+    optional: true
+
+  '@antoniomuso/lz4-napi-win32-x64-msvc@2.9.1':
     optional: true
 
   '@aws-sdk/client-dynamodb@3.1097.0':
@@ -5320,18 +5353,12 @@ snapshots:
   '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4':
     optional: true
 
-  '@napi-rs/triples@1.2.0': {}
-
   '@napi-rs/wasm-runtime@1.2.0(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)':
     dependencies:
       '@emnapi/core': 2.0.0-alpha.3
       '@emnapi/runtime': 2.0.0-alpha.3
       '@tybys/wasm-util': 0.10.3
     optional: true
-
-  '@node-rs/helper@1.6.0':
-    dependencies:
-      '@napi-rs/triples': 1.2.0
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -6884,23 +6911,25 @@ snapshots:
 
   lru.min@1.1.4: {}
 
-  lz4-napi@2.9.0:
-    dependencies:
-      '@node-rs/helper': 1.6.0
+  lz4-napi@2.9.1:
     optionalDependencies:
-      '@antoniomuso/lz4-napi-android-arm-eabi': 2.9.0
-      '@antoniomuso/lz4-napi-android-arm64': 2.9.0
-      '@antoniomuso/lz4-napi-darwin-arm64': 2.9.0
-      '@antoniomuso/lz4-napi-darwin-x64': 2.9.0
-      '@antoniomuso/lz4-napi-freebsd-x64': 2.9.0
-      '@antoniomuso/lz4-napi-linux-arm-gnueabihf': 2.9.0
-      '@antoniomuso/lz4-napi-linux-arm64-gnu': 2.9.0
-      '@antoniomuso/lz4-napi-linux-arm64-musl': 2.9.0
-      '@antoniomuso/lz4-napi-linux-x64-gnu': 2.9.0
-      '@antoniomuso/lz4-napi-linux-x64-musl': 2.9.0
-      '@antoniomuso/lz4-napi-win32-arm64-msvc': 2.9.0
-      '@antoniomuso/lz4-napi-win32-ia32-msvc': 2.9.0
-      '@antoniomuso/lz4-napi-win32-x64-msvc': 2.9.0
+      '@antoniomuso/lz4-napi-android-arm-eabi': 2.9.1
+      '@antoniomuso/lz4-napi-android-arm64': 2.9.1
+      '@antoniomuso/lz4-napi-darwin-arm64': 2.9.1
+      '@antoniomuso/lz4-napi-darwin-x64': 2.9.1
+      '@antoniomuso/lz4-napi-freebsd-x64': 2.9.1
+      '@antoniomuso/lz4-napi-linux-arm-gnueabihf': 2.9.1
+      '@antoniomuso/lz4-napi-linux-arm64-gnu': 2.9.1
+      '@antoniomuso/lz4-napi-linux-arm64-musl': 2.9.1
+      '@antoniomuso/lz4-napi-linux-ppc64-gnu': 2.9.1
+      '@antoniomuso/lz4-napi-linux-riscv64-gnu': 2.9.1
+      '@antoniomuso/lz4-napi-linux-s390x-gnu': 2.9.1
+      '@antoniomuso/lz4-napi-linux-x64-gnu': 2.9.1
+      '@antoniomuso/lz4-napi-linux-x64-musl': 2.9.1
+      '@antoniomuso/lz4-napi-openharmony-arm64': 2.9.1
+      '@antoniomuso/lz4-napi-win32-arm64-msvc': 2.9.1
+      '@antoniomuso/lz4-napi-win32-ia32-msvc': 2.9.1
+      '@antoniomuso/lz4-napi-win32-x64-msvc': 2.9.1
 
   magic-string@0.30.21:
     dependencies:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [ ] Tests for the changes have been added (for bug fixes/features) with 100% code coverage. — n/a, dependency bump with no source changes.

**What kind of change does this PR introduce?**

Chore — dependency upgrade. Runtime phase, standalone deps. Follows #2035.

## Summary

Bumps `lz4-napi` a patch in the two packages that reference it, together, so the resolved native module stays on a single version.

## Changes

- `lz4-napi` 2.9.0 → 2.9.1 — `@keyv/compress-lz4` (runtime dependency) and `@keyv/test-suite` (devDependency, used for compression round-trip tests)

The exact `Latest` value from `pnpm outdated`, so the workspace `minimumReleaseAge` gate (4 days) is respected.

## Verification

- [x] `pnpm build` — full workspace builds clean (40 targets)
- [x] `pnpm --filter @keyv/compress-lz4 test` — **8 tests passed**, biome clean, on the `lz4-napi@2.9.1` native addon under Node 24.18.1 (`@keyv/compress-lz4` has no Docker dependency, so its suite runs locally)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EhFhwXMXeG5bRV8gV61WL3)_