### PR TITLE
serialize - chore: upgrade msgpackr to 2.0.5

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -293,8 +293,8 @@ importers:
         specifier: workspace:^
         version: link:../../core/keyv
       msgpackr:
-        specifier: ^2.0.4
-        version: 2.0.4
+        specifier: ^2.0.5
+        version: 2.0.5
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.5.6
@@ -3643,8 +3643,8 @@ packages:
     resolution: {integrity: sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==}
     hasBin: true
 
-  msgpackr@2.0.4:
-    resolution: {integrity: sha512-o1C5KRmuRt+apqMr1HuGSqWStZoRBUpEsCsl15uM9VdAF1qHLtvMOU2En747EnTyEl6c4pzPewRMFF31s1CNbA==}
+  msgpackr@2.0.5:
+    resolution: {integrity: sha512-cef05H/dSYpLpqp3sj/qyZh5vhUYCalnaLO7j1yOmpsR0y/XwLVtK7r5gn+U/F7CTEfMowcGhlUQJDLcLf7jcA==}
 
   mysql2@3.23.2:
     resolution: {integrity: sha512-fxh3HpQ8vJtu/Mmnd4Xsur19jGjHGzRLMxptiDtOkbX7EVBgnafGSGDx1WGGVmJLClVh2LeeBMMo24IFv8wCyQ==}
@@ -7525,7 +7525,7 @@ snapshots:
       '@msgpackr-extract/msgpackr-extract-win32-x64': 3.0.4
     optional: true
 
-  msgpackr@2.0.4:
+  msgpackr@2.0.5:
     optionalDependencies:
       msgpackr-extract: 3.0.4
 

--- a/serialization/msgpackr/package.json
+++ b/serialization/msgpackr/package.json
@@ -47,7 +47,7 @@
   },
   "homepage": "https://github.com/jaredwray/keyv",
   "dependencies": {
-    "msgpackr": "^2.0.4"
+    "msgpackr": "^2.0.5"
   },
   "peerDependencies": {
     "keyv": "workspace:^"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [ ] Tests for the changes have been added (for bug fixes/features) with 100% code coverage. — n/a, dependency bump with no source changes.

**What kind of change does this PR introduce?**

Chore — dependency upgrade. Runtime phase, standalone deps. Follows #2036.

## Summary

Bumps `msgpackr` a patch in `@keyv/serialize-msgpackr`.

## Changes

- `msgpackr` 2.0.4 → 2.0.5 — `@keyv/serialize-msgpackr`, the only package in the workspace that depends on it

The exact `Latest` value from `pnpm outdated`, so the workspace `minimumReleaseAge` gate (4 days) is respected.

## Verification

- [x] `pnpm build` — full workspace builds clean (40 targets)
- [x] `pnpm --filter @keyv/serialize-msgpackr test` — **22 tests passed**, biome clean (`@keyv/serialize-msgpackr` has no Docker dependency, so its suite runs locally)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EhFhwXMXeG5bRV8gV61WL3)_