### PR TITLE
release: v6.0.0-rc.1

### DIFF
--- a/compression/compress-brotli/package.json
+++ b/compression/compress-brotli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keyv/compress-brotli",
-	"version": "6.0.0-beta.4",
+	"version": "6.0.0-rc.1",
 	"description": "brotli compression for keyv",
 	"type": "module",
 	"main": "./dist/index.mjs",

--- a/compression/compress-gzip/package.json
+++ b/compression/compress-gzip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keyv/compress-gzip",
-  "version": "6.0.0-beta.4",
+  "version": "6.0.0-rc.1",
   "description": "gzip compression for keyv",
   "type": "module",
   "main": "./dist/index.mjs",

--- a/compression/compress-lz4/package.json
+++ b/compression/compress-lz4/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keyv/compress-lz4",
-	"version": "6.0.0-beta.4",
+	"version": "6.0.0-rc.1",
 	"description": "lz4 compression for Keyv",
 	"type": "module",
 	"main": "./dist/index.mjs",

--- a/core/bigmap/package.json
+++ b/core/bigmap/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keyv/bigmap",
-	"version": "6.0.0-beta.4",
+	"version": "6.0.0-rc.1",
 	"description": "Bigmap for Keyv",
 	"type": "module",
 	"main": "./dist/index.mjs",

--- a/core/keyv/package.json
+++ b/core/keyv/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "keyv",
-	"version": "6.0.0-beta.4",
+	"version": "6.0.0-rc.1",
 	"description": "Simple key-value storage with support for multiple backends",
 	"type": "module",
 	"main": "./dist/index.mjs",

--- a/core/test-suite/package.json
+++ b/core/test-suite/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keyv/test-suite",
-	"version": "6.0.0-beta.4",
+	"version": "6.0.0-rc.1",
 	"description": "Test suite for Keyv API compliancy",
 	"type": "module",
 	"main": "./dist/index.mjs",

--- a/encryption/encrypt-node/package.json
+++ b/encryption/encrypt-node/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keyv/encrypt-node",
-	"version": "6.0.0-beta.4",
+	"version": "6.0.0-rc.1",
 	"description": "Node.js crypto encryption adapter for Keyv",
 	"type": "module",
 	"main": "./dist/index.mjs",

--- a/encryption/encrypt-web/package.json
+++ b/encryption/encrypt-web/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keyv/encrypt-web",
-	"version": "6.0.0-beta.4",
+	"version": "6.0.0-rc.1",
 	"description": "Web Crypto API encryption adapter for Keyv",
 	"type": "module",
 	"main": "./dist/index.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keyv/mono-repo",
-  "version": "6.0.0-beta.4",
+  "version": "6.0.0-rc.1",
   "type": "module",
   "description": "Keyv Mono Repo",
   "repository": "https://github.com/jaredwray/keyv.git",

--- a/serialization/msgpackr/package.json
+++ b/serialization/msgpackr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keyv/serialize-msgpackr",
-  "version": "6.0.0-beta.4",
+  "version": "6.0.0-rc.1",
   "description": "MessagePack serialization adapter for Keyv using msgpackr",
   "type": "module",
   "main": "./dist/index.mjs",

--- a/serialization/superjson/package.json
+++ b/serialization/superjson/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keyv/serialize-superjson",
-  "version": "6.0.0-beta.4",
+  "version": "6.0.0-rc.1",
   "description": "SuperJSON serialization adapter for Keyv",
   "type": "module",
   "main": "./dist/index.mjs",

--- a/storage/cloudflare-kv/package.json
+++ b/storage/cloudflare-kv/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keyv/cloudflare-kv",
-  "version": "6.0.0-beta.4",
+  "version": "6.0.0-rc.1",
   "description": "Cloudflare Workers KV storage adapter for Keyv",
   "type": "module",
   "main": "./dist/index.mjs",

--- a/storage/dynamo/package.json
+++ b/storage/dynamo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keyv/dynamo",
-  "version": "6.0.0-beta.4",
+  "version": "6.0.0-rc.1",
   "description": "DynamoDB storage adapter for Keyv",
   "type": "module",
   "main": "./dist/index.mjs",

--- a/storage/etcd/package.json
+++ b/storage/etcd/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keyv/etcd",
-	"version": "6.0.0-beta.4",
+	"version": "6.0.0-rc.1",
 	"description": "Etcd storage adapter for Keyv",
 	"type": "module",
 	"main": "./dist/index.mjs",

--- a/storage/memcache/package.json
+++ b/storage/memcache/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keyv/memcache",
-	"version": "6.0.0-beta.4",
+	"version": "6.0.0-rc.1",
 	"description": "Memcache storage adapter for Keyv",
 	"type": "module",
 	"main": "./dist/index.mjs",

--- a/storage/mongo/package.json
+++ b/storage/mongo/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keyv/mongo",
-	"version": "6.0.0-beta.4",
+	"version": "6.0.0-rc.1",
 	"description": "MongoDB storage adapter for Keyv",
 	"type": "module",
 	"main": "./dist/index.mjs",

--- a/storage/mysql/package.json
+++ b/storage/mysql/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keyv/mysql",
-	"version": "6.0.0-beta.4",
+	"version": "6.0.0-rc.1",
 	"description": "MySQL/MariaDB storage adapter for Keyv",
 	"type": "module",
 	"main": "./dist/index.mjs",

--- a/storage/postgres/package.json
+++ b/storage/postgres/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keyv/postgres",
-	"version": "6.0.0-beta.4",
+	"version": "6.0.0-rc.1",
 	"description": "PostgreSQL storage adapter for Keyv",
 	"type": "module",
 	"main": "./dist/index.mjs",

--- a/storage/redis/package.json
+++ b/storage/redis/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keyv/redis",
-	"version": "6.0.0-beta.4",
+	"version": "6.0.0-rc.1",
 	"description": "Redis storage adapter for Keyv",
 	"type": "module",
 	"main": "./dist/index.mjs",

--- a/storage/sqlite/package.json
+++ b/storage/sqlite/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keyv/sqlite",
-	"version": "6.0.0-beta.4",
+	"version": "6.0.0-rc.1",
 	"description": "SQLite storage adapter for Keyv",
 	"type": "module",
 	"main": "./dist/index.mjs",

--- a/storage/valkey/package.json
+++ b/storage/valkey/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keyv/valkey",
-	"version": "6.0.0-beta.4",
+	"version": "6.0.0-rc.1",
 	"description": "Valkey storage adapter for Keyv",
 	"type": "module",
 	"main": "./dist/index.mjs",

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keyv/website",
-  "version": "6.0.0-beta.4",
+  "version": "6.0.0-rc.1",
   "description": "Keyv Website",
   "repository": "https://github.com/jaredwray/keyv.git",
   "author": "Jared Wray <me@jaredwray.com>",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [ ] Tests for the changes have been added (for bug fixes/features) with 100% code coverage. — n/a, this is a version-bump release PR with no source changes; the shipped work was tested in its own PRs (#1983–#2038).

**What kind of change does this PR introduce?**

Release — promotes the 6.0 line from beta to release candidate. Version-only bump across the monorepo (no source changes).

## Release summary
Promote 6.0 to release candidate: bumps all 21 workspace packages `6.0.0-beta.4 → 6.0.0-rc.1` via `version:sync`. Covers 48 commits since `v6.0.0-beta.4` — the Cloudflare Workers KV adapter, MySQL stability/schema fixes, and a full dependency refresh across the monorepo.

## Packages
Fixed-version monorepo — every published package moves in lockstep.

| Package | Current | New | Bump | Rationale | Commits |
|---|---|---|---|---|---|
| `keyv` + all 19 published `@keyv/*` adapters | `6.0.0-beta.4` | `6.0.0-rc.1` | **beta → rc** | 4 feat, 8 fix, breaking mysql/keyv changes, 34 dep chores | 48 |
| `@keyv/website` | `6.0.0-beta.4` | `6.0.0-rc.1` | _private_ | version synced but not published | — |

## keyv v6.0.0-rc.1 — 2026-08-03

Promote 6.0 to release candidate: Cloudflare KV adapter, MySQL fixes, and a full dependency refresh.

_All published `@keyv/*` adapters release in lockstep at this version. `@keyv/website` is private and not published._

### ⚠ BREAKING CHANGES
- **mysql:** keys are now stored as `VARBINARY` (6e519b4, #2015; f579073, #2016)
  Migration: `@keyv/mysql` tables created under `6.0.0-beta.4` use the previous key column type. Recreate the keyv table, or `ALTER` the key column to `VARBINARY`, before upgrading.
- **keyv:** `checkExpired` now defaults to `true` (f067213, #1984)
  Migration: expired keys are now checked and cleared by default. Pass `checkExpired: false` to restore the previous behavior.
- **keyv:** removed the namespace `removeKeyPrefix` behavior for v6 (73fd79b, #2013)
  Migration: keys are no longer stripped of their namespace prefix on read. If you relied on the stripped form, read the full namespaced key.

### Features
- add Cloudflare Workers KV storage adapter (e004467, #1985)

  ```js
  import { createKeyv } from "@keyv/cloudflare-kv";

  // REST mode — from any Node.js process
  const keyv = createKeyv({
    mode: "rest",
    accountId: process.env.CF_ACCOUNT_ID,
    namespaceId: process.env.CF_KV_NAMESPACE_ID,
    apiToken: process.env.CF_API_TOKEN,
  });
  // Or "bind" mode inside a Worker: createKeyv({ kvNamespace: env.MY_KV })
  ```
- mysql: move to async config changes (b775072, #2018)
- keyv: add the built-in adapters to the docs (2e03276, #1983)
- mysql: add docs (e07dc4c, #2019)

### Bug Fixes
- mysql: isolate pooled connection lifecycles (86b61c8, #2012)
- mysql: scheduled cleanup firing (97fa359, #2017)
- mysql: deleting expired keys sometimes fails (6e5aff2, #2014)
- mysql: resolve TypeScript errors (dc563b6, #2011)

### Documentation
- add keyv-s3fifo to third-party storage adapters (fb420e7, #2020)

### Internal
- refactor: add `KeyvAny`/`KeyvAnyArray` types and replace explicit `any` (49ed583, #2010)
- 34 dependency and tooling upgrades across the monorepo — highlights: TypeScript 6→7, pnpm 11.5→11.18, better-sqlite3 12→13 (N-API, drops `prebuild-install`), mongodb 7.4→7.5, mysql2 3.22→3.23, iovalkey 0.3→0.4, `@redis/client` 6.0→6.1, hookified 3.0.1→3.0.2, `actions/setup-node` v6→v7, and the Node engines floor raised to ≥ 22.19.0. Full inventory below.

### Contributors
- @jaredwray (47)
- @BJS-kr (1)

### Full List of Changes
- keyv - feat: adding in the built in adapters to docs by @jaredwray in #1983
- keyv - fix: moving checkExpired to default to true by @jaredwray in #1984
- cloudflare-kv - feat: Add Cloudflare Workers KV storage adapter by @jaredwray in #1985
- mono - chore: upgrade code quality dependencies by @jaredwray in #1986
- mono - chore: upgrade TypeScript and build tooling by @jaredwray in #1987
- mono - chore: upgrade js-yaml to v5 (breaking) by @jaredwray in #1988
- keyv - chore: upgrade keyv-file by @jaredwray in #1989
- mono - chore: upgrade GitHub Actions (breaking) by @jaredwray in #1990
- dynamo - chore: upgrade AWS SDK dependencies by @jaredwray in #1991
- mongo - chore: upgrade mongodb by @jaredwray in #1992
- postgres - chore: upgrade pg by @jaredwray in #1993
- sqlite - chore: upgrade better-sqlite3 by @jaredwray in #1994
- redis - chore: upgrade @redis/client by @jaredwray in #1995
- memcache - chore: upgrade memcache by @jaredwray in #1996
- mono - chore: upgrade hookified by @jaredwray in #1997
- serialize - chore: upgrade msgpackr by @jaredwray in #1998
- test-suite - chore: upgrade bignumber.js by @jaredwray in #1999
- bigmap - chore: upgrade hashery (breaking) by @jaredwray in #2000
- compress-gzip - chore: upgrade pako (breaking) by @jaredwray in #2001
- mono - refactor: add KeyvAny/KeyvAnyArray types and replace explicit any by @jaredwray in #2010
- mysql - fix: resolve TypeScript errors by @jaredwray in #2011
- mysql - fix: isolate pooled connection lifecycles by @jaredwray in #2012
- fix: removing the namespace removeKeyPrefix with v6 by @jaredwray in #2013
- mysql - fix: deleting expired keys sometimes fail by @jaredwray in #2014
- mysql - fix: moving to VARBINARY for key by @jaredwray in #2015
- mysql - fix: moving to varbinary for key (fixes) by @jaredwray in #2016
- mysql - fix: scheduled cleanup firing by @jaredwray in #2017
- mysql - feat: moving to async config changes by @jaredwray in #2018
- mysql - feat: adding in docs by @jaredwray in #2019
- docs: add keyv-s3fifo to third-party storage adapters by @BJS-kr in #2020
- mono - chore: upgrade code quality dependencies by @jaredwray in #2021
- mono - chore: upgrade TypeScript and build tooling by @jaredwray in #2022
- mono - chore: upgrade pnpm to 11.18.0 by @jaredwray in #2023
- mono - chore: upgrade GitHub Actions by @jaredwray in #2024
- dynamo - chore: upgrade AWS SDK DynamoDB dependencies by @jaredwray in #2025
- redis - chore: upgrade @redis/client to 6.1.0 by @jaredwray in #2026
- mongo - chore: upgrade mongodb to 7.5.0 by @jaredwray in #2027
- mysql - chore: upgrade mysql2 to 3.23.2 by @jaredwray in #2028
- valkey - chore: upgrade iovalkey to 0.4.0 by @jaredwray in #2029
- memcache - chore: upgrade memcache to 1.9.0 by @jaredwray in #2030
- mono - chore: raise Node engines floor to 22.19.0 by @jaredwray in #2031
- sqlite - chore: upgrade better-sqlite3 to 13.0.2 by @jaredwray in #2032
- mono - chore: upgrade hookified to 3.0.2 by @jaredwray in #2033
- bigmap - chore: upgrade hashery to 3.0.1 by @jaredwray in #2034
- test-suite - chore: upgrade bignumber.js to 11.1.5 by @jaredwray in #2035
- mono - chore: upgrade lz4-napi to 2.9.1 by @jaredwray in #2036
- serialize - chore: upgrade msgpackr to 2.0.5 by @jaredwray in #2037
- compress - chore: upgrade pako to 3.0.1 by @jaredwray in #2038

**Full diff:** https://github.com/jaredwray/keyv/compare/v6.0.0-beta.4...v6.0.0-rc.1

## Verification
- [x] `pnpm install --frozen-lockfile` — lockfile valid, no drift (workspace protocol)
- [x] `pnpm build` — all 20 built packages compile clean (40 targets)
- [x] `pnpm test` for the 12 packages that don't need Docker services — 914 tests passed, 4 todo
- [x] `pnpm test:scripts` — 20 tests passed (exercises `version-sync`)
- [x] Only version fields changed — 22 `package.json` files, one line each; no source or lockfile changes
- [ ] Docker-backed adapter suites (mongo, mysql, postgres, redis, valkey, etcd, memcache, dynamo) — not run locally (no Docker in this sandbox); CI runs them with services started

## Post-merge
Merge, then create a **GitHub Release** at tag `v6.0.0-rc.1` — the `release.yaml` workflow (`release-publish.ts`) publishes every package to npm under the pre-release dist-tag. `@keyv/website` is private and is skipped by the publish.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EhFhwXMXeG5bRV8gV61WL3)_