### PR TITLE
etcd - fix: Use Keyv default serializer for value envelope

### DIFF
--- a/storage/etcd/src/index.ts
+++ b/storage/etcd/src/index.ts
@@ -356,17 +356,22 @@ export class KeyvEtcd<GenericValue = KeyvAny> extends Hookified {
 		}
 
 		try {
-			const parsed = jsonSerializer.parse<{ v: T; e: number | null }>(raw as string);
-			if (parsed.v === undefined) {
+			const parsed = jsonSerializer.parse<unknown>(raw as string);
+			if (parsed === null || typeof parsed !== "object") {
+				return { value: raw as T, expired: false };
+			}
+
+			const envelope = parsed as { v: T; e: number | null };
+			if (envelope.v === undefined) {
 				// Not our envelope format — return as-is.
 				return { value: raw as T, expired: false };
 			}
 
-			if (parsed.e !== null && Date.now() > parsed.e) {
+			if (envelope.e !== null && Date.now() > envelope.e) {
 				return { value: undefined, expired: true };
 			}
 
-			return { value: parsed.v, expired: false };
+			return { value: envelope.v, expired: false };
 		} catch {
 			// Not valid JSON — return as-is.
 			return { value: raw as T, expired: false };

--- a/storage/etcd/src/index.ts
+++ b/storage/etcd/src/index.ts
@@ -1,5 +1,6 @@
 import { Hookified } from "hookified";
 import {
+	jsonSerializer,
 	Keyv,
 	type KeyvAny,
 	type KeyvStorageEntry,
@@ -336,10 +337,10 @@ export class KeyvEtcd<GenericValue = KeyvAny> extends Hookified {
 	 * The expiry comes from the `expires` parameter — the encoded value is never parsed.
 	 * @param value - The encoded value to store.
 	 * @param expires - Absolute expiry as Unix ms since epoch, or `undefined` for no expiry.
-	 * @returns A JSON envelope string `{ v, e }`.
+	 * @returns A Keyv-serialized envelope string `{ v, e }`.
 	 */
 	private wrapValue(value: unknown, expires?: number): string {
-		return JSON.stringify({ v: value, e: typeof expires === "number" ? expires : null });
+		return jsonSerializer.stringify({ v: value, e: typeof expires === "number" ? expires : null });
 	}
 
 	/**
@@ -355,7 +356,7 @@ export class KeyvEtcd<GenericValue = KeyvAny> extends Hookified {
 		}
 
 		try {
-			const parsed = JSON.parse(raw as string) as { v: T; e: number | null };
+			const parsed = jsonSerializer.parse<{ v: T; e: number | null }>(raw as string);
 			if (parsed.v === undefined) {
 				// Not our envelope format — return as-is.
 				return { value: raw as T, expired: false };

--- a/storage/etcd/test/test.ts
+++ b/storage/etcd/test/test.ts
@@ -277,6 +277,14 @@ describe("ttl and expiration", () => {
 		t.expect(await store.has(key)).toBe(true);
 	});
 
+	it("should return JSON null written directly to etcd as-is", async (t) => {
+		const store = new KeyvEtcd(etcdUrl);
+		const key = faker.string.uuid();
+		await store.client.put(store.formatKey(key)).value("null");
+		t.expect(await store.get(key)).toBe("null");
+		t.expect(await store.has(key)).toBe(true);
+	});
+
 	it("should cache the granted lease id across concurrent puts", async (t) => {
 		const store = new KeyvEtcd(etcdUrl, { ttl: 5000 });
 		const sharedLease = store.lease;

--- a/storage/etcd/test/test.ts
+++ b/storage/etcd/test/test.ts
@@ -200,6 +200,19 @@ describe("get, set, and delete", () => {
 		const result = await store.get(key);
 		t.expect(result).toBe("raw-value");
 	});
+
+	it("should use Keyv's default serializer for the value envelope", async (t) => {
+		const store = new KeyvEtcd(etcdUrl);
+		const key = faker.string.uuid();
+		const value = {
+			bigint: BigInt("9223372036854775807"),
+			buffer: Buffer.from("keyv-etcd"),
+			markerLikeString: ":bigint:123",
+		};
+
+		t.expect(await store.set(key, value)).toBe(true);
+		t.expect(await store.get(key)).toEqual(value);
+	});
 });
 
 describe("ttl and expiration", () => {


### PR DESCRIPTION
## Summary

- replace native JSON encoding for the etcd adapter's private `{ v, e }` envelope with Keyv's exported `jsonSerializer`
- preserve precise expiry enforcement and raw/non-envelope fallback behavior
- guard valid non-envelope JSON primitives such as `null` before reading envelope fields
- add direct adapter coverage for `BigInt`, `Buffer`, marker-like strings, and raw JSON `null`

## Why

The etcd adapter needs an outer envelope for millisecond-accurate expiry, but native JSON could not serialize `BigInt` and degraded binary values during direct adapter or serialization-disabled usage. Reusing Keyv's default serializer keeps the envelope consistent with Keyv's supported value semantics. Explicitly rejecting parsed primitives before envelope access also avoids caught `TypeError` exceptions for valid non-envelope JSON.

## Impact

There are no public API or dependency changes. The etcd HTTP/JSON protocol codec remains unchanged. Ordinary existing envelopes remain readable; pre-GA direct payloads beginning with Keyv's reserved colon markers adopt the default serializer semantics.

## Validation

- `pnpm lint:ci` in `storage/etcd`
- `pnpm build` in `storage/etcd`
- `pnpm test:ci` in `storage/etcd` — 121 tests passed with 100% line coverage
