### PR TITLE
mono - chore: defense - add security docs and tracking

### DIFF
--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -5,8 +5,8 @@ Tracking against https://github.com/jaredwray/agentic/blob/main/skills/security/
 Profile: npm library · public
 
 ## 1. Security docs
-- [ ] `SECURITY.md` present — contact info + "How this repository is secured" summary (PR pending)
-- [ ] `DEFENSE_IN_DEPTH.md` present (this file) (PR pending)
+- [ ] `SECURITY.md` present — contact info + "How this repository is secured" summary (PR #2053 pending)
+- [ ] `DEFENSE_IN_DEPTH.md` present (this file) (PR #2053 pending)
 
 ## 2. CODEOWNERS and cloud bootstrap
 - [ ] `.github/CODEOWNERS` covers `/.github/`, `/.cursor/`, `/.devcontainer/`, `/scripts/` with owners the maintainer names

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -1,0 +1,55 @@
+# Defense in Depth
+
+Tracking against https://github.com/jaredwray/agentic/blob/main/skills/security/defense-in-depth-nodejs/SKILL.md.
+
+Profile: npm library · public
+
+## 1. Security docs
+- [ ] `SECURITY.md` present — contact info + "How this repository is secured" summary (PR pending)
+- [ ] `DEFENSE_IN_DEPTH.md` present (this file) (PR pending)
+
+## 2. CODEOWNERS and cloud bootstrap
+- [ ] `.github/CODEOWNERS` covers `/.github/`, `/.cursor/`, `/.devcontainer/`, `/scripts/` with owners the maintainer names
+- [ ] Codespaces and Cursor Cloud Agents bootstrap Aikido Safe Chain via scripts/setup-cloud-environment.sh (--ci shims, frozen lockfile)
+
+## 3. Dependencies (pnpm)
+- [x] `packageManager: pnpm@11.3+` pinned in `package.json` — verified 2026-08-24
+- [ ] 7-day cooldown: `minimumReleaseAge: 10080`, `minimumReleaseAgeStrict: true`, `minimumReleaseAgeIgnoreMissingTime: false`; no first-party `minimumReleaseAgeExclude`
+- [ ] `trustPolicy: no-downgrade`; no first-party `trustPolicyExclude`
+- [ ] Lifecycle scripts blocked: `strictDepBuilds: true`, `dangerouslyAllowAllBuilds: false`, `allowBuilds: {}` baseline
+- [ ] `blockExoticSubdeps: true`
+- [ ] Lockfile committed; CI installs with `pnpm install --frozen-lockfile`
+- [x] No `.github/dependabot.yml`; other dependency-update tools (if any) open PRs only — never auto-merge — verified 2026-08-24
+
+## 4. GitHub Actions
+- [ ] `permissions: contents: read` (or `{}` + per-job grants) on every workflow
+- [ ] No `contents: write` except jobs whose purpose is mutating the repo (GitHub Release, Changesets version PR); generated output is a workflow artifact, never committed back from CI
+- [ ] Every action pinned to a full commit SHA (`npx actions-up`)
+- [ ] Every job installs Socket Firewall (`SocketDev/action` SHA-pinned, `firewall-version` pinned); `pnpm install` / `npm install` run as `sfw pnpm install` / `sfw npm install`
+- [ ] `.github/workflows/check-workflows.yaml` lints workflows with zizmor on every PR
+- [ ] Workflow `name:` and job `name:` contain no spaces (kebab-case) so they can be set as required status checks
+- [ ] `persist-credentials: false` on checkouts that don't push
+- [x] No `pull_request_target` on workflows that run untrusted PR code — verified 2026-08-24
+- [ ] Artifact-publishing workflows disable `actions/setup-node` default caching (`package-manager-cache: false`) to prevent cache poisoning
+- [x] No npm tokens (or other registry credentials) in Actions secrets — verified 2026-08-24
+
+## 5. npm publishing — npm libraries only
+- [ ] OIDC trusted publishing configured **stage-only** on npmjs.com for the publish workflow — it can stage, never publish live (manual)
+- [ ] `.github/workflows/release.yaml` packs then stages with `pnpm stage publish ./packed/*.tgz --no-git-checks`
+- [ ] Maintainer promotes staged versions with 2FA (manual)
+- [ ] Drydock connected — staged releases reviewed before promotion (manual)
+- [ ] No direct publish rights: package requires 2FA and disallows tokens (manual)
+- [x] `package.json` `repository.url` accurate so provenance maps to this repo — verified 2026-08-24
+
+## 6. Security tooling
+- [ ] Aikido runs on every build
+- [ ] Aikido release gate: the release workflow's stage-publish job `needs:` a passing `scan-release`
+- [ ] Socket reviews every PR that changes dependencies
+
+## 7. Repository lockdown
+
+The lockdown script is not vendored in this repo. A repo admin applies it from the skill copy in `jaredwray/agentic` last (do not add `scripts/lockdown-repo.sh` here).
+
+- [ ] Phishing-resistant 2FA (passkeys / hardware keys) on the GitHub and npm accounts (manual)
+- [ ] Recovery codes stored offline in a password manager (manual)
+- [ ] `lockdown-repo.sh` applied by a repo admin (never committed to this repo); `--check` with `--required-checks` and `--allowed-actions` passes (PRs required on the default branch, merges blocked unless required status checks pass, tag ruleset, immutable releases, fork-PR approval (public repos), read-only workflow tokens, Actions allowlist, secret scanning, Dependabot disabled, private vulnerability reporting (public repos))

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,9 +1,29 @@
 # Security Policy
 
-To report a security vulnerability, please post an issue in our repository for [Keyv](https://github.com/jaredwray/keyv/issues) and mark it with `security vulnerability`. You need to add in the issue description the following information:
+We take security seriously and work to keep this project up to date. If you discover a security vulnerability, please report it **privately** so we can investigate and ship a fix before the issue becomes public.
 
-- **Vulnerability Type**: Describe the type of vulnerability (e.g., XSS, CSRF, SQL Injection).
-- **Vulnerability Description**: Describe the vulnerability in detail, including how it can be exploited and what impact it may have.
-- **Proof of Concept**: If possible, provide a proof of concept (PoC) that demonstrates the vulnerability.
+## Reporting a vulnerability
 
-Once the issue has been validated, we will open a [Github Security Advisory](https://docs.github.com/en/code-security/repository-security-advisories/about-github-security-advisories-for-repositories), if necessary. When the issue has been resolved, we will alert users of the past vulnerability by publishing the security advisory.
+Please use one of the following private channels — **do not open a public issue, pull request, or discussion** for security concerns:
+
+1. **Preferred:** open a private report via GitHub's [Privately reporting a security vulnerability](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability) flow on this repository's **Security** tab.
+2. **Email:** send the details to me@jaredwray.com. If the issue is urgent, include `[SECURITY]` in the subject line and we will respond as soon as possible.
+
+When reporting, please include as much of the following as you can:
+
+- A description of the vulnerability and its impact.
+- Steps to reproduce, or a proof-of-concept.
+- The affected version(s) and platform.
+- Any suggested remediation, if you have one.
+
+We will acknowledge receipt, work with you on a coordinated disclosure timeline, and credit you in the advisory once a fix is published unless you ask to remain anonymous.
+
+## How this repository is secured
+
+This repository follows the [defense-in-depth](https://github.com/jaredwray/agentic/blob/main/skills/security/defense-in-depth-nodejs/SKILL.md)
+hardening checklist; progress is tracked in [DEFENSE_IN_DEPTH.md](./DEFENSE_IN_DEPTH.md). Measures currently in place:
+
+- pnpm is pinned via `packageManager` (`pnpm@11.18.0`).
+- The lockfile is committed. There is no Dependabot config; dependency updates go through reviewed PRs.
+- Workflows do not use `pull_request_target` and do not store npm tokens (OIDC trusted publishing).
+- Published packages set `repository.url` to this repo so provenance can map back.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Scaffold the defense-in-depth tracking file and rewrite `SECURITY.md` for private disclosure plus a summary of controls that are already live (section 1).

Status update: `DEFENSE_IN_DEPTH.md` § 1 → `(PR #2053 pending)`

## Changes

- Rewrite `SECURITY.md` to require private reporting (GitHub Security tab or me@jaredwray.com) instead of a public issue
- Add `DEFENSE_IN_DEPTH.md` from the catalog (`Profile: npm library · public`)
- Mark already-true items as verified (pinned pnpm, no Dependabot, no `pull_request_target`, no npm tokens, accurate `repository.url`)

## Verification

- [x] Working tree clean on `main` before branching
- [x] Catalog items reconciled against repo state (only live measures listed in `SECURITY.md`)
- [x] Files are markdown-only; no build or test change

Reference: defense-in-depth-nodejs § 1

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5172eb2f-0031-4580-bcaa-6cc9457560b4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5172eb2f-0031-4580-bcaa-6cc9457560b4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

