### PR TITLE
mono - chore: defense - stage npm publishes with Aikido gate

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,6 +45,41 @@ jobs:
       - name: Build
         run: pnpm build
 
+  aikido-gate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    name: aikido-gate
+    permissions:
+      contents: read
+    steps:
+      - name: Install Socket Firewall
+        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+          firewall-version: "1.15.0"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          package-manager-cache: false
+
+      - name: Install Aikido CI client
+        # zizmor: ignore[adhoc-packages] pinned Aikido CI client for the release gate
+        run: sfw npm install --global @aikidosec/ci-api-client@1.0.17
+
+      # Fails on new SAST/IaC/secrets findings. The API key comes from Aikido's
+      # Continuous Integration settings — it grants no publish authority.
+      - name: Run Aikido release scan
+        env:
+          REPO_NAME: ${{ github.event.repository.name }}
+          AIKIDO_CLIENT_API_KEY: ${{ secrets.AIKIDO_CLIENT_API_KEY }}
+        run: >
+          aikido-api-client scan-release
+          "$REPO_NAME" "$GITHUB_SHA"
+          --apikey "$AIKIDO_CLIENT_API_KEY"
+          --fail-on-sast-scan --fail-on-iac-scan --fail-on-secrets-scan
+
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -83,21 +118,22 @@ jobs:
         run: pnpm test
 
   publish:
-    needs: [build, test]
+    needs: [build, test, aikido-gate]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     name: publish
     environment: release
     # OIDC trusted publishing: GitHub mints a short-lived OIDC token that pnpm
-    # exchanges with npm for a one-time publish credential. No NPM_TOKEN needed.
+    # exchanges with npm for a one-time stage credential. No NPM_TOKEN needed.
+    # The trusted publisher must be configured stage-only on npmjs.com.
     permissions:
       contents: read
       id-token: write
     env:
-      # Provenance is generated automatically when publishing via OIDC; setting
+      # Provenance is generated automatically when staging via OIDC; setting
       # this makes it explicit and fails closed if OIDC ever isn't available.
-      # release-publish.ts also passes --provenance on every publish, and the
-      # "Verify release-tag logic" step fails the release if that flag is
+      # release-publish.ts also passes --provenance on every stage publish, and
+      # the "Verify release-tag logic" step fails the release if that flag is
       # ever removed from the script.
       NPM_CONFIG_PROVENANCE: "true"
     steps:
@@ -128,17 +164,17 @@ jobs:
       - name: Build
         run: pnpm build
 
-      # Verify the dist-tag logic before any publish runs.
+      # Verify the dist-tag logic before any stage publish runs.
       - name: Verify release-tag logic
         run: pnpm test:scripts
 
       # Computes the dist-tag from the released version (pre-release -> beta;
       # stable current major -> latest; stable old major -> v{major}-lts),
       # skips versions already on the registry, guards `latest` from moving
-      # backwards, then publishes each package at its own version under that
-      # tag. `release` events ignore dry_run (inputs is empty) and publish for
-      # real; manual runs default to dry_run=true. Uses OIDC only — no token.
-      - name: Publish (compute dist-tag, skip unchanged, guard latest)
+      # backwards, then packs and stages each package under that tag.
+      # `release` events ignore dry_run (inputs is empty) and stage for real;
+      # manual runs default to dry_run=true. Uses OIDC only — no token.
+      - name: Stage publish (compute dist-tag, skip unchanged, guard latest)
         env:
           LATEST_MAJOR: 5 # Version 5 is the LTS at this time
           DRY_RUN: ${{ inputs.dry_run }}

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,9 @@ build/Release
 node_modules
 jspm_packages
 
+# Staged npm pack output (created by scripts/release-publish.ts)
+packed
+
 # Optional npm cache directory
 .npm
 

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -35,7 +35,7 @@ Profile: npm library · public
 
 ## 5. npm publishing — npm libraries only
 - [ ] OIDC trusted publishing configured **stage-only** on npmjs.com for the publish workflow — it can stage, never publish live (manual)
-- [ ] `.github/workflows/release.yaml` packs then stages with `pnpm stage publish ./packed/*.tgz --no-git-checks` (PR pending)
+- [ ] `.github/workflows/release.yaml` packs then stages with `pnpm stage publish ./packed/*.tgz --no-git-checks` (PR #2057 pending)
 - [ ] Maintainer promotes staged versions with 2FA (manual)
 - [ ] Drydock connected — staged releases reviewed before promotion (manual)
 - [ ] No direct publish rights: package requires 2FA and disallows tokens (manual)
@@ -43,7 +43,7 @@ Profile: npm library · public
 
 ## 6. Security tooling
 - [ ] Aikido runs on every build
-- [ ] Aikido release gate: the release workflow's stage-publish job `needs:` a passing `scan-release` (PR pending)
+- [ ] Aikido release gate: the release workflow's stage-publish job `needs:` a passing `scan-release` (PR #2057 pending)
 - [x] Socket reviews every PR that changes dependencies — verified 2026-08-24 (PR #2053: Socket Security Pull Request Alerts and Project Report)
 
 ## 7. Repository lockdown

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -22,20 +22,20 @@ Profile: npm library · public
 - [x] No `.github/dependabot.yml`; other dependency-update tools (if any) open PRs only — never auto-merge — verified 2026-08-24
 
 ## 4. GitHub Actions
-- [ ] `permissions: contents: read` (or `{}` + per-job grants) on every workflow (PR #2056 pending)
-- [ ] No `contents: write` except jobs whose purpose is mutating the repo (GitHub Release, Changesets version PR); generated output is a workflow artifact, never committed back from CI (PR #2056 pending)
-- [ ] Every action pinned to a full commit SHA (`npx actions-up`) (PR #2056 pending)
-- [ ] Every job installs Socket Firewall (`SocketDev/action` SHA-pinned, `firewall-version` pinned); `pnpm install` / `npm install` run as `sfw pnpm install` / `sfw npm install` (PR #2056 pending)
-- [ ] `.github/workflows/check-workflows.yaml` lints workflows with zizmor on every PR (PR #2056 pending)
-- [ ] Workflow `name:` and job `name:` contain no spaces (kebab-case) so they can be set as required status checks (PR #2056 pending)
-- [ ] `persist-credentials: false` on checkouts that don't push (PR #2056 pending)
+- [x] `permissions: contents: read` (or `{}` + per-job grants) on every workflow — PR #2056
+- [x] No `contents: write` except jobs whose purpose is mutating the repo (GitHub Release, Changesets version PR); generated output is a workflow artifact, never committed back from CI — PR #2056
+- [x] Every action pinned to a full commit SHA (`npx actions-up`) — PR #2056
+- [x] Every job installs Socket Firewall (`SocketDev/action` SHA-pinned, `firewall-version` pinned); `pnpm install` / `npm install` run as `sfw pnpm install` / `sfw npm install` — PR #2056
+- [x] `.github/workflows/check-workflows.yaml` lints workflows with zizmor on every PR — PR #2056
+- [x] Workflow `name:` and job `name:` contain no spaces (kebab-case) so they can be set as required status checks — PR #2056
+- [x] `persist-credentials: false` on checkouts that don't push — PR #2056
 - [x] No `pull_request_target` on workflows that run untrusted PR code — verified 2026-08-24
-- [ ] Artifact-publishing workflows disable `actions/setup-node` default caching (`package-manager-cache: false`) to prevent cache poisoning (PR #2056 pending)
+- [x] Artifact-publishing workflows disable `actions/setup-node` default caching (`package-manager-cache: false`) to prevent cache poisoning — PR #2056
 - [x] No npm tokens (or other registry credentials) in Actions secrets — verified 2026-08-24
 
 ## 5. npm publishing — npm libraries only
 - [ ] OIDC trusted publishing configured **stage-only** on npmjs.com for the publish workflow — it can stage, never publish live (manual)
-- [ ] `.github/workflows/release.yaml` packs then stages with `pnpm stage publish ./packed/*.tgz --no-git-checks`
+- [ ] `.github/workflows/release.yaml` packs then stages with `pnpm stage publish ./packed/*.tgz --no-git-checks` (PR pending)
 - [ ] Maintainer promotes staged versions with 2FA (manual)
 - [ ] Drydock connected — staged releases reviewed before promotion (manual)
 - [ ] No direct publish rights: package requires 2FA and disallows tokens (manual)
@@ -43,7 +43,7 @@ Profile: npm library · public
 
 ## 6. Security tooling
 - [ ] Aikido runs on every build
-- [ ] Aikido release gate: the release workflow's stage-publish job `needs:` a passing `scan-release`
+- [ ] Aikido release gate: the release workflow's stage-publish job `needs:` a passing `scan-release` (PR pending)
 - [x] Socket reviews every PR that changes dependencies — verified 2026-08-24 (PR #2053: Socket Security Pull Request Alerts and Project Report)
 
 ## 7. Repository lockdown

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,7 +26,9 @@ hardening checklist; progress is tracked in [DEFENSE_IN_DEPTH.md](./DEFENSE_IN_D
 - pnpm is pinned via `packageManager` (`pnpm@11.18.0`).
 - Dependencies install through pnpm with a 7-day cooldown on new versions, lifecycle scripts blocked by default, and `trustPolicy: no-downgrade`.
 - The lockfile is committed and CI installs with `--frozen-lockfile`. There is no Dependabot config; dependency updates go through reviewed PRs.
+- CI runs with read-only permissions (only the release job gets `id-token: write`); every action is pinned to a full commit SHA; Socket Firewall (`sfw`) wraps `pnpm install` / `npm install`; workflows are security-linted with zizmor on every PR.
 - Workflows do not use `pull_request_target` and do not store npm tokens (OIDC trusted publishing).
+- The release workflow packs each package and stages it with `pnpm stage publish` after an Aikido `scan-release` gate. A maintainer still has to promote the staged version.
 - Published packages set `repository.url` to this repo so provenance can map back.
 - Socket reviews every pull request that changes dependencies.
 - Codespaces and Cursor Cloud Agents install through Aikido Safe Chain; package-manager shims must not be bypassed.

--- a/scripts/release-publish.test.ts
+++ b/scripts/release-publish.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { computeDistTag, isVersionGte, parseVersion, publishArgs } from "./release-publish.ts";
+import { computeDistTag, isVersionGte, packArgs, packedTarballFor, parseVersion, publishArgs } from "./release-publish.ts";
 
 describe("parseVersion", () => {
 	test("parses a stable version", () => {
@@ -83,33 +83,43 @@ describe("isVersionGte (downgrade guard)", () => {
 	});
 });
 
+describe("packedTarballFor / packArgs", () => {
+	test("flattens scoped names into a ./packed tarball path", () => {
+		expect(packedTarballFor("keyv")).toBe("./packed/keyv.tgz");
+		expect(packedTarballFor("@keyv/redis")).toBe("./packed/keyv-redis.tgz");
+	});
+
+	test("packs a workspace package to that tarball path", () => {
+		expect(packArgs("keyv")).toEqual(["--filter", "keyv", "pack", "--out", "./packed/keyv.tgz"]);
+	});
+});
+
 describe("publishArgs", () => {
-	test("builds the exact pnpm publish command for a package + tag", () => {
-		expect(publishArgs("keyv", "beta")).toEqual([
-			"--filter",
-			"keyv",
+	test("builds the exact pnpm stage publish command for a tarball + tag", () => {
+		expect(publishArgs("./packed/keyv.tgz", "beta")).toEqual([
+			"stage",
 			"publish",
+			"./packed/keyv.tgz",
 			"--tag",
 			"beta",
 			"--no-git-checks",
 			"--access",
 			"public",
 			"--provenance",
-			"--loglevel=verbose",
 		]);
 	});
 
-	test("uses the given package name and tag", () => {
-		expect(`pnpm ${publishArgs("@keyv/redis", "v5-lts").join(" ")}`).toBe(
-			"pnpm --filter @keyv/redis publish --tag v5-lts --no-git-checks --access public --provenance --loglevel=verbose",
+	test("uses the given tarball and tag", () => {
+		expect(`pnpm ${publishArgs("./packed/keyv-redis.tgz", "v5-lts").join(" ")}`).toBe(
+			"pnpm stage publish ./packed/keyv-redis.tgz --tag v5-lts --no-git-checks --access public --provenance",
 		);
 	});
 
-	// Release-blocking guard: the workflow runs these tests before publishing,
+	// Release-blocking guard: the workflow runs these tests before staging,
 	// so removing --provenance from publishArgs fails the release. Provenance
-	// attestation is required for every package published from this repo.
+	// attestation is required for every package staged from this repo.
 	test("always includes --provenance (required for npm provenance attestation)", () => {
-		expect(publishArgs("keyv", "latest")).toContain("--provenance");
-		expect(publishArgs("@keyv/redis", "beta")).toContain("--provenance");
+		expect(publishArgs("./packed/keyv.tgz", "latest")).toContain("--provenance");
+		expect(publishArgs("./packed/keyv-redis.tgz", "beta")).toContain("--provenance");
 	});
 });

--- a/scripts/release-publish.ts
+++ b/scripts/release-publish.ts
@@ -32,13 +32,15 @@
  * `6.x`, never a tag. See website/site/docs/versioning.md for the user-facing
  * explanation.
  *
- * ## Why everything is a single `publish --tag` (no `npm dist-tag add`)
+ * ## Why everything is a single `stage publish --tag` (no `npm dist-tag add`)
  *
  * The release workflow authenticates to npm with OIDC trusted publishing (no
- * long-lived NPM_TOKEN). OIDC authorizes the `publish` command only — it does
- * NOT authorize `npm dist-tag add` (npm/cli#8547). So this script never calls
- * `dist-tag add`; it applies exactly one tag per package via `publish --tag`,
- * which keeps the pipeline token-free.
+ * long-lived NPM_TOKEN). CI packs each package and runs `pnpm stage publish`
+ * so the version lands in npm's staging queue, not live on the registry. A
+ * maintainer promotes the staged artifact with 2FA. OIDC authorizes the
+ * publish/stage command only — it does NOT authorize `npm dist-tag add`
+ * (npm/cli#8547). So this script never calls `dist-tag add`; it applies
+ * exactly one tag per package via `stage publish --tag`.
  *
  * ## Safety properties
  *
@@ -129,7 +131,7 @@ export function parseVersion(version: string): ParsedVersion {
 }
 
 export type DistTagPlan = {
-	/** The single tag passed to `pnpm publish --tag`. */
+	/** The single tag passed to `pnpm stage publish --tag`. */
 	tag: string;
 	/** Whether this release moves the `latest` tag (triggers the downgrade guard). */
 	setsLatest: boolean;
@@ -337,40 +339,60 @@ function currentLatest(name: string): string | undefined {
 }
 
 /**
- * The exact `pnpm` argument list used to publish a package — the single source
- * of truth so the same command is both printed and executed. Flags:
- * `--no-git-checks` (the release commit may be detached/tagged in CI),
+ * Relative tarball path for a workspace package (`./` prefix required so
+ * `pnpm stage publish` treats it as a local path). Scoped names are flattened
+ * (`@keyv/redis` -> `keyv-redis`).
+ */
+export function packedTarballFor(name: string): string {
+	return `./packed/${name.replace(/^@/, "").replaceAll("/", "-")}.tgz`;
+}
+
+/**
+ * Pack a workspace package to a known tarball path under `./packed/`.
+ */
+export function packArgs(name: string): string[] {
+	return ["--filter", name, "pack", "--out", packedTarballFor(name)];
+}
+
+/**
+ * The exact `pnpm` argument list used to stage a packed tarball — the single
+ * source of truth so the same command is both printed and executed. Flags:
+ * `--no-git-checks` (git-checks run even for a tarball and fail on a detached
+ * release-tag checkout and on the untracked pack output),
  * `--access public` (required for the scoped `@keyv/*` packages),
  * `--provenance` (REQUIRED: generates the npm provenance attestation from the
- * CI OIDC context so every published package is verifiably built here; it
+ * CI OIDC context so every staged package is verifiably built here; it
  * fails closed when no OIDC context is available, and release-publish.test.ts
- * asserts the flag is always present), and verbose logging to aid debugging
- * during the rollout.
+ * asserts the flag is always present).
  */
-export function publishArgs(name: string, tag: string): string[] {
+export function publishArgs(tarball: string, tag: string): string[] {
 	return [
-		"--filter",
-		name,
+		"stage",
 		"publish",
+		tarball,
 		"--tag",
 		tag,
 		"--no-git-checks",
 		"--access",
 		"public",
 		"--provenance",
-		"--loglevel=verbose",
 	];
 }
 
 /**
- * Publish a single workspace package under exactly one dist-tag. Echoes the
- * exact `pnpm` command first, then runs it inheriting stdio so npm's output
- * streams to the job log. Throws if the publish fails (caught by the caller).
+ * Pack a workspace package, then stage the tarball under exactly one dist-tag.
+ * Echoes the exact `pnpm` commands first, then runs them inheriting stdio so
+ * npm's output streams to the job log. Throws if pack or stage fails.
  */
 function publishPackage(name: string, tag: string): void {
-	const args = publishArgs(name, tag);
+	fs.mkdirSync(path.join(rootDir, "packed"), { recursive: true });
+	const pack = packArgs(name);
+	console.log(`  $ pnpm ${pack.join(" ")}`);
+	execFileSync("pnpm", pack, { cwd: rootDir, stdio: "inherit" });
+
+	const args = publishArgs(packedTarballFor(name), tag);
 	console.log(`  $ pnpm ${args.join(" ")}`);
-	execFileSync("pnpm", args, { stdio: "inherit" });
+	execFileSync("pnpm", args, { cwd: rootDir, stdio: "inherit" });
 }
 
 function appendSummary(markdown: string): void {
@@ -420,7 +442,7 @@ function main(): void {
 
 	console.log(`\nRelease version: ${releaseVersion}`);
 	console.log(`Dist-tag (keyv): ${releasePlan.tag}  (${releasePlan.reason})`);
-	console.log(`Mode:            ${dryRun ? "DRY RUN — nothing will be published" : "PUBLISH"}\n`);
+	console.log(`Mode:            ${dryRun ? "DRY RUN — nothing will be staged" : "STAGE"}\n`);
 
 	// --- Step 3: discover packages ---
 	const packages = getPublishablePackages();
@@ -462,7 +484,7 @@ function main(): void {
 	const nameWidth = Math.max(7, ...rows.map((r) => r.name.length));
 	console.log("Publish plan:");
 	for (const r of rows) {
-		const mark = r.action === "publish" ? "PUBLISH" : "skip (already published)";
+		const mark = r.action === "publish" ? "STAGE" : "skip (already published)";
 		console.log(`  ${r.name.padEnd(nameWidth)}  ${r.version.padEnd(16)}  → ${r.tag.padEnd(8)}  [${mark}]`);
 	}
 
@@ -511,28 +533,29 @@ function main(): void {
 		if (ordered.length > 0) {
 			console.log("Commands that would run (in order):");
 			for (const r of ordered) {
-				console.log(`  $ pnpm ${publishArgs(r.name, r.tag).join(" ")}`);
+				console.log(`  $ pnpm ${packArgs(r.name).join(" ")}`);
+				console.log(`  $ pnpm ${publishArgs(packedTarballFor(r.name), r.tag).join(" ")}`);
 			}
 			console.log("");
 		}
-		console.log("Dry run complete — nothing published.");
+		console.log("Dry run complete — nothing staged.");
 		return;
 	}
 
 	if (ordered.length === 0) {
-		console.log("Nothing to publish — all versions already on the registry.");
+		console.log("Nothing to stage — all versions already on the registry.");
 		return;
 	}
 
 	const failures: string[] = [];
 	for (const r of ordered) {
-		console.log(`\nPublishing ${r.name}@${r.version} → ${r.tag}`);
+		console.log(`\nStaging ${r.name}@${r.version} → ${r.tag}`);
 		try {
 			publishPackage(r.name, r.tag);
 		} catch (error) {
-			console.error(`✖ Failed to publish ${r.name}@${r.version}: ${(error as Error).message}`);
+			console.error(`✖ Failed to stage ${r.name}@${r.version}: ${(error as Error).message}`);
 			if (r.name === "keyv") {
-				console.error("✖ Aborting: core `keyv` failed to publish, so its dependents will not be published.");
+				console.error("✖ Aborting: core `keyv` failed to stage, so its dependents will not be staged.");
 				process.exit(1);
 			}
 			failures.push(`${r.name}@${r.version}`);
@@ -540,11 +563,11 @@ function main(): void {
 	}
 
 	if (failures.length > 0) {
-		console.error(`\n✖ ${failures.length} package(s) failed to publish: ${failures.join(", ")}`);
+		console.error(`\n✖ ${failures.length} package(s) failed to stage: ${failures.join(", ")}`);
 		process.exit(1);
 	}
 
-	console.log(`\n✓ Published ${toPublish.length} package(s).`);
+	console.log(`\n✓ Staged ${toPublish.length} package(s).`);
 }
 
 // Only run when executed directly (e.g. `pnpm tsx scripts/release-publish.ts`),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Switch the existing release pipeline to pack + `pnpm stage publish` (keeping dist-tag, skip-unchanged, and `latest` guards) and require an Aikido `scan-release` gate before staging (sections 5 and 6).

Status update: `DEFENSE_IN_DEPTH.md` § 5 stage-publish + § 6 Aikido gate → `(PR #2057 pending)`; § 4 → `PR #2056`

## Changes

- `release-publish.ts` packs each package to `./packed/` then runs `pnpm stage publish <tarball> --tag … --no-git-checks --access public --provenance`
- Release job `publish` now `needs:` `aikido-gate` (`aikido-api-client scan-release`)
- Dist-tag selection, skip-unchanged, `latest` downgrade guard, and core-first ordering are unchanged
- Gitignore `packed/`

## Verification

- [x] `pnpm exec vitest run --config vitest.config.ts scripts/release-publish.test.ts` (22 tests passed)
- [x] `publishArgs` still requires `--provenance`

Reference: defense-in-depth-nodejs § 5 and § 6

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5172eb2f-0031-4580-bcaa-6cc9457560b4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5172eb2f-0031-4580-bcaa-6cc9457560b4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

