### PR TITLE
mono - chore: defense - reconcile merged stage-publish status

### DIFF
--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -35,15 +35,15 @@ Profile: npm library · public
 
 ## 5. npm publishing — npm libraries only
 - [ ] OIDC trusted publishing configured **stage-only** on npmjs.com for the publish workflow — it can stage, never publish live (manual)
-- [ ] `.github/workflows/release.yaml` packs then stages with `pnpm stage publish ./packed/*.tgz --no-git-checks` (PR #2057 pending)
+- [x] `.github/workflows/release.yaml` packs then stages with `pnpm stage publish ./packed/*.tgz --no-git-checks` — PR #2057
 - [ ] Maintainer promotes staged versions with 2FA (manual)
 - [ ] Drydock connected — staged releases reviewed before promotion (manual)
 - [ ] No direct publish rights: package requires 2FA and disallows tokens (manual)
 - [x] `package.json` `repository.url` accurate so provenance maps to this repo — verified 2026-08-24
 
 ## 6. Security tooling
-- [ ] Aikido runs on every build
-- [ ] Aikido release gate: the release workflow's stage-publish job `needs:` a passing `scan-release` (PR #2057 pending)
+- [x] Aikido runs on every build — verified 2026-08-24 (PR #2053–#2057: Aikido Security: check code)
+- [x] Aikido release gate: the release workflow's stage-publish job `needs:` a passing `scan-release` — PR #2057
 - [x] Socket reviews every PR that changes dependencies — verified 2026-08-24 (PR #2053: Socket Security Pull Request Alerts and Project Report)
 
 ## 7. Repository lockdown

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,5 +30,5 @@ hardening checklist; progress is tracked in [DEFENSE_IN_DEPTH.md](./DEFENSE_IN_D
 - Workflows do not use `pull_request_target` and do not store npm tokens (OIDC trusted publishing).
 - The release workflow packs each package and stages it with `pnpm stage publish` after an Aikido `scan-release` gate. A maintainer still has to promote the staged version.
 - Published packages set `repository.url` to this repo so provenance can map back.
-- Socket reviews every pull request that changes dependencies.
+- Socket reviews every pull request that changes dependencies; Aikido scans every build.
 - Codespaces and Cursor Cloud Agents install through Aikido Safe Chain; package-manager shims must not be bypassed.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reconcile `DEFENSE_IN_DEPTH.md` after #2057 merged, and record that Aikido’s GitHub check runs on every recent PR (sections 5 and 6).

Status update: `DEFENSE_IN_DEPTH.md` § 5 stage-publish + § 6 Aikido gate → `— PR #2057`; § 6 Aikido on every build → `verified 2026-08-24`

## Changes

- Mark pack + `pnpm stage publish` and the Aikido `scan-release` gate as landed in #2057 (they were still `(PR #2057 pending)`)
- Mark “Aikido runs on every build” verified — `Aikido Security: check code` passed on PRs #2053–#2057
- Add “Aikido scans every build” to the public `SECURITY.md` summary

## Verification

- [x] `gh pr view 2057` — merged 2026-08-24
- [x] `gh pr checks` on #2053–#2057 — Aikido Security: check code passed
- [x] Docs-only; no runtime or workflow change

Reference: defense-in-depth-nodejs § 5 and § 6

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5172eb2f-0031-4580-bcaa-6cc9457560b4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5172eb2f-0031-4580-bcaa-6cc9457560b4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

