### PR TITLE
mono - chore: defense - add CODEOWNERS for high-risk paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# High-risk paths. Last matching pattern wins.
+# Root-anchored so nested copies (e.g. skills/**/scripts/) are not owned here.
+/.github/ @jaredwray
+/.cursor/ @jaredwray
+/.devcontainer/ @jaredwray
+/scripts/ @jaredwray

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -9,7 +9,7 @@ Profile: npm library · public
 - [x] `DEFENSE_IN_DEPTH.md` present (this file) — PR #2053
 
 ## 2. CODEOWNERS and cloud bootstrap
-- [ ] `.github/CODEOWNERS` covers `/.github/`, `/.cursor/`, `/.devcontainer/`, `/scripts/` with owners the maintainer names
+- [ ] `.github/CODEOWNERS` covers `/.github/`, `/.cursor/`, `/.devcontainer/`, `/scripts/` with owners the maintainer names (PR pending)
 - [x] Codespaces and Cursor Cloud Agents bootstrap Aikido Safe Chain via scripts/setup-cloud-environment.sh (--ci shims, frozen lockfile) — PR #2054
 
 ## 3. Dependencies (pnpm)

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -9,7 +9,7 @@ Profile: npm library · public
 - [x] `DEFENSE_IN_DEPTH.md` present (this file) — PR #2053
 
 ## 2. CODEOWNERS and cloud bootstrap
-- [ ] `.github/CODEOWNERS` covers `/.github/`, `/.cursor/`, `/.devcontainer/`, `/scripts/` with owners the maintainer names (PR pending)
+- [ ] `.github/CODEOWNERS` covers `/.github/`, `/.cursor/`, `/.devcontainer/`, `/scripts/` with owners the maintainer names (PR #2059 pending)
 - [x] Codespaces and Cursor Cloud Agents bootstrap Aikido Safe Chain via scripts/setup-cloud-environment.sh (--ci shims, frozen lockfile) — PR #2054
 
 ## 3. Dependencies (pnpm)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Add `.github/CODEOWNERS` so changes to workflows, Cursor/Codespaces bootstrap, and publish scripts require a named owner (section 2).

Status update: `DEFENSE_IN_DEPTH.md` § 2 CODEOWNERS → `(PR #2059 pending)`

## Changes

- Own `/.github/`, `/.cursor/`, `/.devcontainer/`, and `/scripts/` as `@jaredwray` (same template as ecto and agentic)
- Paths are root-anchored so nested copies are not owned by this file

## Verification

- [x] File matches the defense-in-depth-nodejs § 2 template
- [x] No other CODEOWNERS at repo root or `docs/`
- [x] Docs + CODEOWNERS only; no runtime or workflow change

Reference: defense-in-depth-nodejs § 2

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5172eb2f-0031-4580-bcaa-6cc9457560b4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5172eb2f-0031-4580-bcaa-6cc9457560b4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

