### PR TITLE
mono - chore: defense - record npm stage-only and Drydock manuals

### DIFF
--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -34,11 +34,11 @@ Profile: npm library · public
 - [x] No npm tokens (or other registry credentials) in Actions secrets — verified 2026-08-24
 
 ## 5. npm publishing — npm libraries only
-- [ ] OIDC trusted publishing configured **stage-only** on npmjs.com for the publish workflow — it can stage, never publish live (manual)
+- [x] OIDC trusted publishing configured **stage-only** on npmjs.com for the publish workflow — it can stage, never publish live (manual) — verified 2026-08-25
 - [x] `.github/workflows/release.yaml` packs then stages with `pnpm stage publish ./packed/*.tgz --no-git-checks` — PR #2057
-- [ ] Maintainer promotes staged versions with 2FA (manual)
-- [ ] Drydock connected — staged releases reviewed before promotion (manual)
-- [ ] No direct publish rights: package requires 2FA and disallows tokens (manual)
+- [x] Maintainer promotes staged versions with 2FA (manual) — verified 2026-08-25
+- [x] Drydock connected — staged releases reviewed before promotion (manual) — verified 2026-08-25
+- [x] No direct publish rights: package requires 2FA and disallows tokens (manual) — verified 2026-08-25
 - [x] `package.json` `repository.url` accurate so provenance maps to this repo — verified 2026-08-24
 
 ## 6. Security tooling

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,8 +30,8 @@ hardening checklist; progress is tracked in [DEFENSE_IN_DEPTH.md](./DEFENSE_IN_D
 - Dependencies install through pnpm with a 7-day cooldown on new versions, lifecycle scripts blocked by default, and `trustPolicy: no-downgrade`.
 - The lockfile is committed and CI installs with `--frozen-lockfile`. There is no Dependabot config; dependency updates go through reviewed PRs.
 - CI runs with read-only permissions (only the release job gets `id-token: write`); every action is pinned to a full commit SHA; Socket Firewall (`sfw`) wraps `pnpm install` / `npm install`; workflows are security-linted with zizmor on every PR.
-- Workflows do not use `pull_request_target` and do not store npm tokens (OIDC trusted publishing).
-- The release workflow packs each package and stages it with `pnpm stage publish` after an Aikido `scan-release` gate. A maintainer still has to promote the staged version.
+- Workflows do not use `pull_request_target`.
+- npm releases are staged, never published directly: CI stages via stage-only OIDC trusted publishing after an Aikido `scan-release` gate, Drydock reviews the staged artifact, and a maintainer promotes it with 2FA. There are no npm tokens.
 - Published packages set `repository.url` to this repo so provenance can map back.
 - Socket reviews every pull request that changes dependencies; Aikido scans every build.
 - Codespaces and Cursor Cloud Agents install through Aikido Safe Chain; package-manager shims must not be bypassed.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Record the remaining § 5 npm manuals as live (stage-only OIDC, Drydock, 2FA promotion, 2FA required / tokens disallowed) and update the public `SECURITY.md` publish summary.

Status update: `DEFENSE_IN_DEPTH.md` § 5 OIDC stage-only, Drydock, 2FA promotion, and require-2FA / disallow-tokens → `verified 2026-08-25`

## Changes

- Check off the four npmjs.com manuals the maintainer completed
- State that releases are staged only, reviewed in Drydock, and promoted with 2FA; there are no npm tokens

## Verification

- [x] Maintainer confirmed items 1–4
- [x] Docs only; no runtime or workflow change

Reference: defense-in-depth-nodejs § 5

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5172eb2f-0031-4580-bcaa-6cc9457560b4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5172eb2f-0031-4580-bcaa-6cc9457560b4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

