### PR TITLE
sqlite - fix: harden v6 sqlite adapter, docs, and tests

### DIFF
--- a/storage/mysql/src/index.ts
+++ b/storage/mysql/src/index.ts
@@ -675,20 +675,23 @@ export class KeyvMysql extends Hookified implements KeyvStorageAdapter {
 	public async *iterator(): AsyncGenerator<[string, string], void, unknown> {
 		const limit = this._iterationLimit || 10;
 		const namespaceValue = this.getNamespaceValue();
+		const table = escapeIdentifier(this._table);
 		let lastKey: string | null = null;
 
 		while (true) {
 			let sql: string;
 			if (lastKey === null) {
-				// First batch: no cursor constraint
+				// First batch: no cursor constraint.
+				// Alias the converted key as converted_id so ORDER BY id uses the VARBINARY
+				// column (keyset order) rather than the utf8 alias (collation order).
 				sql = mysql.format(
-					`SELECT CONVERT(id USING utf8mb4) AS id, value, expires FROM ${escapeIdentifier(this._table)} WHERE namespace = ? AND (expires IS NULL OR expires > ?) ORDER BY id LIMIT ?`,
+					`SELECT CONVERT(id USING utf8mb4) AS converted_id, value, expires FROM ${table} WHERE namespace = ? AND (expires IS NULL OR expires > ?) ORDER BY id LIMIT ?`,
 					[this.encodeNamespace(namespaceValue), Date.now(), limit],
 				);
 			} else {
-				// Subsequent batches: use keyset pagination
+				// Subsequent batches: use keyset pagination on the VARBINARY id column.
 				sql = mysql.format(
-					`SELECT CONVERT(id USING utf8mb4) AS id, value, expires FROM ${escapeIdentifier(this._table)} WHERE namespace = ? AND id > ? AND (expires IS NULL OR expires > ?) ORDER BY id LIMIT ?`,
+					`SELECT CONVERT(id USING utf8mb4) AS converted_id, value, expires FROM ${table} WHERE namespace = ? AND id > ? AND (expires IS NULL OR expires > ?) ORDER BY id LIMIT ?`,
 					[this.encodeNamespace(namespaceValue), this.encodeKey(lastKey), Date.now(), limit],
 				);
 			}
@@ -699,11 +702,11 @@ export class KeyvMysql extends Hookified implements KeyvStorageAdapter {
 			}
 
 			for (const entry of entries) {
-				yield [entry.id, entry.value];
+				yield [entry.converted_id, entry.value];
 			}
 
 			// Update cursor to the last key processed
-			lastKey = entries[entries.length - 1].id;
+			lastKey = entries[entries.length - 1].converted_id;
 
 			// If we got fewer entries than the limit, we've reached the end
 			if (entries.length < limit) {

--- a/storage/mysql/test/test.ts
+++ b/storage/mysql/test/test.ts
@@ -1401,6 +1401,32 @@ describe("iterator", () => {
 		expect(collected.get(key3)).toBe(val3);
 	});
 
+	test("iterates mixed-case keys across keyset pages", async () => {
+		const keyv = new KeyvMysql({ uri, iterationLimit: 2 });
+		keyv.namespace = faker.string.alphanumeric(8);
+		await keyv.clear();
+		// utf8mb4_ci order is apple, banana, Zebra; VARBINARY order is Zebra, apple, banana.
+		// ORDER BY the utf8 alias with LIMIT 2 used to skip Zebra on the next page.
+		const entries = [
+			{ key: "Zebra", value: faker.lorem.word() },
+			{ key: "apple", value: faker.lorem.word() },
+			{ key: "banana", value: faker.lorem.word() },
+		];
+		for (const entry of entries) {
+			await keyv.set(entry.key, entry.value);
+		}
+
+		const collected = new Map<string, string>();
+		for await (const [key, value] of keyv.iterator()) {
+			collected.set(key, value);
+		}
+
+		expect(collected.size).toBe(3);
+		for (const entry of entries) {
+			expect(collected.get(entry.key)).toBe(entry.value);
+		}
+	});
+
 	test("only yields keys from the configured namespace", async () => {
 		const ns1 = faker.string.alphanumeric(8);
 		const ns2 = faker.string.alphanumeric(8);

--- a/storage/sqlite/README.md
+++ b/storage/sqlite/README.md
@@ -104,11 +104,11 @@ const keyv = createKeyv({
 
 | Driver | Package | Runtime | Type |
 | --- | --- | --- | --- |
-| `better-sqlite3` | `better-sqlite3` | Node.js | Synchronous (fallback) |
-| `node:sqlite` | Built-in | Node.js 22.13+ | Synchronous |
+| `better-sqlite3` | `better-sqlite3` | Node.js | Synchronous (bundled fallback) |
+| `node:sqlite` | Built-in | Node.js 22.13+ | Synchronous (auto-detected default; still experimental) |
 | `bun:sqlite` | Built-in | Bun | Synchronous |
 
-The built-in runtime drivers are preferred: on Node.js 22.13+ the built-in `node:sqlite` driver is used (available behind the `--experimental-sqlite` flag from 22.5), and on Bun the native `bun:sqlite` driver is used. `better-sqlite3` is included as a direct dependency and used as a fallback when a built-in driver is unavailable, or explicitly via `driver: 'better-sqlite3'`. If you still need to use `sqlite3` then go to the [using sqlite3](#using-sqlite3).
+The built-in runtime drivers are preferred: on Node.js 22.13+ the built-in `node:sqlite` driver is used (unflagged since 22.13, still experimental — [Stability 1.1](https://nodejs.org/api/sqlite.html)), and on Bun the native `bun:sqlite` driver is used. `better-sqlite3` is included as a direct dependency and used as a fallback when a built-in driver is unavailable, or explicitly via `driver: 'better-sqlite3'`. If you still need to use `sqlite3` then go to the [using sqlite3](#using-sqlite3).
 
 ## Selecting a specific driver
 
@@ -223,6 +223,8 @@ In v5, namespaces were stored as key prefixes in the `key` column (e.g. `key="my
 
 The adapter automatically detects old schemas and migrates existing data on connect — no manual migration steps are needed. During migration, prefixed keys like `myns:mykey` are split into `key="mykey"` and `namespace="myns"`.
 
+**Colon caveat:** migration splits on the **first** colon. That is correct for v5 namespaced keys (`namespace:actualKey`, including keys that themselves contain colons). It is incorrect for v5 data stored **without** a namespace where the key itself contains a colon (e.g. `http://example.com` becomes `namespace="http"`, `key="//example.com"`). If you stored colon-containing keys without a namespace, migrate those rows yourself before upgrading.
+
 ### Hookified integration
 
 The adapter now extends [Hookified](https://hookified.org) instead of a custom EventEmitter. Events work the same (`on`, `emit`), but hooks are also available via the standard Hookified API.
@@ -231,7 +233,7 @@ The adapter now extends [Hookified](https://hookified.org) instead of a custom E
 
 ### Native TTL support with `expires` column
 
-v6 adds an `expires BIGINT` column to the table. When values are stored with a TTL via Keyv core, the adapter automatically extracts the `expires` timestamp from the serialized value and stores it in the column. A partial index is created on the `expires` column for efficient cleanup queries.
+v6 adds an `expires BIGINT` column to the table. Keyv core computes the absolute expiry and passes it to the adapter as the `expires` argument on `set` / `setMany` — the adapter stores that timestamp directly and does **not** parse the serialized value. A partial index is created on the `expires` column for efficient cleanup queries.
 
 The schema migration is automatic on connect — existing tables get the column added via `ALTER TABLE ... ADD COLUMN`.
 
@@ -275,7 +277,7 @@ const keyv = createKeyv('sqlite://path/to/database.sqlite');
 
 ### Multi-driver support
 
-v6 replaces the callback-based `sqlite3` package with `better-sqlite3` as the default driver and adds support for `node:sqlite` (Node.js 22.5+) and `bun:sqlite` (Bun). The driver is auto-detected or can be explicitly selected via the `driver` option. See [Multi-Driver Support](#multi-driver-support) for details.
+v6 prefers the built-in `node:sqlite` driver on Node.js 22.13+ (unflagged, still experimental) and `bun:sqlite` on Bun, with `better-sqlite3` bundled as the fallback (replacing the old callback-based `sqlite3` package). You can still select a driver explicitly via the `driver` option. See [Multi-Driver Support](#multi-driver-support) for details.
 
 ### Improved iterator
 
@@ -326,7 +328,7 @@ console.log(store.uri); // 'sqlite://path/to/database.sqlite'
 
 ## table
 
-Get or set the table name used for storage. The name is sanitized and escaped for safe use in SQL queries to prevent SQL injection.
+Get or set the table name used for storage. The name is sanitized and escaped for safe use in SQL queries to prevent SQL injection. Changing this after construction does not create or migrate the new table — it only changes which table subsequent queries target.
 
 - Type: `string`
 - Default: `'keyv'`
@@ -488,6 +490,8 @@ console.log(store.opts.db); // ':memory:'
 
 Set a key-value pair. Returns `true` on success, `false` on failure.
 
+When called through a `Keyv` instance, `ttl` is a **relative** duration in milliseconds. Keyv converts it to an absolute Unix-ms `expires` timestamp before calling the adapter. If you call `store.set()` directly, the third argument is that absolute `expires` timestamp (not a relative TTL).
+
 - `key` *(string)* - The key to set.
 - `value` *(any)* - The value to store.
 - `ttl` *(number, optional)* - Time to live in milliseconds.
@@ -500,7 +504,7 @@ await keyv.set('foo', 'bar', 5000); // expires in 5 seconds
 
 ## .setMany(entries)
 
-Set multiple key-value pairs at once. Each entry is a `KeyvEntry<Value>` object (`{ key: string, value: Value, ttl?: number }`), where `Value` is inferred from the entries provided. Entries are automatically batched (249 per batch) to stay within SQLite's bind parameter limit. Returns a `boolean[]` with per-entry success tracking. Each batch is atomic — if a batch fails, entries in that batch return `false` while entries in successful batches return `true`. On batch failure, an `error` event is emitted.
+Set multiple key-value pairs at once. Through a `Keyv` instance each entry is a `KeyvEntry` (`{ key, value, ttl? }`) with a relative `ttl`. The adapter itself receives `KeyvStorageEntry` objects (`{ key, value, expires? }`) with an absolute `expires` timestamp. Entries are automatically batched (249 per batch) to stay within SQLite's bind parameter limit. Returns a `boolean[]` with per-entry success tracking. Each batch is atomic — if a batch fails, entries in that batch return `false` while entries in successful batches return `true`. On batch failure, an `error` event is emitted.
 
 ```js
 const results = await keyv.setMany([
@@ -594,7 +598,7 @@ await store.disconnect();
 
 # Clearing Expired Keys
 
-When a key is stored with a TTL, the adapter records the expiration timestamp in the `expires` column. Keyv core enforces TTL automatically — expired keys return `undefined` from `get()` and `false` from `has()`, and are lazily deleted from the store when accessed via `get()`, `getMany()`, or iteration.
+When a key is stored with a TTL, the adapter records the expiration timestamp in the `expires` column. Keyv core enforces TTL automatically — expired keys return `undefined` from `get()` and `false` from `has()`, and are lazily deleted from the store when accessed via `get()`, `getMany()`, `has()`, or `hasMany()`. The iterator skips expired rows but does not delete them.
 
 However, expired rows that are never accessed again will remain in the database. The `clearExpired()` method and `clearExpiredInterval` option provide bulk cleanup to remove these stale rows efficiently via SQL, without needing to deserialize every row.
 
@@ -658,8 +662,8 @@ Simple `set` / `get` benchmarks comparing the built-in SQLite drivers plus an op
 | sqlite3 set / get   |  -74.7%   |       16K |      67µs |  ±1.25%  |       15K |
 <!-- BENCHMARK-RESULTS-END -->
 
-Note: we included `sqlite3` tests in this but by default we do not have it as a dependency as our fallback is `better-sqlite3` now. Please refor to [using sqlite3](#using-sqlite3) if you want to use it.
+Note: we included `sqlite3` tests in this but by default we do not have it as a dependency as our fallback is `better-sqlite3` now. Please refer to [using sqlite3](#using-sqlite3) if you want to use it.
 
 # License
 
-[MIT © Jared Wray](LICENCE)
+[MIT © Jared Wray](LICENSE)

--- a/storage/sqlite/README.md
+++ b/storage/sqlite/README.md
@@ -20,10 +20,12 @@ SQLite storage adapter for [Keyv](https://github.com/jaredwray/keyv).
 - [Migrating to v6](#migrating-to-v6)
 - [Constructor Options](#constructor-options)
 - [Properties](#properties)
+  - [capabilities](#capabilities)
   - [namespace](#namespace)
   - [uri](#uri)
   - [table](#table)
   - [keySize](#keysize)
+  - [keyLength](#keylength)
   - [namespaceLength](#namespacelength)
   - [db](#db)
   - [iterationLimit](#iterationlimit)
@@ -35,7 +37,7 @@ SQLite storage adapter for [Keyv](https://github.com/jaredwray/keyv).
   - [ready](#ready)
   - [opts](#opts)
 - [Methods](#methods)
-  - [.set(key, value, ttl?)](#setkey-value-ttl)
+  - [.set(key, value, expires?)](#setkey-value-expires)
   - [.setMany(entries)](#setmanyentries)
   - [.get(key)](#getkey)
   - [.getMany(keys)](#getmanykeys)
@@ -46,7 +48,10 @@ SQLite storage adapter for [Keyv](https://github.com/jaredwray/keyv).
   - [.clear()](#clear)
   - [.clearExpired()](#clearexpired)
   - [.iterator()](#iterator)
+  - [.query(sql, ...params)](#querysql-params)
+  - [.close()](#close)
   - [.disconnect()](#disconnect)
+- [Events](#events)
 - [Clearing Expired Keys](#clearing-expired-keys)
 - [WAL Mode](#wal-mode)
 - [Benchmarks](#benchmarks)
@@ -301,6 +306,17 @@ The iterator now uses cursor-based (keyset) pagination instead of `OFFSET`. This
 
 # Properties
 
+## capabilities
+
+Read-only capability descriptor. `capabilities.expires` is `true`, which tells Keyv that `set` / `setMany` accept an **absolute** Unix-ms `expires` timestamp (the v6 storage contract).
+
+- Type: `KeyvStorageCapability`
+
+```js
+const store = new KeyvSqlite('sqlite://:memory:');
+console.log(store.capabilities.expires); // true
+```
+
 ## namespace
 
 Get or set the namespace for the adapter. Used for key prefixing and scoping operations like `clear()` and `iterator()`.
@@ -348,6 +364,19 @@ Get or set the maximum key length (VARCHAR length) for the key column.
 
 ```js
 const store = new KeyvSqlite({ uri: 'sqlite://:memory:', keySize: 512 });
+console.log(store.keySize); // 512
+```
+
+## keyLength
+
+Alias for `keySize`. The constructor option `keyLength` is deprecated; prefer `keySize`.
+
+- Type: `number`
+- Default: `255`
+
+```js
+const store = new KeyvSqlite({ uri: 'sqlite://:memory:', keyLength: 512 });
+console.log(store.keyLength); // 512
 console.log(store.keySize); // 512
 ```
 
@@ -486,92 +515,124 @@ console.log(store.opts.db); // ':memory:'
 
 # Methods
 
-## .set(key, value, ttl?)
+## .set(key, value, expires?)
 
-Set a key-value pair. Returns `true` on success, `false` on failure.
+Set a key-value pair on the store. Returns `true` on success, `false` on failure (an `error` event is also emitted).
 
-When called through a `Keyv` instance, `ttl` is a **relative** duration in milliseconds. Keyv converts it to an absolute Unix-ms `expires` timestamp before calling the adapter. If you call `store.set()` directly, the third argument is that absolute `expires` timestamp (not a relative TTL).
+The third argument is an **absolute** Unix timestamp in milliseconds (`Date.now() + ttl`), or omitted/`undefined` for no expiry. This is the v6 adapter contract.
+
+When you call `keyv.set(key, value, ttl)` on a `Keyv` instance, `ttl` is still a **relative** duration in milliseconds — Keyv converts it to `expires` before calling the adapter.
 
 - `key` *(string)* - The key to set.
 - `value` *(any)* - The value to store.
-- `ttl` *(number, optional)* - Time to live in milliseconds.
+- `expires` *(number, optional)* - Absolute expiry as Unix ms since epoch.
 - Returns: `Promise<boolean>`
 
 ```js
-await keyv.set('foo', 'bar');
+await store.set('foo', 'bar');
+await store.set('foo', 'bar', Date.now() + 5000); // expires at an absolute timestamp
+
+// Through Keyv, ttl is still relative:
 await keyv.set('foo', 'bar', 5000); // expires in 5 seconds
 ```
 
 ## .setMany(entries)
 
-Set multiple key-value pairs at once. Through a `Keyv` instance each entry is a `KeyvEntry` (`{ key, value, ttl? }`) with a relative `ttl`. The adapter itself receives `KeyvStorageEntry` objects (`{ key, value, expires? }`) with an absolute `expires` timestamp. Entries are automatically batched (249 per batch) to stay within SQLite's bind parameter limit. Returns a `boolean[]` with per-entry success tracking. Each batch is atomic — if a batch fails, entries in that batch return `false` while entries in successful batches return `true`. On batch failure, an `error` event is emitted.
+Set multiple key-value pairs at once. Each entry is a `KeyvStorageEntry` (`{ key, value, expires? }`) with an absolute `expires` timestamp. Through a `Keyv` instance, `keyv.setMany()` takes `KeyvEntry` objects (`{ key, value, ttl? }`) with a relative `ttl` and converts them before calling the adapter.
+
+Entries are automatically batched (249 per batch) to stay within SQLite's bind parameter limit. Returns a `boolean[]` with per-entry success tracking. Each batch is atomic — if a batch fails, entries in that batch return `false` while entries in successful batches return `true`. On batch failure, an `error` event is emitted.
+
+- `entries` *(`KeyvStorageEntry[]`)* - Entries to upsert (`{ key, value, expires? }`).
+- Returns: `Promise<boolean[]>`
 
 ```js
-const results = await keyv.setMany([
+const results = await store.setMany([
   { key: 'foo', value: 'bar' },
-  { key: 'baz', value: 'qux' },
+  { key: 'baz', value: 'qux', expires: Date.now() + 5000 },
 ]); // [true, true]
 ```
 
 ## .get(key)
 
-Get a value by key. Returns `undefined` if the key does not exist.
+Get a value by key. Returns `undefined` if the key does not exist, has expired, or was stored as SQL `NULL`. Never returns `null`.
+
+- `key` *(string)* - The key to retrieve.
+- Returns: `Promise<Value | undefined>`
 
 ```js
-const value = await keyv.get('foo'); // 'bar'
+const value = await store.get('foo'); // 'bar'
 ```
 
 ## .getMany(keys)
 
-Get multiple values at once. Returns an array of values in the same order as the keys, with `undefined` for missing keys.
+Get multiple values at once. Returns an array of values in the same order as the keys, with `undefined` for missing, expired, or SQL `NULL` entries (never `null`).
+
+- `keys` *(string[])* - The keys to retrieve.
+- Returns: `Promise<Array<Value | undefined>>`
 
 ```js
-const values = await keyv.getMany(['foo', 'baz']); // ['bar', 'qux']
+const values = await store.getMany(['foo', 'baz']); // ['bar', 'qux']
 ```
 
 ## .has(key)
 
-Check if a key exists. Returns a boolean.
+Check if a key exists. Returns a boolean. Expired keys are deleted on read and reported as missing.
+
+- `key` *(string)* - The key to check.
+- Returns: `Promise<boolean>`
 
 ```js
-const exists = await keyv.has('foo'); // true
+const exists = await store.has('foo'); // true
 ```
 
 ## .hasMany(keys)
 
-Check if multiple keys exist. Returns an array of booleans in the same order as the input keys.
+Check if multiple keys exist. Returns an array of booleans in the same order as the input keys. Expired keys are deleted on read and reported as missing.
+
+- `keys` *(string[])* - The keys to check.
+- Returns: `Promise<boolean[]>`
 
 ```js
-const results = await keyv.hasMany(['foo', 'baz', 'unknown']); // [true, true, false]
+const results = await store.hasMany(['foo', 'baz', 'unknown']); // [true, true, false]
 ```
 
 ## .delete(key)
 
 Delete a key. Returns `true` if the key existed, `false` otherwise.
 
+- `key` *(string)* - The key to delete.
+- Returns: `Promise<boolean>`
+
 ```js
-const deleted = await keyv.delete('foo'); // true
+const deleted = await store.delete('foo'); // true
 ```
 
 ## .deleteMany(keys)
 
 Delete multiple keys at once. Returns a `boolean[]` indicating whether each key existed.
 
+- `keys` *(string[])* - The keys to delete.
+- Returns: `Promise<boolean[]>`
+
 ```js
-const results = await keyv.deleteMany(['foo', 'baz']); // [true, true]
+const results = await store.deleteMany(['foo', 'baz']); // [true, true]
 ```
 
 ## .clear()
 
-Clear all keys in the current namespace.
+Clear all keys in the current namespace. If no namespace is set, entries with an empty namespace are removed.
+
+- Returns: `Promise<void>`
 
 ```js
-await keyv.clear();
+await store.clear();
 ```
 
 ## .clearExpired()
 
 Utility helper method to delete all expired entries from the store. This removes any rows where the `expires` column is set and the timestamp is in the past. This is useful for periodic cleanup of expired data.
+
+- Returns: `Promise<void>`
 
 ```js
 await store.clearExpired();
@@ -579,22 +640,67 @@ await store.clearExpired();
 
 ## .iterator()
 
-Iterate over all key-value pairs. The iterator uses the namespace configured on the instance. Uses cursor-based pagination controlled by the `iterationLimit` option.
+Iterate over all key-value pairs. The iterator uses the namespace configured on the instance. Uses cursor-based pagination controlled by the `iterationLimit` option. Expired rows are skipped (not deleted). SQL `NULL` values are yielded as `undefined`.
+
+- Returns: `AsyncGenerator<[string, string | undefined]>`
+- Yields: `[key, value]` tuples. Values are never `null`.
 
 ```js
-const iterator = keyv.iterator();
-for await (const [key, value] of iterator) {
+for await (const [key, value] of store.iterator()) {
   console.log(key, value);
 }
 ```
 
+## .query(sql, ...params)
+
+Execute a SQL statement against the database. Returns result rows for `SELECT`, `PRAGMA`, and `RETURNING` statements, and an empty array for mutations.
+
+- `sql` *(string)* - The SQL statement to execute.
+- `...params` *(unknown[])* - Bind parameters for the statement.
+- Returns: `Promise<unknown[]>`
+
+```js
+const rows = await store.query('SELECT * FROM keyv WHERE namespace = ?', 'my-namespace');
+```
+
+## .close()
+
+Close the underlying database connection. Prefer `.disconnect()`, which also stops the expired-entry cleanup timer.
+
+- Returns: `Promise<void>`
+
+```js
+await store.close();
+```
+
 ## .disconnect()
 
-Disconnect from the SQLite database and release resources. Stops the automatic expired-entry cleanup interval if running.
+Disconnect from the SQLite database and release resources. Stops the automatic expired-entry cleanup interval if running, then closes the connection.
+
+- Returns: `Promise<void>`
 
 ```js
 await store.disconnect();
 ```
+
+# Events
+
+`KeyvSqlite` extends [Hookified](https://hookified.org) (not Node's `EventEmitter`). The constructor calls `super({ throwOnEmptyListeners: false })`, so emitting `error` with no listener does not throw. Use `on`, `once`, and `emit` the same way as EventEmitter.
+
+An `error` event is emitted on:
+
+- connection / schema-setup failures
+- `set` / `setMany` failures
+- iterator failures
+- `clearExpired` interval failures
+
+```js
+const store = new KeyvSqlite('sqlite://path/to/database.sqlite');
+store.on('error', (error) => console.error(error));
+store.once('error', (error) => console.error('first error only', error));
+```
+
+Hooks from the Hookified API (`onHook`, `hook`, `before`, `after`, etc.) are also available. Storage adapters emit events; Keyv core owns operation hooks (`before:get`, `after:set`, etc.). See the [Hookified documentation](https://hookified.org).
 
 # Clearing Expired Keys
 

--- a/storage/sqlite/src/drivers/better-sqlite3-driver.ts
+++ b/storage/sqlite/src/drivers/better-sqlite3-driver.ts
@@ -7,7 +7,7 @@ function createBetterSqlite3Connection(options: SqliteDriverConnectOptions): Db 
 	const db = new Database(options.filename);
 
 	if (options.busyTimeout) {
-		db.pragma(`busy_timeout = ${options.busyTimeout}`);
+		db.pragma(`busy_timeout = ${Number(options.busyTimeout)}`);
 	}
 
 	if (shouldApplyWal(options.filename, options.wal)) {

--- a/storage/sqlite/src/drivers/driver-utils.ts
+++ b/storage/sqlite/src/drivers/driver-utils.ts
@@ -3,8 +3,8 @@ import type { DbQuery } from "../types.js";
 /**
  * Coerces bind parameters for SQLite drivers. Non-primitive values (objects)
  * are serialized to JSON strings since SQLite drivers only accept primitives.
- * @param params - The raw parameters to coerce.
- * @returns An array of primitive-safe parameters.
+ * @param {unknown[]} params - The raw parameters to coerce.
+ * @returns {unknown[]} An array of primitive-safe parameters.
  */
 export function coerceParams(params: unknown[]): unknown[] {
 	return params.map((p) => (p !== null && typeof p === "object" ? JSON.stringify(p) : p));
@@ -13,6 +13,8 @@ export function coerceParams(params: unknown[]): unknown[] {
 /**
  * Checks whether a SQL statement should return rows.
  * Matches SELECT, PRAGMA, and any statement containing a RETURNING clause.
+ * @param {string} trimmedUpperSql - The SQL statement, already trimmed and uppercased.
+ * @returns {boolean} `true` when the statement produces result rows.
  */
 export function isReturningQuery(trimmedUpperSql: string): boolean {
 	return (
@@ -25,9 +27,9 @@ export function isReturningQuery(trimmedUpperSql: string): boolean {
 /**
  * Creates a standard query function that dispatches to the appropriate
  * method based on the SQL command type (SELECT/PRAGMA/RETURNING vs mutations).
- * @param allFn - Function to execute read queries (SELECT, PRAGMA, RETURNING) that return rows.
- * @param runFn - Function to execute mutation queries (INSERT, UPDATE, DELETE).
- * @returns A {@link DbQuery} function.
+ * @param {(sql: string, params: unknown[]) => unknown[] | Promise<unknown[]>} allFn - Function to execute read queries (SELECT, PRAGMA, RETURNING) that return rows.
+ * @param {(sql: string, params: unknown[]) => void | Promise<void>} runFn - Function to execute mutation queries (INSERT, UPDATE, DELETE).
+ * @returns {DbQuery} A {@link DbQuery} function.
  */
 export function createQueryFn(
 	allFn: (sql: string, params: unknown[]) => unknown[] | Promise<unknown[]>,
@@ -48,9 +50,9 @@ export function createQueryFn(
 /**
  * Checks if WAL mode should be applied and logs a warning for in-memory databases.
  * Returns `true` if WAL mode should be enabled, `false` otherwise.
- * @param filename - The database filename.
- * @param wal - Whether WAL mode is requested.
- * @returns `true` if WAL mode should be applied.
+ * @param {string} filename - The database filename.
+ * @param {boolean} [wal] - Whether WAL mode is requested.
+ * @returns {boolean} `true` if WAL mode should be applied.
  */
 export function shouldApplyWal(filename: string, wal?: boolean): boolean {
 	if (!wal) {

--- a/storage/sqlite/src/drivers/index.ts
+++ b/storage/sqlite/src/drivers/index.ts
@@ -75,6 +75,6 @@ export async function resolveDriver(
 
 	/* v8 ignore next 3 -- @preserve */
 	throw new Error(
-		"No SQLite driver found. Use Node.js 22.13+ (built-in node:sqlite) or install better-sqlite3: npm install better-sqlite3",
+		"No SQLite driver found. Use Node.js 22.13+ (built-in node:sqlite, still experimental) or install better-sqlite3: npm install better-sqlite3",
 	);
 }

--- a/storage/sqlite/src/drivers/index.ts
+++ b/storage/sqlite/src/drivers/index.ts
@@ -40,6 +40,9 @@ declare const Bun: KeyvAny;
  * - If `preferred` is omitted, auto-detection tries drivers in priority order:
  *   - **Bun**: `bun:sqlite` then `better-sqlite3`
  *   - **Node.js**: `node:sqlite` then `better-sqlite3`
+ * @param {SqliteDriverName | SqliteDriver} [preferred] - An explicit driver name, custom driver object, or omitted for auto-detection.
+ * @returns {Promise<SqliteDriver>} The resolved driver.
+ * @throws {Error} If an explicit driver cannot be loaded, or if no auto-detected driver is available.
  */
 export async function resolveDriver(
 	preferred?: SqliteDriverName | SqliteDriver,

--- a/storage/sqlite/src/drivers/node-sqlite-driver.ts
+++ b/storage/sqlite/src/drivers/node-sqlite-driver.ts
@@ -4,7 +4,7 @@ import { createQueryFn, shouldApplyWal } from "./driver-utils.js";
 import type { SqliteDriver, SqliteDriverConnectOptions } from "./types.js";
 
 async function createNodeSqliteConnection(options: SqliteDriverConnectOptions): Promise<Db> {
-	// Dynamic import — only available on Node.js 22.5+ with --experimental-sqlite
+	// Dynamic import — unflagged since Node.js 22.13, still experimental (Stability 1.1).
 	const { DatabaseSync } = (await import("node:sqlite")) as KeyvAny;
 	const db = new DatabaseSync(options.filename);
 

--- a/storage/sqlite/src/drivers/sqlite3-driver.ts
+++ b/storage/sqlite/src/drivers/sqlite3-driver.ts
@@ -5,6 +5,7 @@ import type { SqliteDriver, SqliteDriverConnectOptions } from "./types.js";
 
 /**
  * Structural type for the `sqlite3` module so consumers don't need `@types/sqlite3`.
+ * @property {new (filename: string, callback?: (err: Error | null) => void) => Sqlite3DatabaseLike} Database - Database constructor.
  */
 export type Sqlite3ModuleLike = {
 	Database: new (filename: string, callback?: (err: Error | null) => void) => Sqlite3DatabaseLike;
@@ -12,6 +13,11 @@ export type Sqlite3ModuleLike = {
 
 /**
  * Structural type for a `sqlite3.Database` instance.
+ * @property {(sql: string, params: unknown[], callback: (err: Error | null, rows: unknown[]) => void) => void} all - Execute a statement that returns rows.
+ * @property {(sql: string, params: unknown[], callback: (err: Error | null) => void) => void} run - Execute a mutation statement.
+ * @property {(sql: string, callback?: (err: Error | null) => void) => void} exec - Execute raw SQL.
+ * @property {(option: string, value: number) => void} configure - Configure the connection (for example `busyTimeout`).
+ * @property {(callback?: (err: Error | null) => void) => void} close - Close the connection.
  */
 export type Sqlite3DatabaseLike = {
 	all(sql: string, params: unknown[], callback: (err: Error | null, rows: unknown[]) => void): void;
@@ -23,6 +29,9 @@ export type Sqlite3DatabaseLike = {
 
 /**
  * Creates a {@link SqliteDriver} backed by the user-provided `sqlite3` module.
+ *
+ * @param {Sqlite3ModuleLike} sqlite3 - The `sqlite3` module (or `sqlite3.verbose()`).
+ * @returns {SqliteDriver} A driver object suitable for `KeyvSqliteOptions.driver`.
  *
  * @example
  * ```ts

--- a/storage/sqlite/src/drivers/sqlite3-driver.ts
+++ b/storage/sqlite/src/drivers/sqlite3-driver.ts
@@ -71,30 +71,26 @@ export function createSqlite3Driver(sqlite3: Sqlite3ModuleLike): SqliteDriver {
 				await execAsync("PRAGMA journal_mode = WAL");
 			}
 
-			// Serial queue to ensure statement ordering
+			// Serial queue so statements stay ordered. A failed query must not
+			// poison the queue or leave later callers hanging.
 			let queue = Promise.resolve();
 
 			const query = async (sqlString: string, ...parameter: unknown[]) => {
 				const safeParams = coerceParams(parameter);
 				const trimmed = sqlString.trimStart().toUpperCase();
+				const task = queue.then(async () => {
+					if (isReturningQuery(trimmed)) {
+						return allAsync(sqlString, safeParams);
+					}
 
-				const result = new Promise<unknown[]>((resolve, reject) => {
-					queue = queue.then(async () => {
-						try {
-							if (isReturningQuery(trimmed)) {
-								resolve(await allAsync(sqlString, safeParams));
-							} else {
-								await runAsync(sqlString, safeParams);
-								resolve([]);
-							}
-						} catch (error) {
-							/* v8 ignore next -- @preserve: error path */
-							reject(error);
-						}
-					});
+					await runAsync(sqlString, safeParams);
+					return [];
 				});
-
-				return result;
+				queue = task.then(
+					() => undefined,
+					() => undefined,
+				);
+				return task;
 			};
 
 			const close = async () => closeAsync();

--- a/storage/sqlite/src/drivers/types.ts
+++ b/storage/sqlite/src/drivers/types.ts
@@ -1,14 +1,32 @@
 import type { Db } from "../types.js";
 
+/**
+ * Built-in and custom SQLite driver names accepted by the `driver` option.
+ */
 export type SqliteDriverName = "better-sqlite3" | "node:sqlite" | "bun:sqlite" | "custom";
 
+/**
+ * Connection options passed to {@link SqliteDriver.connect}.
+ */
 export type SqliteDriverConnectOptions = {
+	/** Database file path, or `':memory:'` for an in-memory database. */
 	filename: string;
+	/** SQLite busy timeout in milliseconds. */
 	busyTimeout?: number;
+	/** Whether WAL mode should be enabled (ignored for in-memory databases). */
 	wal?: boolean;
 };
 
+/**
+ * Pluggable SQLite driver used by {@link KeyvSqlite}.
+ */
 export type SqliteDriver = {
+	/** Driver identifier reported as `driverName` on `KeyvSqlite`. */
 	name: SqliteDriverName;
+	/**
+	 * Opens a database connection.
+	 * @param {SqliteDriverConnectOptions} options - File path, busy timeout, and WAL flag.
+	 * @returns {Promise<Db>} A handle with `query` and `close`.
+	 */
 	connect(options: SqliteDriverConnectOptions): Promise<Db>;
 };

--- a/storage/sqlite/src/index.ts
+++ b/storage/sqlite/src/index.ts
@@ -39,6 +39,16 @@ function escapeIdentifier(identifier: string): string {
 }
 
 /**
+ * Returns true when `identifier` is a safe unquoted SQLite name (letter/underscore, then
+ * alphanumeric or underscore). Table names are reduced to this set by {@link toTableString}.
+ * @param {string} identifier - The identifier to validate.
+ * @returns {boolean} `true` if the identifier is safe to quote and interpolate.
+ */
+function isSafeSqlIdentifier(identifier: string): boolean {
+	return /^[A-Za-z_][A-Za-z0-9_]*$/.test(identifier);
+}
+
+/**
  * SQLite storage adapter for Keyv.
  *
  * Supports multiple drivers (`better-sqlite3`, `node:sqlite`, `bun:sqlite`) with
@@ -839,7 +849,7 @@ export class KeyvSqlite extends Hookified implements KeyvStorageAdapter {
 				await database.query(createTable);
 			}
 
-			await database.query(this.getLegacyMigrationInsertSql(oldTable));
+			await database.query(this.getLegacyMigrationInsertSql());
 			await database.query(`DROP TABLE ${oldTable}`);
 		});
 	}
@@ -857,7 +867,7 @@ export class KeyvSqlite extends Hookified implements KeyvStorageAdapter {
 		await this.runInTransaction(database, async () => {
 			await database.query(`ALTER TABLE ${newTable} RENAME TO ${oldTable}`);
 			await database.query(createTable);
-			await database.query(this.getLegacyMigrationInsertSql(oldTable));
+			await database.query(this.getLegacyMigrationInsertSql());
 			await database.query(`DROP TABLE ${oldTable}`);
 		});
 	}
@@ -882,12 +892,26 @@ export class KeyvSqlite extends Hookified implements KeyvStorageAdapter {
 	/**
 	 * Copies rows from a pre-v6 table, splitting `namespace:key` prefixes on the
 	 * first colon. Keys with no colon stay in the default (empty) namespace.
-	 * @param {string} oldTable - The escaped identifier of the source table.
+	 * Identifiers are derived from the sanitized {@link table} name and quoted only
+	 * after an alphanumeric whitelist check (table names cannot be bound as parameters).
 	 * @returns {string} An `INSERT OR IGNORE ... SELECT` statement.
 	 */
-	private getLegacyMigrationInsertSql(oldTable: string): string {
-		const newTable = this.getCleanTableName();
-		return `INSERT OR IGNORE INTO ${newTable} (key, value, namespace) SELECT CASE WHEN INSTR(key, ':') > 0 THEN SUBSTR(key, INSTR(key, ':') + 1) ELSE key END, value, CASE WHEN INSTR(key, ':') > 0 THEN SUBSTR(key, 1, INSTR(key, ':') - 1) ELSE '' END FROM ${oldTable}`;
+	private getLegacyMigrationInsertSql(): string {
+		const table = this._table;
+		const oldName = `${table}_migration_old`;
+		/* v8 ignore next 3 -- @preserve: table names are sanitized in the constructor */
+		if (!isSafeSqlIdentifier(table) || !isSafeSqlIdentifier(oldName)) {
+			throw new Error("Invalid table name: must contain alphanumeric characters");
+		}
+
+		const newTable = `"${table}"`;
+		const oldTable = `"${oldName}"`;
+		return (
+			"INSERT OR IGNORE INTO " +
+			newTable +
+			" (key, value, namespace) SELECT CASE WHEN INSTR(key, ':') > 0 THEN SUBSTR(key, INSTR(key, ':') + 1) ELSE key END, value, CASE WHEN INSTR(key, ':') > 0 THEN SUBSTR(key, 1, INSTR(key, ':') - 1) ELSE '' END FROM " +
+			oldTable
+		);
 	}
 
 	/**

--- a/storage/sqlite/src/index.ts
+++ b/storage/sqlite/src/index.ts
@@ -128,6 +128,9 @@ export class KeyvSqlite extends Hookified implements KeyvStorageAdapter {
 	/** The timer reference for the automatic expired-entry cleanup interval. */
 	private _clearExpiredTimer?: ReturnType<typeof setInterval>;
 
+	/** Guards overlapping `clearExpired()` runs from the interval timer. */
+	private _clearExpiredRunning = false;
+
 	/** The resolved driver name, populated after connection. */
 	private _resolvedDriverName?: string;
 
@@ -165,35 +168,7 @@ export class KeyvSqlite extends Hookified implements KeyvStorageAdapter {
 
 		const connected: Promise<Db> = this.createConnection()
 			.then(async (database) => {
-				// Check if table exists and needs migration
-				const tableInfo = await database.query(`PRAGMA table_info(${this.getCleanTableName()})`);
-
-				if (tableInfo.length === 0) {
-					// Table doesn't exist — create with new schema
-					await database.query(createTable);
-				} else {
-					// Table exists — check if migration is needed
-					const columnNames = (tableInfo as Array<{ name: string }>).map((c) => c.name);
-					if (!columnNames.includes("namespace")) {
-						// Old schema detected — migrate by recreating table
-						// Old keys are stored as "namespace:actualKey" (e.g. "keyv:foo").
-						// Split them so the new schema stores key and namespace separately.
-						const oldTable = escapeIdentifier(`${this._table}_migration_old`);
-						const newTable = this.getCleanTableName();
-						await database.query(`ALTER TABLE ${newTable} RENAME TO ${oldTable}`);
-						await database.query(createTable);
-						await database.query(
-							`INSERT OR IGNORE INTO ${newTable} (key, value, namespace) SELECT CASE WHEN INSTR(key, ':') > 0 THEN SUBSTR(key, INSTR(key, ':') + 1) ELSE key END, value, CASE WHEN INSTR(key, ':') > 0 THEN SUBSTR(key, 1, INSTR(key, ':') - 1) ELSE '' END FROM ${oldTable}`,
-						);
-						await database.query(`DROP TABLE ${oldTable}`);
-					} else if (!columnNames.includes("expires")) {
-						// Has namespace but missing expires — add column
-						await database.query(
-							`ALTER TABLE ${this.getCleanTableName()} ADD COLUMN expires BIGINT DEFAULT NULL`,
-						);
-					}
-				}
-
+				await this.ensureSchema(database, createTable);
 				await database.query(createExpiresIndex);
 				return database as Db;
 			})
@@ -286,6 +261,8 @@ export class KeyvSqlite extends Hookified implements KeyvStorageAdapter {
 	/**
 	 * Set the table name used for storage.
 	 * The name is sanitized to prevent SQL injection.
+	 * Changing this after construction does not create or migrate the new table;
+	 * it only changes which table subsequent queries target.
 	 * @param {string} value - The table name to use.
 	 */
 	public set table(value: string) {
@@ -303,6 +280,7 @@ export class KeyvSqlite extends Hookified implements KeyvStorageAdapter {
 
 	/**
 	 * Set the maximum key length (VARCHAR length) for the key column.
+	 * Changing this after construction does not alter an existing table's column definition.
 	 * @param {number} value - The maximum key length.
 	 */
 	public set keySize(value: number) {
@@ -329,6 +307,7 @@ export class KeyvSqlite extends Hookified implements KeyvStorageAdapter {
 
 	/**
 	 * Set the maximum namespace length (VARCHAR length) for the namespace column.
+	 * Changing this after construction does not alter an existing table's column definition.
 	 * @param {number} value - The maximum namespace length.
 	 */
 	public set namespaceLength(value: number) {
@@ -795,6 +774,100 @@ export class KeyvSqlite extends Hookified implements KeyvStorageAdapter {
 	}
 
 	/**
+	 * Creates the storage table if needed and migrates pre-v6 schemas.
+	 *
+	 * Recovers a leftover `{table}_migration_old` table from an interrupted v6
+	 * migration, then either creates the table, rebuilds it to add `namespace`,
+	 * or `ALTER`s in the `expires` column.
+	 */
+	private async ensureSchema(database: Db, createTable: string): Promise<void> {
+		await this.recoverIncompleteMigration(database, createTable);
+
+		const tableInfo = await database.query(`PRAGMA table_info(${this.getCleanTableName()})`);
+		if (tableInfo.length === 0) {
+			await database.query(createTable);
+			return;
+		}
+
+		const columnNames = (tableInfo as Array<{ name: string }>).map((c) => c.name);
+		if (!columnNames.includes("namespace")) {
+			await this.migrateLegacySchema(database, createTable);
+			return;
+		}
+
+		if (!columnNames.includes("expires")) {
+			await database.query(
+				`ALTER TABLE ${this.getCleanTableName()} ADD COLUMN expires BIGINT DEFAULT NULL`,
+			);
+		}
+	}
+
+	/**
+	 * Completes a migration that was interrupted after the old table was renamed
+	 * to `{table}_migration_old`. Copies remaining rows into the v6 table and
+	 * drops the leftover. No-op when that table does not exist.
+	 */
+	private async recoverIncompleteMigration(database: Db, createTable: string): Promise<void> {
+		const oldTableName = `${this._table}_migration_old`;
+		const leftover = await database.query(
+			"SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?",
+			oldTableName,
+		);
+		if (leftover.length === 0) {
+			return;
+		}
+
+		const oldTable = escapeIdentifier(oldTableName);
+		await this.runInTransaction(database, async () => {
+			const tableInfo = await database.query(`PRAGMA table_info(${this.getCleanTableName()})`);
+			if (tableInfo.length === 0) {
+				await database.query(createTable);
+			}
+
+			await database.query(this.getLegacyMigrationInsertSql(oldTable));
+			await database.query(`DROP TABLE ${oldTable}`);
+		});
+	}
+
+	/**
+	 * Rebuilds a pre-v6 table (no `namespace` column) inside a transaction.
+	 * Prefixed keys like `myns:mykey` are split into `key` + `namespace`.
+	 */
+	private async migrateLegacySchema(database: Db, createTable: string): Promise<void> {
+		const oldTable = escapeIdentifier(`${this._table}_migration_old`);
+		const newTable = this.getCleanTableName();
+		await this.runInTransaction(database, async () => {
+			await database.query(`ALTER TABLE ${newTable} RENAME TO ${oldTable}`);
+			await database.query(createTable);
+			await database.query(this.getLegacyMigrationInsertSql(oldTable));
+			await database.query(`DROP TABLE ${oldTable}`);
+		});
+	}
+
+	/**
+	 * Runs `work` inside a SQLite transaction, rolling back on failure.
+	 */
+	private async runInTransaction(database: Db, work: () => Promise<void>): Promise<void> {
+		await database.query("BEGIN");
+		try {
+			await work();
+			await database.query("COMMIT");
+		} catch (error) {
+			await database.query("ROLLBACK").catch(() => undefined);
+			throw error;
+		}
+	}
+
+	/**
+	 * Copies rows from a pre-v6 table, splitting `namespace:key` prefixes on the
+	 * first colon. Keys with no colon stay in the default (empty) namespace.
+	 */
+	private getLegacyMigrationInsertSql(oldTable: string): string {
+		const newTable = this.getCleanTableName();
+		return `INSERT OR IGNORE INTO ${newTable} (key, value, namespace) SELECT CASE WHEN INSTR(key, ':') > 0 THEN SUBSTR(key, INSTR(key, ':') + 1) ELSE key END, value, CASE WHEN INSTR(key, ':') > 0 THEN SUBSTR(key, 1, INSTR(key, ':') - 1) ELSE '' END FROM ${oldTable}`;
+	}
+
+	/**
 	 * Creates a new SQLite database connection using the resolved driver.
 	 * The driver handles busy timeout, WAL mode, and connection setup.
 	 * @returns {Promise<Db>} An object with `query` and `close` functions for database operations.
@@ -844,11 +917,18 @@ export class KeyvSqlite extends Hookified implements KeyvStorageAdapter {
 		this.stopClearExpiredTimer();
 		if (this._clearExpiredInterval > 0) {
 			this._clearExpiredTimer = setInterval(async () => {
+				if (this._clearExpiredRunning) {
+					return;
+				}
+
+				this._clearExpiredRunning = true;
 				try {
 					await this.clearExpired();
 				} catch (error) {
 					/* v8 ignore next -- @preserve */
 					this.emit("error", error);
+				} finally {
+					this._clearExpiredRunning = false;
 				}
 			}, this._clearExpiredInterval);
 			this._clearExpiredTimer.unref();

--- a/storage/sqlite/src/index.ts
+++ b/storage/sqlite/src/index.ts
@@ -3,13 +3,14 @@ import Keyv, {
 	type KeyvAny,
 	type KeyvAnyArray,
 	type KeyvStorageAdapter,
+	type KeyvStorageCapability,
 	type KeyvStorageEntry,
 	type KeyvStorageGetResult,
 	keyvStorageCapability,
 } from "keyv";
 import { resolveDriver } from "./drivers/index.js";
 import type { SqliteDriver, SqliteDriverName } from "./drivers/types.js";
-import type { Db, DbClose, DbQuery, KeyvSqliteOptions } from "./types.js";
+import type { Db, KeyvSqliteOptions } from "./types.js";
 
 /**
  * Sanitizes a table name for safe use in SQL statements.
@@ -56,11 +57,6 @@ function escapeIdentifier(identifier: string): string {
  * ```
  */
 export class KeyvSqlite extends Hookified implements KeyvStorageAdapter {
-	/** Declares the v6 absolute-`expires` storage contract via `capabilities.expires`. */
-	public get capabilities() {
-		return keyvStorageCapability(this);
-	}
-
 	/** The namespace used to prefix keys for multi-tenant separation. */
 	private _namespace?: string;
 
@@ -134,6 +130,9 @@ export class KeyvSqlite extends Hookified implements KeyvStorageAdapter {
 	/** The resolved driver name, populated after connection. */
 	private _resolvedDriverName?: string;
 
+	/** The pending database connection used by {@link query} and {@link close}. */
+	private _connected: Promise<Db>;
+
 	/**
 	 * Creates a new KeyvSqlite instance.
 	 *
@@ -166,7 +165,7 @@ export class KeyvSqlite extends Hookified implements KeyvStorageAdapter {
 		const createTable = `CREATE TABLE IF NOT EXISTS ${this.getCleanTableName()}(key VARCHAR(${keySize}) NOT NULL, value TEXT, namespace VARCHAR(${Number(this._namespaceLength)}) NOT NULL DEFAULT '', expires BIGINT DEFAULT NULL, UNIQUE(key, namespace))`;
 		const createExpiresIndex = `CREATE INDEX IF NOT EXISTS ${escapeIdentifier(`${this._table}_expires_idx`)} ON ${this.getCleanTableName()} (expires) WHERE expires IS NOT NULL`;
 
-		const connected: Promise<Db> = this.createConnection()
+		this._connected = this.createConnection()
 			.then(async (database) => {
 				await this.ensureSchema(database, createTable);
 				await database.query(createExpiresIndex);
@@ -183,14 +182,9 @@ export class KeyvSqlite extends Hookified implements KeyvStorageAdapter {
 		// Suppress unhandled-rejection on the base promise. Connection errors
 		// are still surfaced through this.query, this.close, and this.ready
 		// when those are awaited, and via the 'error' event emitted above.
-		connected.catch(() => {});
+		this._connected.catch(() => {});
 
-		this.query = async (sqlString, ...parameter) =>
-			connected.then(async (database) => database.query(sqlString, ...parameter));
-
-		this.close = async () => connected.then((database) => database.close());
-
-		this.ready = connected.then(() => {});
+		this.ready = this._connected.then(() => undefined);
 		// Suppress unhandled-rejection when callers never await ready
 		this.ready.catch(() => {});
 
@@ -201,25 +195,17 @@ export class KeyvSqlite extends Hookified implements KeyvStorageAdapter {
 	 * A promise that resolves when the database connection and schema setup
 	 * are complete. Useful for awaiting initialization before the first operation.
 	 * @type {Promise<void>}
+	 * @returns {Promise<void>} Resolves once the connection and schema are ready.
 	 */
 	public readonly ready: Promise<void>;
 
 	/**
-	 * Promise-based function that closes the underlying database connection.
-	 * @type {DbClose}
-	 * @returns {Promise<void>} Resolves once the connection has been closed.
+	 * Declares the v6 absolute-`expires` storage contract via `capabilities.expires`.
+	 * @returns {KeyvStorageCapability} The capability descriptor with `expires` set to `true`.
 	 */
-	public close: DbClose;
-
-	/**
-	 * Promise-based function that executes a SQL statement against the database.
-	 * Returns the result rows for `SELECT`/`PRAGMA` statements and an empty array otherwise.
-	 * @type {DbQuery}
-	 * @param {string} sqlString - The SQL statement to execute.
-	 * @param {...unknown} parameter - The bind parameters for the statement.
-	 * @returns {Promise<unknown[]>} The result rows.
-	 */
-	public query: DbQuery;
+	public get capabilities(): KeyvStorageCapability {
+		return keyvStorageCapability(this);
+	}
 
 	/**
 	 * Get the namespace for the adapter. If `undefined`, no namespace prefix is applied
@@ -477,7 +463,7 @@ export class KeyvSqlite extends Hookified implements KeyvStorageAdapter {
 				if (row.expires !== null && row.expires !== undefined && row.expires <= now) {
 					expiredKeys.push(row.key);
 				} else {
-					validMap.set(row.key, row.value);
+					validMap.set(row.key, (row.value ?? undefined) as Value);
 				}
 			}
 
@@ -498,7 +484,7 @@ export class KeyvSqlite extends Hookified implements KeyvStorageAdapter {
 	 * Sets a key-value pair. Uses an upsert operation via `ON CONFLICT` to
 	 * insert a new entry or update an existing one atomically.
 	 * @param {string} key - The key to set. If a namespace is set, the namespace prefix is stripped before storing.
-	 * @param {any} value - The value to store.
+	 * @param {KeyvAny} value - The value to store.
 	 * @param {number} [expires] - Absolute expiry as Unix ms since epoch, or `undefined` for no expiry.
 	 * @returns {Promise<boolean>} `true` on success, or `false` if an error occurred (an `error` event is also emitted).
 	 */
@@ -698,16 +684,17 @@ export class KeyvSqlite extends Hookified implements KeyvStorageAdapter {
 	 * The namespace does not need to be passed in — it is read from the {@link namespace} property.
 	 * Uses cursor-based (keyset) pagination with batch size controlled by {@link iterationLimit},
 	 * which safely handles concurrent modifications during iteration without skipping entries.
-	 * @yields {[string, string]} A `[key, value]` tuple for each non-expired entry.
-	 * @returns {AsyncGenerator<[string, string], void, unknown>} An async generator of `[key, value]` tuples.
+	 * @yields {[string, string | undefined]} A `[key, value]` tuple for each non-expired entry.
+	 *   SQL `NULL` values are yielded as `undefined` (the adapter never yields `null`).
+	 * @returns {AsyncGenerator<[string, string | undefined], void, unknown>} An async generator of `[key, value]` tuples.
 	 */
-	public async *iterator(): AsyncGenerator<[string, string], void, unknown> {
+	public async *iterator(): AsyncGenerator<[string, string | undefined], void, unknown> {
 		const limit = this._iterationLimit > 0 ? this._iterationLimit : 10;
 		const ns = this.getNamespaceValue();
 		let lastKey: string | null = null;
 
 		while (true) {
-			let entries: Array<{ key: string; value: string }>;
+			let entries: Array<{ key: string; value: string | null }>;
 
 			try {
 				let select: string;
@@ -723,7 +710,7 @@ export class KeyvSqlite extends Hookified implements KeyvStorageAdapter {
 
 				entries = (await this.query(select, ...params)) as Array<{
 					key: string;
-					value: string;
+					value: string | null;
 				}>;
 				/* v8 ignore start -- @preserve */
 			} catch (error) {
@@ -740,7 +727,7 @@ export class KeyvSqlite extends Hookified implements KeyvStorageAdapter {
 			}
 
 			for (const entry of entries) {
-				yield [entry.key, entry.value];
+				yield [entry.key, entry.value ?? undefined];
 			}
 
 			// Update cursor to the last key processed
@@ -751,6 +738,28 @@ export class KeyvSqlite extends Hookified implements KeyvStorageAdapter {
 				return;
 			}
 		}
+	}
+
+	/**
+	 * Executes a SQL statement against the database.
+	 * Returns the result rows for `SELECT`/`PRAGMA`/`RETURNING` statements and an empty array otherwise.
+	 * @param {string} sqlString - The SQL statement to execute.
+	 * @param {...unknown} parameter - The bind parameters for the statement.
+	 * @returns {Promise<unknown[]>} The result rows, or an empty array for mutations.
+	 */
+	public async query(sqlString: string, ...parameter: unknown[]): Promise<unknown[]> {
+		const database = await this._connected;
+		return database.query(sqlString, ...parameter);
+	}
+
+	/**
+	 * Closes the underlying database connection.
+	 * Prefer {@link disconnect}, which also stops the expired-entry cleanup timer.
+	 * @returns {Promise<void>} Resolves once the connection has been closed.
+	 */
+	public async close(): Promise<void> {
+		const database = await this._connected;
+		return database.close();
 	}
 
 	/**
@@ -779,6 +788,9 @@ export class KeyvSqlite extends Hookified implements KeyvStorageAdapter {
 	 * Recovers a leftover `{table}_migration_old` table from an interrupted v6
 	 * migration, then either creates the table, rebuilds it to add `namespace`,
 	 * or `ALTER`s in the `expires` column.
+	 * @param {Db} database - The open database connection.
+	 * @param {string} createTable - The `CREATE TABLE` statement for the v6 schema.
+	 * @returns {Promise<void>} Resolves once the schema is ready.
 	 */
 	private async ensureSchema(database: Db, createTable: string): Promise<void> {
 		await this.recoverIncompleteMigration(database, createTable);
@@ -806,6 +818,9 @@ export class KeyvSqlite extends Hookified implements KeyvStorageAdapter {
 	 * Completes a migration that was interrupted after the old table was renamed
 	 * to `{table}_migration_old`. Copies remaining rows into the v6 table and
 	 * drops the leftover. No-op when that table does not exist.
+	 * @param {Db} database - The open database connection.
+	 * @param {string} createTable - The `CREATE TABLE` statement for the v6 schema.
+	 * @returns {Promise<void>} Resolves once leftover rows are merged or skipped.
 	 */
 	private async recoverIncompleteMigration(database: Db, createTable: string): Promise<void> {
 		const oldTableName = `${this._table}_migration_old`;
@@ -832,6 +847,9 @@ export class KeyvSqlite extends Hookified implements KeyvStorageAdapter {
 	/**
 	 * Rebuilds a pre-v6 table (no `namespace` column) inside a transaction.
 	 * Prefixed keys like `myns:mykey` are split into `key` + `namespace`.
+	 * @param {Db} database - The open database connection.
+	 * @param {string} createTable - The `CREATE TABLE` statement for the v6 schema.
+	 * @returns {Promise<void>} Resolves once the rebuild and copy have committed.
 	 */
 	private async migrateLegacySchema(database: Db, createTable: string): Promise<void> {
 		const oldTable = escapeIdentifier(`${this._table}_migration_old`);
@@ -846,6 +864,9 @@ export class KeyvSqlite extends Hookified implements KeyvStorageAdapter {
 
 	/**
 	 * Runs `work` inside a SQLite transaction, rolling back on failure.
+	 * @param {Db} database - The open database connection.
+	 * @param {() => Promise<void>} work - The statements to run inside the transaction.
+	 * @returns {Promise<void>} Resolves once the transaction has committed.
 	 */
 	private async runInTransaction(database: Db, work: () => Promise<void>): Promise<void> {
 		await database.query("BEGIN");
@@ -861,6 +882,8 @@ export class KeyvSqlite extends Hookified implements KeyvStorageAdapter {
 	/**
 	 * Copies rows from a pre-v6 table, splitting `namespace:key` prefixes on the
 	 * first colon. Keys with no colon stay in the default (empty) namespace.
+	 * @param {string} oldTable - The escaped identifier of the source table.
+	 * @returns {string} An `INSERT OR IGNORE ... SELECT` statement.
 	 */
 	private getLegacyMigrationInsertSql(oldTable: string): string {
 		const newTable = this.getCleanTableName();
@@ -912,6 +935,7 @@ export class KeyvSqlite extends Hookified implements KeyvStorageAdapter {
 	 * Starts (or restarts) the automatic expired-entry cleanup interval.
 	 * If the interval is `0` or negative, any existing timer is stopped.
 	 * The timer is unreffed so it does not prevent the Node.js process from exiting.
+	 * @returns {void}
 	 */
 	private startClearExpiredTimer(): void {
 		this.stopClearExpiredTimer();
@@ -938,6 +962,7 @@ export class KeyvSqlite extends Hookified implements KeyvStorageAdapter {
 	/**
 	 * Stops the automatic expired-entry cleanup interval if running
 	 * and clears the timer reference.
+	 * @returns {void}
 	 */
 	private stopClearExpiredTimer(): void {
 		if (this._clearExpiredTimer) {
@@ -951,6 +976,7 @@ export class KeyvSqlite extends Hookified implements KeyvStorageAdapter {
 	 * Only properties that are explicitly defined (not `undefined`) are updated.
 	 * The `keyLength` property is treated as an alias for `keySize`.
 	 * @param {KeyvSqliteOptions} options - The options to apply.
+	 * @returns {void}
 	 */
 	private setOptions(options: KeyvSqliteOptions): void {
 		if (options.uri !== undefined) {
@@ -999,6 +1025,11 @@ export class KeyvSqlite extends Hookified implements KeyvStorageAdapter {
  * Helper function to create a Keyv instance with KeyvSqlite as the storage adapter.
  * @param {KeyvSqliteOptions | string} [keyvOptions] - Optional {@link KeyvSqliteOptions} configuration object or URI string.
  * @returns {Keyv} A new Keyv instance backed by SQLite.
+ * @example
+ * ```ts
+ * import { createKeyv } from '@keyv/sqlite';
+ * const keyv = createKeyv('sqlite://path/to/db.sqlite');
+ * ```
  */
 export const createKeyv = (keyvOptions?: KeyvSqliteOptions | string) =>
 	new Keyv({ store: new KeyvSqlite(keyvOptions) });

--- a/storage/sqlite/src/types.ts
+++ b/storage/sqlite/src/types.ts
@@ -1,28 +1,80 @@
 import type { SqliteDriver, SqliteDriverName } from "./drivers/types.js";
 
+/**
+ * Executes a SQL statement and returns result rows.
+ * @param {string} sqlString - The SQL statement to execute.
+ * @param {...unknown} parameter - Bind parameters for the statement.
+ * @returns {Promise<unknown[]>} Result rows for `SELECT`/`PRAGMA`/`RETURNING`, otherwise an empty array.
+ */
 export type DbQuery = (sqlString: string, ...parameter: unknown[]) => Promise<unknown[]>;
+
+/**
+ * Closes an open SQLite connection.
+ * @returns {Promise<void>} Resolves once the connection has been closed.
+ */
 export type DbClose = () => Promise<void>;
 
+/**
+ * Constructor options for `KeyvSqlite`.
+ */
 export type KeyvSqliteOptions = {
+	/**
+	 * SQLite connection URI.
+	 * @default 'sqlite://:memory:'
+	 */
 	uri?: string;
+	/**
+	 * SQLite busy timeout in milliseconds. Controls how long SQLite waits
+	 * when the database is locked by another connection.
+	 */
 	busyTimeout?: number;
+	/**
+	 * Table name for key-value storage. Sanitized to alphanumeric and underscore characters.
+	 * @default 'keyv'
+	 */
 	table?: string;
-	/** Maximum key length (VARCHAR size). Alias: keyLength. @default 255 */
+	/**
+	 * Maximum key length (VARCHAR size). Alias: `keyLength`.
+	 * @default 255
+	 */
 	keySize?: number;
-	/** @deprecated Use `keySize` instead. */
+	/**
+	 * Deprecated alias for `keySize`.
+	 * @deprecated Use `keySize` instead.
+	 */
 	keyLength?: number;
-	/** Maximum namespace length (VARCHAR size). @default 255 */
+	/**
+	 * Maximum namespace length (VARCHAR size).
+	 * @default 255
+	 */
 	namespaceLength?: number;
+	/**
+	 * Number of rows fetched per iterator batch.
+	 * @default 10
+	 */
 	iterationLimit?: number;
-	/** Enable WAL (Write-Ahead Logging) mode. */
+	/**
+	 * Enable WAL (Write-Ahead Logging) mode. Ignored for in-memory databases.
+	 * @default false
+	 */
 	wal?: boolean;
-	/** Interval in milliseconds between automatic expired-entry cleanup runs. 0 disables. @default 0 */
+	/**
+	 * Interval in milliseconds between automatic expired-entry cleanup runs. `0` disables.
+	 * @default 0
+	 */
 	clearExpiredInterval?: number;
-	/** Explicit driver selection or custom driver object. Auto-detected if omitted. */
+	/**
+	 * Explicit driver selection or custom driver object. Auto-detected if omitted.
+	 */
 	driver?: SqliteDriverName | SqliteDriver;
 };
 
+/**
+ * Minimal database handle returned by a {@link SqliteDriver}.
+ */
 export type Db = {
+	/** Execute a SQL statement. @see {@link DbQuery} */
 	query: DbQuery;
+	/** Close the connection. @see {@link DbClose} */
 	close: DbClose;
 };

--- a/storage/sqlite/test/drivers.test.ts
+++ b/storage/sqlite/test/drivers.test.ts
@@ -111,6 +111,23 @@ describe("driver selection", () => {
 		await store.disconnect();
 	});
 
+	test("accepts explicit driver: 'node:sqlite'", async () => {
+		const store = new KeyvSqlite({
+			uri: "sqlite://:memory:",
+			driver: "node:sqlite",
+		});
+		await store.ready;
+		expect(store.driverName).toBe("node:sqlite");
+		const key = faker.string.uuid();
+		const val = faker.lorem.word();
+		await store.set(key, val);
+		expect(await store.get(key)).toBe(val);
+		expect(await store.has(key)).toBe(true);
+		expect(await store.delete(key)).toBe(true);
+		expect(await store.get(key)).toBeUndefined();
+		await store.disconnect();
+	});
+
 	test("throws for invalid driver name", async () => {
 		const store = new KeyvSqlite({
 			uri: "sqlite://:memory:",
@@ -443,6 +460,23 @@ describe("sqlite3 helper driver", () => {
 		const val = faker.lorem.word();
 		await store.set(key, val);
 		expect(await store.get(key)).toBe(val);
+		await store.disconnect();
+	});
+
+	test("continues serving queries after a statement error", async () => {
+		const store = new KeyvSqlite({
+			uri: "sqlite://:memory:",
+			driver: createSqlite3Driver(sqlite3),
+		});
+		const key = faker.string.uuid();
+		const val = faker.lorem.word();
+		await store.set(key, val);
+		await expect(store.query("THIS IS NOT SQL")).rejects.toThrow();
+		expect(await store.get(key)).toBe(val);
+		const nextKey = faker.string.uuid();
+		const nextVal = faker.lorem.word();
+		await store.set(nextKey, nextVal);
+		expect(await store.get(nextKey)).toBe(nextVal);
 		await store.disconnect();
 	});
 });

--- a/storage/sqlite/test/drivers.test.ts
+++ b/storage/sqlite/test/drivers.test.ts
@@ -77,20 +77,20 @@ function createSqlite3TestModule(): Sqlite3TestModule {
 const sqlite3 = createSqlite3TestModule();
 
 describe("driver selection", () => {
-	test("driverName is available after ready", async () => {
+	test("should expose driverName after ready", async () => {
 		const store = new KeyvSqlite("sqlite://:memory:");
 		await store.ready;
 		expect(store.driverName).toEqual(expect.any(String));
 		await store.disconnect();
 	});
 
-	test("ready promise resolves without error", async () => {
+	test("should resolve the ready promise without error", async () => {
 		const store = new KeyvSqlite("sqlite://:memory:");
 		await expect(store.ready).resolves.toBeUndefined();
 		await store.disconnect();
 	});
 
-	test("auto-detects a built-in driver by default", async () => {
+	test("should auto-detect a built-in driver by default", async () => {
 		const store = new KeyvSqlite("sqlite://:memory:");
 		const key = faker.string.uuid();
 		const val = faker.lorem.word();
@@ -99,7 +99,7 @@ describe("driver selection", () => {
 		await store.disconnect();
 	});
 
-	test("accepts explicit driver: 'better-sqlite3'", async () => {
+	test("should accept explicit driver: 'better-sqlite3'", async () => {
 		const store = new KeyvSqlite({
 			uri: "sqlite://:memory:",
 			driver: "better-sqlite3",
@@ -111,7 +111,7 @@ describe("driver selection", () => {
 		await store.disconnect();
 	});
 
-	test("accepts explicit driver: 'node:sqlite'", async () => {
+	test("should accept explicit driver: 'node:sqlite'", async () => {
 		const store = new KeyvSqlite({
 			uri: "sqlite://:memory:",
 			driver: "node:sqlite",
@@ -128,22 +128,22 @@ describe("driver selection", () => {
 		await store.disconnect();
 	});
 
-	test("throws for invalid driver name", async () => {
+	test("should throw for invalid driver name", async () => {
 		const store = new KeyvSqlite({
 			uri: "sqlite://:memory:",
 			// @ts-expect-error testing invalid driver
 			driver: "nonexistent-driver",
 		});
-		await expect(store.get("key1")).rejects.toThrow(/Failed to load SQLite driver/);
+		await expect(store.get(faker.string.uuid())).rejects.toThrow(/Failed to load SQLite driver/);
 	});
 
-	test("bun:sqlite driver fails to load outside Bun runtime", async () => {
+	test("should fail to load the bun:sqlite driver outside the Bun runtime", async () => {
 		await expect(resolveDriver("bun:sqlite")).rejects.toThrow(
 			/Failed to load SQLite driver "bun:sqlite"/,
 		);
 	});
 
-	test("accepts a custom SqliteDriver object", async () => {
+	test("should accept a custom SqliteDriver object", async () => {
 		const Database = (await import("better-sqlite3")).default;
 		const customDriver: SqliteDriver = {
 			name: "better-sqlite3",
@@ -182,7 +182,7 @@ describe("driver selection", () => {
 });
 
 describe("better-sqlite3 driver operations", () => {
-	test("get/set/delete/has work correctly", async () => {
+	test("should get, set, delete, and check keys", async () => {
 		const store = new KeyvSqlite({
 			uri: "sqlite://:memory:",
 			driver: "better-sqlite3",
@@ -201,7 +201,7 @@ describe("better-sqlite3 driver operations", () => {
 		await store.disconnect();
 	});
 
-	test("getMany/setMany/deleteMany/hasMany work correctly", async () => {
+	test("should getMany, setMany, deleteMany, and hasMany values", async () => {
 		const store = new KeyvSqlite({
 			uri: "sqlite://:memory:",
 			driver: "better-sqlite3",
@@ -226,7 +226,7 @@ describe("better-sqlite3 driver operations", () => {
 		await store.disconnect();
 	});
 
-	test("clear works correctly", async () => {
+	test("should clear stored values", async () => {
 		const store = new KeyvSqlite({
 			uri: "sqlite://:memory:",
 			driver: "better-sqlite3",
@@ -238,7 +238,7 @@ describe("better-sqlite3 driver operations", () => {
 		await store.disconnect();
 	});
 
-	test("iterator works correctly", async () => {
+	test("should iterate stored values", async () => {
 		const store = new KeyvSqlite({
 			uri: "sqlite://:memory:",
 			driver: "better-sqlite3",
@@ -254,7 +254,7 @@ describe("better-sqlite3 driver operations", () => {
 		await store.disconnect();
 	});
 
-	test("WAL mode works with file-based database", async () => {
+	test("should enable WAL mode on a file-based database", async () => {
 		const fs = await import("node:fs");
 		const dbPath = "test/testdb-wal-driver.sqlite";
 		try {
@@ -279,7 +279,7 @@ describe("better-sqlite3 driver operations", () => {
 		} catch {}
 	});
 
-	test("WAL mode on in-memory database logs warning", async () => {
+	test("should log a warning when WAL is requested for an in-memory database", async () => {
 		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 		const store = new KeyvSqlite({
 			uri: "sqlite://:memory:",
@@ -294,7 +294,7 @@ describe("better-sqlite3 driver operations", () => {
 		await store.disconnect();
 	});
 
-	test("busyTimeout option is accepted", async () => {
+	test("should accept the busyTimeout option", async () => {
 		const store = new KeyvSqlite({
 			uri: "sqlite://:memory:",
 			driver: "better-sqlite3",
@@ -309,7 +309,7 @@ describe("better-sqlite3 driver operations", () => {
 });
 
 describe("sqlite3 helper driver", () => {
-	test("basic set/get with in-memory db", async () => {
+	test("should set and get values on an in-memory database", async () => {
 		const store = new KeyvSqlite({
 			uri: "sqlite://:memory:",
 			driver: createSqlite3Driver(sqlite3),
@@ -321,12 +321,12 @@ describe("sqlite3 helper driver", () => {
 		await store.disconnect();
 	});
 
-	test("driver name is 'custom'", () => {
+	test("should report the sqlite3 helper driver name as custom", () => {
 		const driver = createSqlite3Driver(sqlite3);
 		expect(driver.name).toBe("custom");
 	});
 
-	test("get/set/delete/has work correctly", async () => {
+	test("should get, set, delete, and check keys", async () => {
 		const store = new KeyvSqlite({
 			uri: "sqlite://:memory:",
 			driver: createSqlite3Driver(sqlite3),
@@ -345,7 +345,7 @@ describe("sqlite3 helper driver", () => {
 		await store.disconnect();
 	});
 
-	test("getMany/setMany/deleteMany/hasMany work correctly", async () => {
+	test("should getMany, setMany, deleteMany, and hasMany values", async () => {
 		const store = new KeyvSqlite({
 			uri: "sqlite://:memory:",
 			driver: createSqlite3Driver(sqlite3),
@@ -370,7 +370,7 @@ describe("sqlite3 helper driver", () => {
 		await store.disconnect();
 	});
 
-	test("clear works correctly", async () => {
+	test("should clear stored values", async () => {
 		const store = new KeyvSqlite({
 			uri: "sqlite://:memory:",
 			driver: createSqlite3Driver(sqlite3),
@@ -382,7 +382,7 @@ describe("sqlite3 helper driver", () => {
 		await store.disconnect();
 	});
 
-	test("iterator works correctly", async () => {
+	test("should iterate stored values", async () => {
 		const store = new KeyvSqlite({
 			uri: "sqlite://:memory:",
 			driver: createSqlite3Driver(sqlite3),
@@ -398,7 +398,7 @@ describe("sqlite3 helper driver", () => {
 		await store.disconnect();
 	});
 
-	test("WAL mode works with file-based database", async () => {
+	test("should enable WAL mode on a file-based database", async () => {
 		const fs = await import("node:fs");
 		const dbPath = "test/testdb-wal-sqlite3.sqlite";
 		try {
@@ -423,7 +423,7 @@ describe("sqlite3 helper driver", () => {
 		} catch {}
 	});
 
-	test("WAL mode on in-memory database logs warning", async () => {
+	test("should log a warning when WAL is requested for an in-memory database", async () => {
 		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 		const store = new KeyvSqlite({
 			uri: "sqlite://:memory:",
@@ -438,7 +438,7 @@ describe("sqlite3 helper driver", () => {
 		await store.disconnect();
 	});
 
-	test("busyTimeout option is accepted", async () => {
+	test("should accept the busyTimeout option", async () => {
 		const store = new KeyvSqlite({
 			uri: "sqlite://:memory:",
 			driver: createSqlite3Driver(sqlite3),
@@ -451,7 +451,7 @@ describe("sqlite3 helper driver", () => {
 		await store.disconnect();
 	});
 
-	test("works with sqlite3.verbose()", async () => {
+	test("should work with sqlite3.verbose()", async () => {
 		const store = new KeyvSqlite({
 			uri: "sqlite://:memory:",
 			driver: createSqlite3Driver(sqlite3.verbose()),
@@ -463,7 +463,7 @@ describe("sqlite3 helper driver", () => {
 		await store.disconnect();
 	});
 
-	test("continues serving queries after a statement error", async () => {
+	test("should continue serving queries after a statement error", async () => {
 		const store = new KeyvSqlite({
 			uri: "sqlite://:memory:",
 			driver: createSqlite3Driver(sqlite3),

--- a/storage/sqlite/test/iterator.test.ts
+++ b/storage/sqlite/test/iterator.test.ts
@@ -6,7 +6,7 @@ import KeyvSqlite from "../src/index.js";
 const sqliteUri = "sqlite://test/testdb2.sqlite";
 
 describe("iterator with Keyv", () => {
-	test("iterates over values set through a Keyv instance", async () => {
+	test("should iterate over values set through a Keyv instance", async () => {
 		const store = new KeyvSqlite({ uri: sqliteUri, busyTimeout: 3000 });
 		const keyv = new Keyv({ store });
 		await keyv.clear();
@@ -28,7 +28,7 @@ describe("iterator with Keyv", () => {
 		expect(keyvDataFound).toBe(true);
 	});
 
-	test("iterates when the Keyv namespace is undefined", async () => {
+	test("should iterate when the Keyv namespace is undefined", async () => {
 		const store = new KeyvSqlite({ uri: sqliteUri, busyTimeout: 3000 });
 		const keyv = new Keyv({ store });
 		keyv.namespace = undefined;

--- a/storage/sqlite/test/test.ts
+++ b/storage/sqlite/test/test.ts
@@ -287,6 +287,26 @@ describe("set and setMany", () => {
 		expect(await keyv.get(key2)).toBe(val2);
 	});
 
+	test("setMany and getMany batch past SQLite bind-parameter limits", async () => {
+		const keyv = store();
+		const entries = Array.from({ length: 250 }, (_, i) => ({
+			key: `batch-key-${i}`,
+			value: `v${i}`,
+		}));
+		const results = await keyv.setMany(entries);
+		expect(results).toHaveLength(250);
+		expect(results?.every(Boolean)).toBe(true);
+
+		const keys = entries.map((entry) => entry.key);
+		keys.push("batch-missing");
+		const values = await keyv.getMany(keys);
+		expect(values).toHaveLength(251);
+		expect(values[0]).toBe("v0");
+		expect(values[249]).toBe("v249");
+		expect(values[250]).toBeUndefined();
+		await keyv.deleteMany(keys);
+	});
+
 	test("setMany emits an error and returns false entries on query error", async () => {
 		const keyv = new KeyvSqlite("sqlite://:memory:");
 		let emittedError = false;
@@ -727,6 +747,131 @@ describe("schema migration", () => {
 		await keyv.set("newkey", "newval");
 		expect(await keyv.get("newkey")).toBe("newval");
 		await keyv.disconnect();
+
+		try {
+			fs.unlinkSync(dbPath);
+		} catch {}
+	});
+
+	test("splits v5 namespaced keys into key and namespace columns", async () => {
+		const dbPath = "test/testdb-migration-ns.sqlite";
+		const fs = await import("node:fs");
+		try {
+			fs.unlinkSync(dbPath);
+		} catch {}
+
+		const Database = (await import("better-sqlite3")).default;
+		const db = new Database(dbPath);
+		db.exec("CREATE TABLE keyv(key VARCHAR(255) PRIMARY KEY, value TEXT)");
+		db.prepare("INSERT INTO keyv (key, value) VALUES (?, ?)").run("keyv:foo", "bar");
+		db.prepare("INSERT INTO keyv (key, value) VALUES (?, ?)").run("app:user:123", "nested");
+		db.prepare("INSERT INTO keyv (key, value) VALUES (?, ?)").run("plain", "noprefix");
+		db.close();
+
+		const keyv = new KeyvSqlite({ uri: `sqlite://${dbPath}`, busyTimeout: 3000 });
+		expect(await keyv.get("plain")).toBe("noprefix");
+
+		keyv.namespace = "keyv";
+		expect(await keyv.get("keyv:foo")).toBe("bar");
+
+		keyv.namespace = "app";
+		expect(await keyv.get("app:user:123")).toBe("nested");
+		await keyv.disconnect();
+
+		try {
+			fs.unlinkSync(dbPath);
+		} catch {}
+	});
+
+	test("recovers a leftover _migration_old table from an interrupted migration", async () => {
+		const dbPath = "test/testdb-migration-leftover.sqlite";
+		const fs = await import("node:fs");
+		try {
+			fs.unlinkSync(dbPath);
+		} catch {}
+
+		const Database = (await import("better-sqlite3")).default;
+		const db = new Database(dbPath);
+		// Simulate a crash after RENAME + CREATE but before INSERT/DROP.
+		db.exec("CREATE TABLE keyv_migration_old(key VARCHAR(255) PRIMARY KEY, value TEXT)");
+		db.prepare("INSERT INTO keyv_migration_old (key, value) VALUES (?, ?)").run(
+			"ns:legacy",
+			"kept",
+		);
+		db.exec(
+			"CREATE TABLE keyv(key VARCHAR(255) NOT NULL, value TEXT, namespace VARCHAR(255) NOT NULL DEFAULT '', expires BIGINT DEFAULT NULL, UNIQUE(key, namespace))",
+		);
+		db.close();
+
+		const keyv = new KeyvSqlite({ uri: `sqlite://${dbPath}`, busyTimeout: 3000 });
+		keyv.namespace = "ns";
+		expect(await keyv.get("ns:legacy")).toBe("kept");
+
+		const leftover = (await keyv.query(
+			"SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'keyv_migration_old'",
+		)) as unknown[];
+		expect(leftover).toHaveLength(0);
+		await keyv.disconnect();
+
+		try {
+			fs.unlinkSync(dbPath);
+		} catch {}
+	});
+
+	test("recovers leftover migration data when the new table is missing", async () => {
+		const dbPath = "test/testdb-migration-leftover-missing.sqlite";
+		const fs = await import("node:fs");
+		try {
+			fs.unlinkSync(dbPath);
+		} catch {}
+
+		const Database = (await import("better-sqlite3")).default;
+		const db = new Database(dbPath);
+		// Simulate a crash after RENAME but before CREATE.
+		db.exec("CREATE TABLE keyv_migration_old(key VARCHAR(255) PRIMARY KEY, value TEXT)");
+		db.prepare("INSERT INTO keyv_migration_old (key, value) VALUES (?, ?)").run("oldkey", "oldval");
+		db.close();
+
+		const keyv = new KeyvSqlite({ uri: `sqlite://${dbPath}`, busyTimeout: 3000 });
+		expect(await keyv.get("oldkey")).toBe("oldval");
+		const leftover = (await keyv.query(
+			"SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'keyv_migration_old'",
+		)) as unknown[];
+		expect(leftover).toHaveLength(0);
+		await keyv.disconnect();
+
+		try {
+			fs.unlinkSync(dbPath);
+		} catch {}
+	});
+
+	test("rolls back leftover recovery when the copy fails", async () => {
+		const dbPath = "test/testdb-migration-rollback.sqlite";
+		const fs = await import("node:fs");
+		try {
+			fs.unlinkSync(dbPath);
+		} catch {}
+
+		const Database = (await import("better-sqlite3")).default;
+		const db = new Database(dbPath);
+		db.exec("CREATE TABLE keyv_migration_old(notkey TEXT)");
+		db.exec("INSERT INTO keyv_migration_old (notkey) VALUES ('x')");
+		db.exec(
+			"CREATE TABLE keyv(key VARCHAR(255) NOT NULL, value TEXT, namespace VARCHAR(255) NOT NULL DEFAULT '', expires BIGINT DEFAULT NULL, UNIQUE(key, namespace))",
+		);
+		db.close();
+
+		const keyv = new KeyvSqlite({ uri: `sqlite://${dbPath}`, busyTimeout: 3000 });
+		await expect(keyv.ready).rejects.toThrow();
+
+		const leftoverDb = new Database(dbPath);
+		const leftover = leftoverDb
+			.prepare(
+				"SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'keyv_migration_old'",
+			)
+			.all();
+		expect(leftover).toHaveLength(1);
+		leftoverDb.close();
 
 		try {
 			fs.unlinkSync(dbPath);

--- a/storage/sqlite/test/test.ts
+++ b/storage/sqlite/test/test.ts
@@ -475,6 +475,32 @@ describe("clearExpiredInterval", () => {
 		expect(keyv.clearExpiredInterval).toBe(0);
 		await keyv.disconnect();
 	});
+
+	test("does not overlap automatic cleanup runs", async () => {
+		const keyv = store();
+		let releaseCleanup = () => {};
+		const blockedCleanup = new Promise<void>((resolve) => {
+			releaseCleanup = resolve;
+		});
+		const clearExpired = vi
+			.spyOn(keyv, "clearExpired")
+			.mockImplementation(async () => blockedCleanup);
+
+		try {
+			keyv.clearExpiredInterval = 20;
+			await vi.waitFor(() => {
+				expect(clearExpired).toHaveBeenCalledTimes(1);
+			});
+			await new Promise((resolve) => {
+				setTimeout(resolve, 80);
+			});
+			expect(clearExpired).toHaveBeenCalledTimes(1);
+		} finally {
+			keyv.clearExpiredInterval = 0;
+			releaseCleanup();
+			await keyv.disconnect();
+		}
+	});
 });
 
 describe("namespace", () => {

--- a/storage/sqlite/test/test.ts
+++ b/storage/sqlite/test/test.ts
@@ -1,5 +1,6 @@
 import { faker } from "@faker-js/faker";
 import { keyvIteratorTests, keyvTestSuite, storageTestSuite } from "@keyv/test-suite";
+import { Hookified } from "hookified";
 import Keyv from "keyv";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import KeyvSqlite, { createKeyv } from "../src/index.js";
@@ -19,12 +20,12 @@ beforeEach(async () => {
 });
 
 describe("constructor", () => {
-	test("sets the uri when constructed with a string", () => {
+	test("should set the uri when constructed with a string", () => {
 		const keyv = new KeyvSqlite(sqliteUri);
 		expect(keyv.uri).toBe(sqliteUri);
 	});
 
-	test("returns default property values", async () => {
+	test("should return default property values", async () => {
 		const keyv = new KeyvSqlite();
 		expect(keyv.uri).toBe("sqlite://:memory:");
 		expect(keyv.table).toBe("keyv");
@@ -40,7 +41,7 @@ describe("constructor", () => {
 		await keyv.disconnect();
 	});
 
-	test("returns constructor-provided property values", async () => {
+	test("should return constructor-provided property values", async () => {
 		const keyv = new KeyvSqlite({
 			uri: "sqlite://:memory:",
 			table: "custom",
@@ -60,7 +61,7 @@ describe("constructor", () => {
 		await keyv.disconnect();
 	});
 
-	test("returns all configured property values", () => {
+	test("should return all configured property values", () => {
 		const keyv = new KeyvSqlite({
 			uri: sqliteUri,
 			keySize: 512,
@@ -80,18 +81,18 @@ describe("constructor", () => {
 		expect(keyv.clearExpiredInterval).toBe(1000);
 	});
 
-	test("respects the namespaceLength option", () => {
+	test("should respect the namespaceLength option", () => {
 		const keyv = new KeyvSqlite({ uri: sqliteUri, namespaceLength: 128 });
 		expect(keyv.namespaceLength).toBe(128);
 	});
 
-	test("treats keyLength as an alias for keySize", () => {
+	test("should treat keyLength as an alias for keySize", () => {
 		const keyv = new KeyvSqlite({ uri: sqliteUri, keyLength: 512 });
 		expect(keyv.keySize).toBe(512);
 		expect(keyv.keyLength).toBe(512);
 	});
 
-	test("sanitizes numeric, alphabetic, and special-character table names", () => {
+	test("should sanitize numeric, alphabetic, and special-character table names", () => {
 		let keyv = new KeyvSqlite({
 			uri: sqliteUri,
 			// @ts-expect-error testing a numeric table name
@@ -112,7 +113,7 @@ describe("constructor", () => {
 		);
 	});
 
-	test("throws for invalid keySize values", () => {
+	test("should throw for invalid keySize values", () => {
 		expect(
 			() =>
 				new KeyvSqlite({
@@ -135,13 +136,13 @@ describe("constructor", () => {
 		);
 	});
 
-	test("accepts valid keySize values", () => {
+	test("should accept valid keySize values", () => {
 		expect(new KeyvSqlite({ uri: sqliteUri, keySize: 100 }).keySize).toBe(100);
 		expect(new KeyvSqlite({ uri: sqliteUri, keySize: 65535 }).keySize).toBe(65535);
 		expect(new KeyvSqlite({ uri: sqliteUri, keySize: 1 }).keySize).toBe(1);
 	});
 
-	test("uses default values when the options object omits uri", async () => {
+	test("should use default values when the options object omits uri", async () => {
 		const keyv = new KeyvSqlite({ table: "no_uri" });
 		expect(keyv.uri).toBe("sqlite://:memory:");
 		expect(keyv.db).toBe(":memory:");
@@ -150,8 +151,16 @@ describe("constructor", () => {
 	});
 });
 
+describe("capabilities", () => {
+	test("should declare the v6 expires capability", async () => {
+		const keyv = new KeyvSqlite("sqlite://:memory:");
+		expect(keyv.capabilities.expires).toBe(true);
+		await keyv.disconnect();
+	});
+});
+
 describe("property setters", () => {
-	test("table setter sanitizes the table name", async () => {
+	test("should sanitize the table name via the setter", async () => {
 		const keyv = new KeyvSqlite("sqlite://:memory:");
 		keyv.table = "my_table";
 		expect(keyv.table).toBe("my_table");
@@ -160,7 +169,7 @@ describe("property setters", () => {
 		await keyv.disconnect();
 	});
 
-	test("keySize setter updates the value", async () => {
+	test("should update keySize via the setter", async () => {
 		const keyv = new KeyvSqlite("sqlite://:memory:");
 		expect(keyv.keySize).toBe(255);
 		keyv.keySize = 512;
@@ -168,7 +177,7 @@ describe("property setters", () => {
 		await keyv.disconnect();
 	});
 
-	test("namespaceLength setter updates the value", async () => {
+	test("should update namespaceLength via the setter", async () => {
 		const keyv = new KeyvSqlite("sqlite://:memory:");
 		expect(keyv.namespaceLength).toBe(255);
 		keyv.namespaceLength = 128;
@@ -176,7 +185,7 @@ describe("property setters", () => {
 		await keyv.disconnect();
 	});
 
-	test("iterationLimit setter updates the value", async () => {
+	test("should update iterationLimit via the setter", async () => {
 		const keyv = new KeyvSqlite("sqlite://:memory:");
 		expect(keyv.iterationLimit).toBe(10);
 		keyv.iterationLimit = 99;
@@ -186,7 +195,7 @@ describe("property setters", () => {
 });
 
 describe("opts", () => {
-	test("returns a snapshot of the current configuration", () => {
+	test("should return a snapshot of the current configuration", () => {
 		const keyv = new KeyvSqlite({
 			uri: sqliteUri,
 			table: "cache",
@@ -207,12 +216,12 @@ describe("opts", () => {
 });
 
 describe("get", () => {
-	test("returns undefined for a missing key", async () => {
+	test("should return undefined for a missing key", async () => {
 		const keyv = store();
 		expect(await keyv.get(faker.string.uuid())).toBeUndefined();
 	});
 
-	test("returns undefined (not null) for a key stored with a null value", async () => {
+	test("should return undefined (not null) for a key stored with a null value", async () => {
 		const keyv = store();
 		const key = faker.string.uuid();
 		// biome-ignore lint/suspicious/noExplicitAny: testing the null value path
@@ -221,10 +230,23 @@ describe("get", () => {
 		expect(result).toBeUndefined();
 		expect(result).not.toBeNull();
 	});
+
+	test("should return undefined (not null) for a SQL NULL stored via query", async () => {
+		const keyv = store();
+		const key = faker.string.uuid();
+		await keyv.query(
+			`INSERT INTO "${keyv.table}" (key, value, namespace, expires) VALUES (?, NULL, ?, NULL)`,
+			key,
+			"",
+		);
+		const result = await keyv.get(key);
+		expect(result).toBeUndefined();
+		expect(result).not.toBeNull();
+	});
 });
 
 describe("getMany", () => {
-	test("returns multiple values in order", async () => {
+	test("should return multiple values in order", async () => {
 		const keyv = store();
 		const key1 = faker.string.uuid();
 		const key2 = faker.string.uuid();
@@ -238,7 +260,7 @@ describe("getMany", () => {
 		expect(await keyv.getMany([key1, key2, key3])).toStrictEqual([val1, val2, val3]);
 	});
 
-	test("returns undefined (not null) for keys stored with a null value", async () => {
+	test("should return undefined (not null) for keys stored with a null value", async () => {
 		const keyv = store();
 		const key = faker.string.uuid();
 		// biome-ignore lint/suspicious/noExplicitAny: testing the null value path
@@ -248,15 +270,34 @@ describe("getMany", () => {
 		expect(results[0]).not.toBeNull();
 	});
 
-	test("returns undefined for expired keys and deletes them", async () => {
+	test("should return undefined (not null) from getMany for a SQL NULL stored via query", async () => {
+		const keyv = store();
+		const key = faker.string.uuid();
+		await keyv.query(
+			`INSERT INTO "${keyv.table}" (key, value, namespace, expires) VALUES (?, NULL, ?, NULL)`,
+			key,
+			"",
+		);
+		const results = await keyv.getMany([key]);
+		expect(results).toEqual([undefined]);
+		expect(results[0]).not.toBeNull();
+	});
+
+	test("should return undefined for expired keys and delete them", async () => {
 		const keyv = store();
 		const expiredKey1 = faker.string.uuid();
 		const expiredKey2 = faker.string.uuid();
 		const validKey = faker.string.uuid();
 		const pastExpires = Date.now() - 1000;
 		const futureExpires = Date.now() + 60_000;
-		const expiredValue = JSON.stringify({ value: "old", expires: pastExpires });
-		const validValue = JSON.stringify({ value: "fresh", expires: futureExpires });
+		const expiredValue = JSON.stringify({
+			value: faker.lorem.word(),
+			expires: pastExpires,
+		});
+		const validValue = JSON.stringify({
+			value: faker.lorem.word(),
+			expires: futureExpires,
+		});
 		await keyv.set(expiredKey1, expiredValue, pastExpires);
 		await keyv.set(expiredKey2, expiredValue, pastExpires);
 		await keyv.set(validKey, validValue, futureExpires);
@@ -271,7 +312,7 @@ describe("getMany", () => {
 });
 
 describe("set and setMany", () => {
-	test("setMany upserts existing keys", async () => {
+	test("should upsert existing keys with setMany", async () => {
 		const keyv = store();
 		const key1 = faker.string.uuid();
 		const key2 = faker.string.uuid();
@@ -287,28 +328,33 @@ describe("set and setMany", () => {
 		expect(await keyv.get(key2)).toBe(val2);
 	});
 
-	test("setMany and getMany batch past SQLite bind-parameter limits", async () => {
+	test("should batch setMany and getMany past SQLite bind-parameter limits", async () => {
 		const keyv = store();
-		const entries = Array.from({ length: 250 }, (_, i) => ({
-			key: `batch-key-${i}`,
-			value: `v${i}`,
+		const entries = Array.from({ length: 250 }, () => ({
+			key: faker.string.uuid(),
+			value: faker.lorem.word(),
 		}));
 		const results = await keyv.setMany(entries);
 		expect(results).toHaveLength(250);
 		expect(results?.every(Boolean)).toBe(true);
 
 		const keys = entries.map((entry) => entry.key);
-		keys.push("batch-missing");
+		const missingKey = faker.string.uuid();
+		keys.push(missingKey);
 		const values = await keyv.getMany(keys);
 		expect(values).toHaveLength(251);
-		expect(values[0]).toBe("v0");
-		expect(values[249]).toBe("v249");
+		expect(values[0]).toBe(entries[0].value);
+		expect(values[249]).toBe(entries[249].value);
 		expect(values[250]).toBeUndefined();
 		await keyv.deleteMany(keys);
 	});
 
-	test("setMany emits an error and returns false entries on query error", async () => {
+	test("should emit an error from setMany and return false entries on query error", async () => {
 		const keyv = new KeyvSqlite("sqlite://:memory:");
+		const key1 = faker.string.uuid();
+		const key2 = faker.string.uuid();
+		const val1 = faker.lorem.word();
+		const val2 = faker.lorem.word();
 		let emittedError = false;
 		keyv.on("error", () => {
 			emittedError = true;
@@ -316,8 +362,8 @@ describe("set and setMany", () => {
 		// Close the connection to force an error.
 		await keyv.disconnect();
 		const result = await keyv.setMany([
-			{ key: "key1", value: "val1" },
-			{ key: "key2", value: "val2" },
+			{ key: key1, value: val1 },
+			{ key: key2, value: val2 },
 		]);
 		expect(result).toEqual([false, false]);
 		expect(emittedError).toBe(true);
@@ -325,26 +371,35 @@ describe("set and setMany", () => {
 });
 
 describe("has and hasMany", () => {
-	test("has returns false and deletes an expired key", async () => {
+	test("should return false from has and delete an expired key", async () => {
 		const keyv = store();
 		const key = faker.string.uuid();
 		const pastExpires = Date.now() - 1000;
-		const expiredValue = JSON.stringify({ value: "old", expires: pastExpires });
+		const expiredValue = JSON.stringify({
+			value: faker.lorem.word(),
+			expires: pastExpires,
+		});
 		await keyv.set(key, expiredValue, pastExpires);
 		expect(await keyv.has(key)).toBe(false);
 		// The expired key should have been deleted.
 		expect(await keyv.get(key)).toBeUndefined();
 	});
 
-	test("hasMany returns false for expired keys and deletes them", async () => {
+	test("should return false from hasMany for expired keys and delete them", async () => {
 		const keyv = store();
 		const expiredKey1 = faker.string.uuid();
 		const expiredKey2 = faker.string.uuid();
 		const validKey = faker.string.uuid();
 		const pastExpires = Date.now() - 1000;
 		const futureExpires = Date.now() + 60_000;
-		const expiredValue = JSON.stringify({ value: "old", expires: pastExpires });
-		const validValue = JSON.stringify({ value: "fresh", expires: futureExpires });
+		const expiredValue = JSON.stringify({
+			value: faker.lorem.word(),
+			expires: pastExpires,
+		});
+		const validValue = JSON.stringify({
+			value: faker.lorem.word(),
+			expires: futureExpires,
+		});
 		await keyv.set(expiredKey1, expiredValue, pastExpires);
 		await keyv.set(expiredKey2, expiredValue, pastExpires);
 		await keyv.set(validKey, validValue, futureExpires);
@@ -357,7 +412,7 @@ describe("has and hasMany", () => {
 });
 
 describe("delete and deleteMany", () => {
-	test("deleteMany deletes multiple records", async () => {
+	test("should delete multiple records with deleteMany", async () => {
 		const keyv = store();
 		const key1 = faker.string.uuid();
 		const key2 = faker.string.uuid();
@@ -373,7 +428,7 @@ describe("delete and deleteMany", () => {
 		expect(await keyv.getMany([key1, key2, key3])).toStrictEqual([undefined, undefined, undefined]);
 	});
 
-	test("deleteMany returns per-key booleans for existing and missing keys", async () => {
+	test("should return per-key booleans from deleteMany for existing and missing keys", async () => {
 		const keyv = store();
 		const existingKey1 = faker.string.uuid();
 		const existingKey2 = faker.string.uuid();
@@ -391,11 +446,17 @@ describe("delete and deleteMany", () => {
 });
 
 describe("clearExpired", () => {
-	test("removes expired entries and keeps valid ones", async () => {
+	test("should remove expired entries and keep valid ones", async () => {
 		const keyv = store();
 		const pastExpires = Date.now() - 1000;
-		const expiredValue = JSON.stringify({ value: "old", expires: pastExpires });
-		const validValue = JSON.stringify({ value: "current", expires: null });
+		const expiredValue = JSON.stringify({
+			value: faker.lorem.word(),
+			expires: pastExpires,
+		});
+		const validValue = JSON.stringify({
+			value: faker.lorem.word(),
+			expires: null,
+		});
 		const expiredKey = faker.string.uuid();
 		const validKey = faker.string.uuid();
 		await keyv.set(expiredKey, expiredValue, pastExpires);
@@ -408,7 +469,7 @@ describe("clearExpired", () => {
 		expect(await keyv.has(validKey)).toBe(true);
 	});
 
-	test("stores non-string object values with an explicit expires", async () => {
+	test("should store non-string object values with an explicit expires", async () => {
 		const keyv = store();
 		const futureExpires = Date.now() + 60_000;
 		const objValue = { value: faker.lorem.word(), expires: futureExpires };
@@ -421,7 +482,7 @@ describe("clearExpired", () => {
 	// Regression: before v6 the adapter recovered `expires` by JSON.parsing the stored
 	// value, which silently failed for compressed/encrypted/msgpackr/superjson output and
 	// left the expires column NULL. The contract now passes expires directly.
-	test("populates the expires column for non-JSON encoded values so expiry still works", async () => {
+	test("should populate the expires column for non-JSON encoded values so expiry still works", async () => {
 		const store = new KeyvSqlite({ uri: sqliteUri, busyTimeout: 3000 });
 		const serialization = {
 			stringify: (data: unknown) => `RAW:${JSON.stringify(data)}`,
@@ -430,8 +491,9 @@ describe("clearExpired", () => {
 		// Opt out of Keyv-layer expiry so this test isolates the store's own expires column.
 		const keyv = new Keyv({ store, serialization, checkExpired: false });
 		const key = faker.string.uuid();
-		await keyv.set(key, "value", 100);
-		expect(await keyv.get(key)).toBe("value");
+		const serializedValue = faker.lorem.word();
+		await keyv.set(key, serializedValue, 100);
+		expect(await keyv.get(key)).toBe(serializedValue);
 		await new Promise((resolve) => {
 			setTimeout(resolve, 200);
 		});
@@ -444,7 +506,7 @@ describe("clearExpired", () => {
 });
 
 describe("clearExpiredInterval", () => {
-	test("automatically cleans up expired entries on the configured schedule", async () => {
+	test("should automatically clean up expired entries on the configured schedule", async () => {
 		const keyv = new KeyvSqlite({
 			uri: sqliteUri,
 			busyTimeout: 3000,
@@ -452,7 +514,10 @@ describe("clearExpiredInterval", () => {
 		});
 		await keyv.clear();
 		const pastExpires = Date.now() - 1000;
-		const expiredValue = JSON.stringify({ value: "old", expires: pastExpires });
+		const expiredValue = JSON.stringify({
+			value: faker.lorem.word(),
+			expires: pastExpires,
+		});
 		const autoExpiredKey = faker.string.uuid();
 		await keyv.set(autoExpiredKey, expiredValue, pastExpires);
 		// has() already filters expired entries.
@@ -465,7 +530,7 @@ describe("clearExpiredInterval", () => {
 		await keyv.disconnect();
 	});
 
-	test("setter restarts the timer and can disable it", async () => {
+	test("should restart and disable the clearExpired timer via the setter", async () => {
 		const keyv = store();
 		expect(keyv.clearExpiredInterval).toBe(0);
 		keyv.clearExpiredInterval = 500;
@@ -476,7 +541,7 @@ describe("clearExpiredInterval", () => {
 		await keyv.disconnect();
 	});
 
-	test("does not overlap automatic cleanup runs", async () => {
+	test("should not overlap automatic cleanup runs", async () => {
 		const keyv = store();
 		let releaseCleanup = () => {};
 		const blockedCleanup = new Promise<void>((resolve) => {
@@ -504,11 +569,13 @@ describe("clearExpiredInterval", () => {
 });
 
 describe("namespace", () => {
-	test("stores the namespace separately from the key", async () => {
+	test("should store the namespace separately from the key", async () => {
 		const storeA = store();
 		const storeB = store();
-		storeA.namespace = "nsA";
-		storeB.namespace = "nsB";
+		const namespaceA = faker.string.alphanumeric(8);
+		const namespaceB = faker.string.alphanumeric(8);
+		storeA.namespace = namespaceA;
+		storeB.namespace = namespaceB;
 
 		await storeA.clear();
 		await storeB.clear();
@@ -517,23 +584,25 @@ describe("namespace", () => {
 		const nsKey = faker.string.uuid();
 		const valA = faker.lorem.word();
 		const valB = faker.lorem.word();
-		await storeA.set(`nsA:${nsKey}`, valA);
-		await storeB.set(`nsB:${nsKey}`, valB);
+		await storeA.set(`${namespaceA}:${nsKey}`, valA);
+		await storeB.set(`${namespaceB}:${nsKey}`, valB);
 
-		expect(await storeA.get(`nsA:${nsKey}`)).toBe(valA);
-		expect(await storeB.get(`nsB:${nsKey}`)).toBe(valB);
+		expect(await storeA.get(`${namespaceA}:${nsKey}`)).toBe(valA);
+		expect(await storeB.get(`${namespaceB}:${nsKey}`)).toBe(valB);
 
 		// Clearing one namespace should not affect the other.
 		await storeA.clear();
-		expect(await storeA.get(`nsA:${nsKey}`)).toBeUndefined();
-		expect(await storeB.get(`nsB:${nsKey}`)).toBe(valB);
+		expect(await storeA.get(`${namespaceA}:${nsKey}`)).toBeUndefined();
+		expect(await storeB.get(`${namespaceB}:${nsKey}`)).toBe(valB);
 
 		await storeB.clear();
 	});
 
-	test("isolates data across multiple Keyv instances", async () => {
-		const keyvA = new Keyv({ store: store(), namespace: "ns1" });
-		const keyvB = new Keyv({ store: store(), namespace: "ns2" });
+	test("should isolate data across multiple Keyv instances", async () => {
+		const namespaceA = faker.string.alphanumeric(8);
+		const namespaceB = faker.string.alphanumeric(8);
+		const keyvA = new Keyv({ store: store(), namespace: namespaceA });
+		const keyvB = new Keyv({ store: store(), namespace: namespaceB });
 
 		await keyvA.clear();
 		await keyvB.clear();
@@ -576,7 +645,7 @@ describe("namespace", () => {
 });
 
 describe("iterator", () => {
-	test("iterates over a single element", async () => {
+	test("should iterate over a single element", async () => {
 		const keyv = store();
 		await keyv.clear();
 		const testKey = faker.string.uuid();
@@ -588,7 +657,7 @@ describe("iterator", () => {
 		}
 	});
 
-	test("iterates over multiple elements", async () => {
+	test("should iterate over multiple elements", async () => {
 		const keyv = new KeyvSqlite({ uri: sqliteUri, busyTimeout: 3000, iterationLimit: 3 });
 		await keyv.clear();
 		const key1 = faker.string.uuid();
@@ -613,7 +682,7 @@ describe("iterator", () => {
 		expect(actual).toStrictEqual(expected);
 	});
 
-	test("iterates over multiple elements with an iterationLimit of 1", async () => {
+	test("should iterate over multiple elements with an iterationLimit of 1", async () => {
 		const keyv = new KeyvSqlite({ uri: sqliteUri, busyTimeout: 3000, iterationLimit: 1 });
 		await keyv.clear();
 		const key1 = faker.string.uuid();
@@ -642,7 +711,7 @@ describe("iterator", () => {
 		expect(actual).toStrictEqual(expected);
 	});
 
-	test("returns no entries when the store is empty (no namespace passed)", async () => {
+	test("should return no entries when the store is empty (no namespace passed)", async () => {
 		const keyv = new KeyvSqlite({ uri: sqliteUri, busyTimeout: 3000, iterationLimit: 1 });
 		await keyv.clear();
 		const iterator = keyv.iterator();
@@ -651,16 +720,17 @@ describe("iterator", () => {
 		expect(entry.done).toBe(true);
 	});
 
-	test("iterates using the configured namespace without passing it to iterator()", async () => {
+	test("should iterate using the configured namespace without passing it to iterator()", async () => {
 		const keyv = store();
-		keyv.namespace = "iter-ns";
+		const namespace = faker.string.alphanumeric(8);
+		keyv.namespace = namespace;
 		await keyv.clear();
 		const key1 = faker.string.uuid();
 		const key2 = faker.string.uuid();
 		const val1 = faker.lorem.word();
 		const val2 = faker.lorem.word();
-		await keyv.set(`iter-ns:${key1}`, val1);
-		await keyv.set(`iter-ns:${key2}`, val2);
+		await keyv.set(`${namespace}:${key1}`, val1);
+		await keyv.set(`${namespace}:${key2}`, val2);
 
 		const collected = new Map<string, string>();
 		for await (const [key, value] of keyv.iterator()) {
@@ -673,13 +743,14 @@ describe("iterator", () => {
 		await keyv.clear();
 	});
 
-	test("falls back to the default limit when iterationLimit is 0", async () => {
+	test("should fall back to the default limit when iterationLimit is 0", async () => {
 		const keyv = new KeyvSqlite({ uri: sqliteUri, busyTimeout: 3000, iterationLimit: 0 });
-		keyv.namespace = "zero-limit-ns";
+		const namespace = faker.string.alphanumeric(8);
+		keyv.namespace = namespace;
 		await keyv.clear();
 		const key = faker.string.uuid();
 		const val = faker.lorem.word();
-		await keyv.set(`zero-limit-ns:${key}`, val);
+		await keyv.set(`${namespace}:${key}`, val);
 
 		const keys: string[] = [];
 		for await (const [k] of keyv.iterator()) {
@@ -689,43 +760,114 @@ describe("iterator", () => {
 		expect(keys).toContain(key);
 		await keyv.clear();
 	});
+
+	test("should yield undefined instead of null when the stored value is SQL NULL", async () => {
+		const keyv = store();
+		await keyv.clear();
+		const key = faker.string.uuid();
+		await keyv.query(
+			`INSERT INTO "${keyv.table}" (key, value, namespace, expires) VALUES (?, NULL, ?, NULL)`,
+			key,
+			"",
+		);
+		const values: Array<string | undefined> = [];
+		for await (const [iterKey, value] of keyv.iterator()) {
+			if (iterKey === key) {
+				expect(value).not.toBeNull();
+				values.push(value);
+			}
+		}
+
+		expect(values).toEqual([undefined]);
+		await keyv.clear();
+	});
 });
 
 describe("events", () => {
-	test("exposes the hookified event methods", () => {
+	test("should extend Hookified", async () => {
+		const keyv = new KeyvSqlite("sqlite://:memory:");
+		expect(keyv).toBeInstanceOf(Hookified);
+		await keyv.disconnect();
+	});
+
+	test("should expose the Hookified event methods", () => {
 		const keyv = store();
 		expect(typeof keyv.on).toBe("function");
 		expect(typeof keyv.once).toBe("function");
 		expect(typeof keyv.emit).toBe("function");
+		expect(typeof keyv.onHook).toBe("function");
 	});
 
-	test("emits an error event when an operation fails", async () => {
+	test("should emit and receive a custom event", async () => {
 		const keyv = new KeyvSqlite("sqlite://:memory:");
+		const payload = faker.lorem.word();
+		let received: unknown;
+		keyv.on("test-event", (value: unknown) => {
+			received = value;
+		});
+		keyv.emit("test-event", payload);
+		expect(received).toBe(payload);
+		await keyv.disconnect();
+	});
+
+	test("should invoke a once listener only once", async () => {
+		const keyv = new KeyvSqlite("sqlite://:memory:");
+		let count = 0;
+		keyv.once("ping", () => {
+			count += 1;
+		});
+		keyv.emit("ping");
+		keyv.emit("ping");
+		expect(count).toBe(1);
+		await keyv.disconnect();
+	});
+
+	test("should run a Hookified hook registered with onHook", async () => {
+		const keyv = new KeyvSqlite("sqlite://:memory:");
+		let called = false;
+		keyv.onHook("custom", () => {
+			called = true;
+		});
+		await keyv.hook("custom");
+		expect(called).toBe(true);
+		await keyv.disconnect();
+	});
+
+	test("should not throw when emitting error with no listeners", async () => {
+		const keyv = new KeyvSqlite("sqlite://:memory:");
+		expect(() => keyv.emit("error", new Error(faker.lorem.sentence()))).not.toThrow();
+		await keyv.disconnect();
+	});
+
+	test("should emit an error event when an operation fails", async () => {
+		const keyv = new KeyvSqlite("sqlite://:memory:");
+		const failedKey = faker.string.uuid();
+		const failedValue = faker.lorem.word();
 		const error = await new Promise<unknown>((resolve) => {
 			keyv.on("error", (emitted: unknown) => resolve(emitted));
 			// Close the connection then trigger an operation to force an error.
-			void keyv.disconnect().then(() => keyv.setMany([{ key: "k", value: "v" }]));
+			void keyv.disconnect().then(() => keyv.setMany([{ key: failedKey, value: failedValue }]));
 		});
 		expect(error).toBeInstanceOf(Error);
 	});
 });
 
 describe("WAL mode", () => {
-	test("can be enabled for a file-based database", async () => {
+	test("should enable WAL for a file-based database", async () => {
 		const keyv = new KeyvSqlite({ uri: "sqlite://test/testdb-wal.sqlite", wal: true });
 		const result = (await keyv.query("PRAGMA journal_mode")) as Array<{ journal_mode: string }>;
 		expect(result[0].journal_mode).toBe("wal");
 		await keyv.disconnect();
 	});
 
-	test("is not enabled by default", async () => {
+	test("should not enable WAL by default", async () => {
 		const keyv = new KeyvSqlite({ uri: "sqlite://test/testdb-nowal.sqlite" });
 		const result = (await keyv.query("PRAGMA journal_mode")) as Array<{ journal_mode: string }>;
 		expect(result[0].journal_mode).not.toBe("wal");
 		await keyv.disconnect();
 	});
 
-	test("is ignored for an in-memory database but operations still work", async () => {
+	test("should ignore WAL for an in-memory database and still operate", async () => {
 		const keyv = new KeyvSqlite({ uri: "sqlite://:memory:", wal: true });
 		const result = (await keyv.query("PRAGMA journal_mode")) as Array<{ journal_mode: string }>;
 		// In-memory databases cannot use WAL mode; they remain in "memory" journal mode.
@@ -737,7 +879,7 @@ describe("WAL mode", () => {
 		await keyv.disconnect();
 	});
 
-	test("logs a warning for an in-memory database", async () => {
+	test("should log a warning for an in-memory database", async () => {
 		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 		const keyv = new KeyvSqlite({ uri: "sqlite://:memory:", wal: true });
 		// Wait for the database to initialize (the warning happens during initialization).
@@ -751,27 +893,32 @@ describe("WAL mode", () => {
 });
 
 describe("schema migration", () => {
-	test("migrates an old schema that lacks the namespace column", async () => {
+	test("should migrate an old schema that lacks the namespace column", async () => {
 		const dbPath = "test/testdb-migration.sqlite";
 		const fs = await import("node:fs");
 		try {
 			fs.unlinkSync(dbPath);
 		} catch {}
 
+		const oldKey = faker.string.uuid();
+		const oldVal = faker.lorem.word();
+		const newKey = faker.string.uuid();
+		const newVal = faker.lorem.word();
+
 		// Create a database with the old schema (no namespace/expires columns).
 		const Database = (await import("better-sqlite3")).default;
 		const db = new Database(dbPath);
 		db.exec("CREATE TABLE keyv(key VARCHAR(255) PRIMARY KEY, value TEXT)");
-		db.prepare("INSERT INTO keyv (key, value) VALUES (?, ?)").run("oldkey", "oldval");
+		db.prepare("INSERT INTO keyv (key, value) VALUES (?, ?)").run(oldKey, oldVal);
 		db.close();
 
 		// Open with the new adapter — should trigger migration.
 		const keyv = new KeyvSqlite({ uri: `sqlite://${dbPath}`, busyTimeout: 3000 });
 		// Old data should be preserved.
-		expect(await keyv.get("oldkey")).toBe("oldval");
+		expect(await keyv.get(oldKey)).toBe(oldVal);
 		// New features should work.
-		await keyv.set("newkey", "newval");
-		expect(await keyv.get("newkey")).toBe("newval");
+		await keyv.set(newKey, newVal);
+		expect(await keyv.get(newKey)).toBe(newVal);
 		await keyv.disconnect();
 
 		try {
@@ -779,29 +926,44 @@ describe("schema migration", () => {
 		} catch {}
 	});
 
-	test("splits v5 namespaced keys into key and namespace columns", async () => {
+	test("should split v5 namespaced keys into key and namespace columns", async () => {
 		const dbPath = "test/testdb-migration-ns.sqlite";
 		const fs = await import("node:fs");
 		try {
 			fs.unlinkSync(dbPath);
 		} catch {}
 
+		const prefixNs = faker.string.alphanumeric(8);
+		const prefixKey = faker.string.alphanumeric(8);
+		const prefixVal = faker.lorem.word();
+		const nestedNs = faker.string.alphanumeric(8);
+		const nestedKey = `${faker.string.alphanumeric(6)}:${faker.string.alphanumeric(6)}`;
+		const nestedVal = faker.lorem.word();
+		const plainKey = faker.string.alphanumeric(10);
+		const plainVal = faker.lorem.word();
+
 		const Database = (await import("better-sqlite3")).default;
 		const db = new Database(dbPath);
 		db.exec("CREATE TABLE keyv(key VARCHAR(255) PRIMARY KEY, value TEXT)");
-		db.prepare("INSERT INTO keyv (key, value) VALUES (?, ?)").run("keyv:foo", "bar");
-		db.prepare("INSERT INTO keyv (key, value) VALUES (?, ?)").run("app:user:123", "nested");
-		db.prepare("INSERT INTO keyv (key, value) VALUES (?, ?)").run("plain", "noprefix");
+		db.prepare("INSERT INTO keyv (key, value) VALUES (?, ?)").run(
+			`${prefixNs}:${prefixKey}`,
+			prefixVal,
+		);
+		db.prepare("INSERT INTO keyv (key, value) VALUES (?, ?)").run(
+			`${nestedNs}:${nestedKey}`,
+			nestedVal,
+		);
+		db.prepare("INSERT INTO keyv (key, value) VALUES (?, ?)").run(plainKey, plainVal);
 		db.close();
 
 		const keyv = new KeyvSqlite({ uri: `sqlite://${dbPath}`, busyTimeout: 3000 });
-		expect(await keyv.get("plain")).toBe("noprefix");
+		expect(await keyv.get(plainKey)).toBe(plainVal);
 
-		keyv.namespace = "keyv";
-		expect(await keyv.get("keyv:foo")).toBe("bar");
+		keyv.namespace = prefixNs;
+		expect(await keyv.get(`${prefixNs}:${prefixKey}`)).toBe(prefixVal);
 
-		keyv.namespace = "app";
-		expect(await keyv.get("app:user:123")).toBe("nested");
+		keyv.namespace = nestedNs;
+		expect(await keyv.get(`${nestedNs}:${nestedKey}`)).toBe(nestedVal);
 		await keyv.disconnect();
 
 		try {
@@ -809,20 +971,24 @@ describe("schema migration", () => {
 		} catch {}
 	});
 
-	test("recovers a leftover _migration_old table from an interrupted migration", async () => {
+	test("should recover a leftover _migration_old table from an interrupted migration", async () => {
 		const dbPath = "test/testdb-migration-leftover.sqlite";
 		const fs = await import("node:fs");
 		try {
 			fs.unlinkSync(dbPath);
 		} catch {}
 
+		const namespace = faker.string.alphanumeric(8);
+		const legacyKey = faker.string.alphanumeric(8);
+		const keptValue = faker.lorem.word();
+
 		const Database = (await import("better-sqlite3")).default;
 		const db = new Database(dbPath);
 		// Simulate a crash after RENAME + CREATE but before INSERT/DROP.
 		db.exec("CREATE TABLE keyv_migration_old(key VARCHAR(255) PRIMARY KEY, value TEXT)");
 		db.prepare("INSERT INTO keyv_migration_old (key, value) VALUES (?, ?)").run(
-			"ns:legacy",
-			"kept",
+			`${namespace}:${legacyKey}`,
+			keptValue,
 		);
 		db.exec(
 			"CREATE TABLE keyv(key VARCHAR(255) NOT NULL, value TEXT, namespace VARCHAR(255) NOT NULL DEFAULT '', expires BIGINT DEFAULT NULL, UNIQUE(key, namespace))",
@@ -830,8 +996,8 @@ describe("schema migration", () => {
 		db.close();
 
 		const keyv = new KeyvSqlite({ uri: `sqlite://${dbPath}`, busyTimeout: 3000 });
-		keyv.namespace = "ns";
-		expect(await keyv.get("ns:legacy")).toBe("kept");
+		keyv.namespace = namespace;
+		expect(await keyv.get(`${namespace}:${legacyKey}`)).toBe(keptValue);
 
 		const leftover = (await keyv.query(
 			"SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'keyv_migration_old'",
@@ -844,22 +1010,28 @@ describe("schema migration", () => {
 		} catch {}
 	});
 
-	test("recovers leftover migration data when the new table is missing", async () => {
+	test("should recover leftover migration data when the new table is missing", async () => {
 		const dbPath = "test/testdb-migration-leftover-missing.sqlite";
 		const fs = await import("node:fs");
 		try {
 			fs.unlinkSync(dbPath);
 		} catch {}
 
+		const leftoverKey = faker.string.uuid();
+		const leftoverVal = faker.lorem.word();
+
 		const Database = (await import("better-sqlite3")).default;
 		const db = new Database(dbPath);
 		// Simulate a crash after RENAME but before CREATE.
 		db.exec("CREATE TABLE keyv_migration_old(key VARCHAR(255) PRIMARY KEY, value TEXT)");
-		db.prepare("INSERT INTO keyv_migration_old (key, value) VALUES (?, ?)").run("oldkey", "oldval");
+		db.prepare("INSERT INTO keyv_migration_old (key, value) VALUES (?, ?)").run(
+			leftoverKey,
+			leftoverVal,
+		);
 		db.close();
 
 		const keyv = new KeyvSqlite({ uri: `sqlite://${dbPath}`, busyTimeout: 3000 });
-		expect(await keyv.get("oldkey")).toBe("oldval");
+		expect(await keyv.get(leftoverKey)).toBe(leftoverVal);
 		const leftover = (await keyv.query(
 			"SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'keyv_migration_old'",
 		)) as unknown[];
@@ -871,7 +1043,7 @@ describe("schema migration", () => {
 		} catch {}
 	});
 
-	test("rolls back leftover recovery when the copy fails", async () => {
+	test("should roll back leftover recovery when the copy fails", async () => {
 		const dbPath = "test/testdb-migration-rollback.sqlite";
 		const fs = await import("node:fs");
 		try {
@@ -904,7 +1076,7 @@ describe("schema migration", () => {
 		} catch {}
 	});
 
-	test("migrates a schema that has namespace but lacks the expires column", async () => {
+	test("should migrate a schema that has namespace but lacks the expires column", async () => {
 		const dbPath = "test/testdb-migration2.sqlite";
 		const fs = await import("node:fs");
 		try {
@@ -914,21 +1086,31 @@ describe("schema migration", () => {
 		// Create a database with namespace but no expires column.
 		const Database = (await import("better-sqlite3")).default;
 		const db = new Database(dbPath);
+		const existingKey = faker.string.uuid();
+		const existingVal = faker.lorem.word();
 		db.exec(
 			"CREATE TABLE keyv(key VARCHAR(255) NOT NULL, value TEXT, namespace VARCHAR(255) NOT NULL DEFAULT '', UNIQUE(key, namespace))",
 		);
-		db.prepare("INSERT INTO keyv (key, value, namespace) VALUES (?, ?, ?)").run("k1", "v1", "");
+		db.prepare("INSERT INTO keyv (key, value, namespace) VALUES (?, ?, ?)").run(
+			existingKey,
+			existingVal,
+			"",
+		);
 		db.close();
 
 		// Open with the new adapter — should add the expires column.
 		const keyv = new KeyvSqlite({ uri: `sqlite://${dbPath}`, busyTimeout: 3000 });
-		expect(await keyv.get("k1")).toBe("v1");
+		expect(await keyv.get(existingKey)).toBe(existingVal);
 		// Expires-related features should work.
 		const pastExpires = Date.now() - 1000;
-		const expiredValue = JSON.stringify({ value: "temp", expires: pastExpires });
-		await keyv.set("expiring", expiredValue, pastExpires);
+		const expiredValue = JSON.stringify({
+			value: faker.lorem.word(),
+			expires: pastExpires,
+		});
+		const expiringKey = faker.string.uuid();
+		await keyv.set(expiringKey, expiredValue, pastExpires);
 		await keyv.clearExpired();
-		expect(await keyv.has("expiring")).toBe(false);
+		expect(await keyv.has(expiringKey)).toBe(false);
 		await keyv.disconnect();
 
 		try {
@@ -938,7 +1120,7 @@ describe("schema migration", () => {
 });
 
 describe("SQL injection prevention", () => {
-	test("sanitizes a table name with injection characters at construction", async () => {
+	test("should sanitize a table name with injection characters at construction", async () => {
 		const keyv = new KeyvSqlite({
 			uri: sqliteUri,
 			table: "keyv'; DROP TABLE keyv; --",
@@ -955,14 +1137,14 @@ describe("SQL injection prevention", () => {
 		await keyv.disconnect();
 	});
 
-	test("table setter sanitizes input to prevent post-construction injection", () => {
+	test("should sanitize table setter input to prevent post-construction injection", () => {
 		const keyv = new KeyvSqlite({ uri: sqliteUri });
 		keyv.table = "evil'; DROP TABLE keyv;--";
 		// Should be sanitized, not the raw malicious string.
 		expect(keyv.table).toBe("evilDROPTABLEkeyv");
 	});
 
-	test("handles a table name that is a SQLite reserved keyword", async () => {
+	test("should handle a table name that is a SQLite reserved keyword", async () => {
 		const keyv = new KeyvSqlite({ uri: sqliteUri, table: "select", busyTimeout: 3000 });
 		// escapeIdentifier wraps the name in double quotes, so "select" is safe.
 		expect(keyv.table).toBe("select");
@@ -974,7 +1156,7 @@ describe("SQL injection prevention", () => {
 		await keyv.disconnect();
 	});
 
-	test("escapes a table name containing double quotes", async () => {
+	test("should escape a table name containing double quotes", async () => {
 		const keyv = new KeyvSqlite({ uri: sqliteUri, table: 'my"table', busyTimeout: 3000 });
 		// toTableString strips the double-quote character.
 		expect(keyv.table).toBe("mytable");
@@ -988,7 +1170,7 @@ describe("SQL injection prevention", () => {
 });
 
 describe("connection", () => {
-	test("rejects operations after disconnect", async () => {
+	test("should reject operations after disconnect", async () => {
 		const keyv = new KeyvSqlite({ uri: sqliteUri });
 		const testKey = faker.string.uuid();
 		const testVal = faker.lorem.word();
@@ -1001,7 +1183,7 @@ describe("connection", () => {
 });
 
 describe("createKeyv", () => {
-	test("returns a Keyv instance backed by KeyvSqlite", () => {
+	test("should return a Keyv instance backed by KeyvSqlite", () => {
 		const keyv = createKeyv(sqliteUri);
 		expect(keyv).toBeInstanceOf(Keyv);
 	});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Please check if the PR fulfills these requirements**
- [x] Followed the Contributing and Code of Conduct guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix + docs + test/API cleanup for the SQLite adapter before a stable v6, plus a MySQL iterator pagination fix that failed `node-22` CI.

## Review summary

The adapter is in good shape for the v6 contract (`capabilities.expires`, absolute `expires` on `set`/`setMany`, namespace column, Hookified, bulk ops, multi-driver). A few things should land before a stable v6.

### Fixed in this PR

1. **Schema migration was not transactional.** The v5 → v6 rebuild was `RENAME` → `CREATE` → `INSERT` → `DROP` with autocommit. A crash after rename (or after create, before insert) left an empty new table; the next connect saw a `namespace` column and skipped migration. Data sat unused in `{table}_migration_old`. Migration now runs in `BEGIN`/`COMMIT` with `ROLLBACK` on failure, and leftover `_migration_old` tables are recovered on connect.
2. **sqlite3 custom-driver queue hung after any error.** A rejected query poisoned the serial promise chain so later `set`/`get` never settled. The queue now continues after failures.
3. **`busyTimeout` interpolation** in `better-sqlite3` now matches the other drivers (`Number(...)`).
4. **Overlapping `clearExpired()` interval runs** are skipped (same guard MySQL already has).
5. **README** matches the public store API: `capabilities`, `query`, `close`, `disconnect`, adapter `set`/`setMany` take absolute `expires`, `get`/`getMany`/`iterator` never return `null`, and Events documents Hookified (`on`/`once`/`emit`, `throwOnEmptyListeners: false`). Also: default driver is `node:sqlite` (still experimental), iterator skips expired rows but does not delete them, first-colon migration caveat.
6. **MySQL iterator skipped mixed-case keys across pages.** `CONVERT(id USING utf8mb4) AS id` made `ORDER BY id` use utf8 collation while `id > cursor` used VARBINARY. With `iterationLimit: 2` that dropped a key (CI `node-22`: expected 3, got 2). The converted column is now aliased as `converted_id` so ordering and the cursor stay on the binary `id` column.
7. **Aikido SAST on migration SQL.** Extracting `getLegacyMigrationInsertSql(oldTable)` interpolated a parameter into SQL. Identifiers are now derived from the sanitized table name, checked against an alphanumeric whitelist, quoted, and concatenated. Table names still cannot be bound as SQLite parameters.

### API / test cleanup

- Public properties sit under the constructor; `query` and `close` are methods with the other public functions; private helpers remain below them.
- JSDoc on public members includes `@param` types and `@returns`.
- Adapters return `undefined` (never `null`) for missing, expired, or SQL `NULL` values.
- Tests use `test("should …")` descriptions, faker for payload keys/values, and Hookified coverage (`instanceof`, `on`/`once`/`emit`, `onHook`).

### Recommended, not changed (product calls)

- **Defaulting to `node:sqlite`.** Auto-detect prefers it on Node 22.13+. It is unflagged but still **Stability 1.1**. Every connect emits Node's `ExperimentalWarning`. Safer default until it is stable: `better-sqlite3` first, `node:sqlite` opt-in. Current order looks intentional, so it was left as-is.
- **`better-sqlite3` as a hard native dependency.** On supported Node, `node:sqlite` is the default, but install still compiles `better-sqlite3`. Optional peer / `optionalDependencies` would help Alpine/serverless; it is a packaging decision.
- **`clearExpired()` uses `expires < now` while `get`/`has` use `<=`.** Same in Postgres/MySQL. Family-wide, not SQLite-only.
- **Postgres/MySQL READMEs** still say the adapter extracts expires from the serialized value. Same copy-paste as SQLite had.
- **Website getting-started** still shows `new Keyv('sqlite://...')` auto-loading adapters. Core no longer does that.

### Intentional / acceptable

- WAL default remains `false` (extra `-wal`/`-shm` files).
- Table/`keySize` setters after construct do not rebuild schema (now documented).
- Native compile of `better-sqlite3` kept as a bundled fallback.

## Test plan

- `@keyv/sqlite` vitest suite: 166 tests passed, 100% line/branch coverage (`pnpm test` in `storage/sqlite`).
- MySQL iterator regression: mixed-case keys (`Zebra` / `apple` / `banana`) with `iterationLimit: 2` (verified on CI `node-22`).
- Coverage: namespaced v5 key split, leftover `_migration_old` recovery, rollback when copy fails, explicit `node:sqlite` driver, sqlite3 queue after error, setMany/getMany past bind-parameter limits, overlapping `clearExpired` interval, SQL `NULL` → `undefined`, Hookified events.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba7dd0d0-edec-4b3b-a7dd-ea21e7471f5f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba7dd0d0-edec-4b3b-a7dd-ea21e7471f5f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

