### PR TITLE
valkey - refactor: v6 review cleanup for docs, tests, and events

### DIFF
--- a/storage/valkey/README.md
+++ b/storage/valkey/README.md
@@ -17,12 +17,14 @@ We are using the [iovalkey](https://www.npmjs.com/package/iovalkey) which is a N
 
 - [Install](#install)
 - [Usage](#usage)
+- [Using the createKeyv function](#using-the-createkeyv-function)
 - [Migrating to v6](#migrating-to-v6)
 - [Constructor Options](#constructor-options)
 - [Properties](#properties)
+  - [capabilities](#capabilities)
   - [namespace](#namespace)
   - [useSets](#usesets)
-  - [useRedisSets (deprecated)](#useredisSets-deprecated)
+  - [useRedisSets (deprecated)](#useredissets-deprecated)
   - [client](#client)
 - [Methods](#methods)
   - [.get(key)](#getkey)
@@ -36,17 +38,18 @@ We are using the [iovalkey](https://www.npmjs.com/package/iovalkey) which is a N
   - [.clear()](#clear)
   - [.iterator()](#iterator)
   - [.disconnect()](#disconnect)
+- [Events](#events)
 - [Expiration and TTL](#expiration-and-ttl)
 - [Clustering](#clustering)
 - [License](#license)
 
-# Install
+## Install
 
 ```shell
 npm install --save keyv @keyv/valkey
 ```
 
-# Usage
+## Usage
 
 This is using the helper `createKeyv` function to create a Keyv instance with the Valkey storage adapter:
 
@@ -101,6 +104,21 @@ const cluster = new Redis.Cluster([{ host: '127.0.0.1', port: 7001 }]);
 const keyvValkey = new KeyvValkey(cluster);
 const keyv = new Keyv({ store: keyvValkey });
 ```
+
+## Using the createKeyv function
+
+`createKeyv` is a convenience factory that returns a `Keyv` instance with the Valkey adapter already wired. The namespace is taken from the adapter so it is preserved whether it was passed in the connect options object or the second argument.
+
+```js
+import {createKeyv} from '@keyv/valkey';
+
+const keyv = createKeyv('redis://localhost:6379', { namespace: 'my-app' });
+console.log(keyv.namespace); // 'my-app'
+console.log(keyv.store.namespace); // 'my-app'
+```
+
+If no connect argument is provided, the default URI is `redis://localhost:6379`.
+
 ## Migrating to v6
 
 ### Breaking changes
@@ -149,19 +167,34 @@ When `useSets` is enabled, all keys (both data keys and the SET tracking key) no
 
 The `clear()` method automatically detects and cleans up legacy `namespace:`-prefixed SET keys, so no manual migration is needed.
 
+#### Missing values are `undefined`, never `null`
+
+`get()`, `getMany()`, and `iterator()` return `undefined` for missing keys. They never return `null`.
+
 ## Constructor Options
 
 `KeyvValkey` accepts a connection URI string, an options object, or an existing iovalkey `Redis`/`Cluster` instance. The options object accepts the following properties along with any [`RedisOptions`](https://github.com/valkey-io/iovalkey#connect-to-valkey) from the `iovalkey` library:
 
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
-| `uri` | `string` | `undefined` | Valkey connection URI |
+| `uri` | `string` | `undefined` | Valkey connection URI (`redis://` or `valkey://`) |
 | `useSets` | `boolean` | `false` | Whether to use sets for namespace key management |
 | `namespace` | `string` | `undefined` | Namespace used to prefix keys for multi-tenant isolation |
 
 ## Properties
 
 All configuration options are exposed as properties with getters and setters on the `KeyvValkey` instance. You can read or update them after construction.
+
+### capabilities
+
+Read-only capability descriptor for the v6 storage contract. `capabilities.expires` is `true`, which means `set()` / `setMany()` accept an absolute Unix-ms `expires` timestamp.
+
+- Type: `KeyvStorageCapability`
+
+```js
+const store = new KeyvValkey('redis://localhost:6379');
+console.log(store.capabilities.expires); // true
+```
 
 ### namespace
 
@@ -192,7 +225,7 @@ console.log(store.useSets); // true
 
 When `useSets` is enabled, all keys use the `sets:` prefix (e.g., `sets:myns:mykey`) to isolate them from non-useSets keys. The SET tracking key is stored at `sets:<namespace>`.
 
-When `useSets` is `false`, the `clear()` function uses pattern matching (`KEYS` command) to find and delete keys, which may be slower on very large databases.
+When `useSets` is `false`, the `clear()` function uses pattern matching (`KEYS` command) to find and delete keys, which may be slower on very large databases. With no namespace this matches every key in the current database.
 
 ### useRedisSets (deprecated)
 
@@ -200,7 +233,7 @@ Deprecated alias for `useSets`. Use `useSets` instead.
 
 ### client
 
-Get or set the underlying iovalkey `Redis` or `Cluster` client instance.
+Get or set the underlying iovalkey `Redis` or `Cluster` client instance. Replacing the client re-wires Hookified event listeners on the new instance and removes them from the previous one.
 
 - Type: `Redis | Cluster`
 
@@ -218,7 +251,7 @@ store.client = new Redis('redis://localhost:6380');
 
 ### .get(key)
 
-Returns the value for the given key. Returns `undefined` if the key does not exist.
+Returns the value for the given key. Returns `undefined` if the key does not exist. Never returns `null`.
 
 ```js
 const value = await store.get('foo');
@@ -226,7 +259,7 @@ const value = await store.get('foo');
 
 ### .getMany(keys)
 
-Returns an array of values for the given keys. Returns `undefined` for any key that does not exist.
+Returns an array of values for the given keys. Returns `undefined` for any key that does not exist. Never returns `null` entries. In cluster mode, keys are grouped by hash slot and fetched with per-slot `MGET`.
 
 ```js
 const values = await store.getMany(['foo', 'bar']);
@@ -235,6 +268,8 @@ const values = await store.getMany(['foo', 'bar']);
 ### .set(key, value, expires?)
 
 Sets a value for the given key with an optional absolute `expires` (Unix ms since epoch). The adapter writes it via `PXAT`. Through Keyv (`keyv.set(key, value, ttl)`) you still pass a relative TTL in milliseconds — Keyv converts it to `expires` for you.
+
+Returns `true` if the value was stored, or `false` if `value` is `undefined` or the write failed (the failure is also emitted as an `error` event).
 
 ```js
 await store.set('foo', 'bar');
@@ -262,7 +297,7 @@ const deleted = await store.delete('foo');
 
 ### .deleteMany(keys)
 
-Deletes multiple key-value pairs from the store in a single batch operation. Returns a `boolean[]` indicating whether each key was deleted.
+Deletes multiple key-value pairs from the store. Each key is deleted individually (cluster-safe; not a single `MULTI` batch). Returns a `boolean[]` indicating whether each key was deleted.
 
 ```js
 const results = await store.deleteMany(['foo', 'bar']); // [true, true]
@@ -278,7 +313,7 @@ const exists = await store.has('foo');
 
 ### .hasMany(keys)
 
-Checks if multiple keys exist in the store in a single batch operation. Returns an array of booleans.
+Checks if multiple keys exist in the store in a single batch operation. In cluster mode, keys are grouped by hash slot. Returns an array of booleans.
 
 ```js
 const results = await store.hasMany(['foo', 'bar', 'baz']);
@@ -287,7 +322,7 @@ const results = await store.hasMany(['foo', 'bar', 'baz']);
 
 ### .clear()
 
-Clears all entries from the store. If a namespace is set, only entries within that namespace are cleared.
+Clears all entries from the store. If a namespace is set, only entries within that namespace are cleared. If no namespace is set and `useSets` is `false`, this uses `KEYS *` and removes every key in the current database.
 
 ```js
 await store.clear();
@@ -295,7 +330,7 @@ await store.clear();
 
 ### .iterator()
 
-Returns an async iterator for iterating over all key-value pairs in the store. The iterator uses the namespace configured on the instance.
+Returns an async iterator for iterating over all key-value pairs in the store. The iterator uses the namespace configured on the instance. Missing values are yielded as `undefined`, never `null`.
 
 ```js
 for await (const [key, value] of store.iterator()) {
@@ -305,17 +340,50 @@ for await (const [key, value] of store.iterator()) {
 
 ### .disconnect()
 
-Disconnects from the Valkey server.
+Disconnects from the Valkey server. Subsequent operations on this adapter will throw.
 
 ```js
 await store.disconnect();
 ```
 
+## Events
+
+`KeyvValkey` extends [Hookified](https://hookified.org), so you can use `on`, `once`, `off`, and `emit`. The adapter re-emits the following events from the underlying iovalkey client:
+
+| Event | Source | Payload |
+| --- | --- | --- |
+| `error` | client `error` | The `Error` from the client |
+| `connect` | client `connect` | The iovalkey client instance |
+| `reconnecting` | client `reconnecting` | Arguments from the client (e.g. delay) |
+| `disconnect` | client `close` | The iovalkey client instance |
+
+```js
+const store = new KeyvValkey('redis://localhost:6379');
+
+store.on('error', (error) => {
+  console.error(error);
+});
+
+store.on('connect', (client) => {
+  console.log('connected', client);
+});
+
+store.on('reconnecting', () => {
+  console.log('reconnecting');
+});
+
+store.on('disconnect', () => {
+  console.log('disconnected');
+});
+```
+
+Replacing `store.client` removes listeners from the previous client and attaches them to the new one, so events are not duplicated or leaked.
+
 ## Expiration and TTL
 
 Keyv hands this adapter an **absolute** expiry — a Unix timestamp in milliseconds — computed once on the Keyv host. The adapter writes it with `SET ... PXAT`, the absolute-expiry option, so the deadline is immune to clock skew and to any latency between Keyv computing the expiry and Valkey receiving the command. The same applies to `setMany`, including the per-hash-slot grouping used in cluster mode.
 
-Unlike the [Redis adapter](https://github.com/jaredwray/keyv/tree/main/storage/redis#expiration-and-ttl), there is **no relative `PX` fallback** and none is needed: `PXAT` was added in Redis 6.2, and every Valkey release is forked from Redis 7.2+, so absolute expiry is always available. You always call `keyv.set(key, value, ttl)` with a relative millisecond `ttl` (or rely on the `ttl` option); the adapter converts it to the absolute `PXAT` deadline for you.
+Unlike the [Redis adapter](https://github.com/jaredwray/keyv/tree/main/storage/redis#expiration-and-ttl), there is **no relative `PX` fallback** and none is needed: `PXAT` was added in Redis 6.2, and every Valkey release is forked from Redis 7.2+, so absolute expiry is always available. You always call `keyv.set(key, value, ttl)` with a relative millisecond `ttl` (or rely on the `ttl` option); Keyv converts it to the absolute `PXAT` deadline for you.
 
 ## Clustering
 
@@ -333,14 +401,17 @@ const cluster = new Redis.Cluster([
 const store = new KeyvValkey(cluster);
 ```
 
-Batch methods (`getMany`, `setMany`, `deleteMany`, `hasMany`) automatically group keys by hash slot and run separate transactions per slot group. This avoids `CROSSSLOT` errors without any extra configuration.
+`getMany`, `setMany`, and `hasMany` automatically group keys by hash slot and run separate commands per slot group. This avoids `CROSSSLOT` errors without any extra configuration.
+
+`deleteMany` deletes each key individually, which is also cluster-safe.
 
 Single-key methods (`get`, `set`, `delete`, `has`) work automatically in cluster mode — iovalkey routes each command to the correct node.
 
 ### Cluster gotchas
 
-- **`clear()` with `useSets: false` (the default)** uses the `KEYS` command, which only scans the node that receives the command. In cluster mode this may miss keys on other nodes. Set `useSets: true` if you need reliable `clear()` across all cluster nodes.
+- **`clear()` with `useSets: false` (the default)** uses the `KEYS` command, which only scans the node that receives the command. In cluster mode this may miss keys on other nodes.
 - **`iterator()` in cluster mode** uses `SCAN`, which only iterates keys on the node the command is routed to. It may not return all keys across the cluster.
+- **`useSets: true` is not cluster-safe.** Tracking set members and data keys hash to different slots, so `SET` + `SADD` in a `MULTI` transaction (and bulk `UNLINK` of tracked keys on `clear()`) can raise `CROSSSLOT`. Prefer the default `useSets: false` on a cluster.
 
 ## License
 

--- a/storage/valkey/src/index.ts
+++ b/storage/valkey/src/index.ts
@@ -4,6 +4,7 @@ import Redis, { type Cluster } from "iovalkey";
 import Keyv, {
 	type KeyvAny,
 	type KeyvStorageAdapter,
+	type KeyvStorageCapability,
 	type KeyvStorageEntry,
 	type KeyvStorageGetResult,
 	keyvStorageCapability,
@@ -14,13 +15,18 @@ import type { KeyvUriOptions, KeyvValkeyOptions } from "./types.js";
  * Valkey storage adapter for Keyv. Supports both standalone and cluster modes
  * using iovalkey as the underlying client. Implements the {@link KeyvStorageAdapter}
  * interface with support for namespacing, TTL, batch operations, and async iteration.
+ *
+ * Client events (`error`, `connect`, `reconnecting`, `close`) are re-emitted on this
+ * adapter via Hookified. `close` is surfaced as `disconnect` to match the Keyv event name.
+ *
+ * @example
+ * ```typescript
+ * const store = new KeyvValkey("redis://localhost:6379");
+ * await store.set("greeting", "hello");
+ * console.log(await store.get("greeting")); // "hello"
+ * ```
  */
-class KeyvValkey extends Hookified implements KeyvStorageAdapter {
-	/** Declares the v6 absolute-`expires` storage contract via `capabilities.expires`. */
-	public get capabilities() {
-		return keyvStorageCapability(this);
-	}
-
+export class KeyvValkey extends Hookified implements KeyvStorageAdapter {
 	/**
 	 * The namespace used to prefix keys for multi-tenant separation.
 	 * When set, all keys are scoped under this namespace to prevent collisions
@@ -32,16 +38,16 @@ class KeyvValkey extends Hookified implements KeyvStorageAdapter {
 	/**
 	 * Whether to use Redis/Valkey sets for tracking namespaced keys.
 	 * When true, keys are tracked in a set for efficient `clear()` operations.
-	 * When false, `clear()` uses pattern-based key scanning with `KEYS` command.
+	 * When false, `clear()` uses pattern-based key scanning with the `KEYS` command.
 	 * @default false
 	 */
 	private _useSets = false;
 
 	/**
 	 * The underlying iovalkey Redis or Cluster client instance used for all
-	 * storage operations. Can be a standalone Redis connection or a Cluster instance.
-	 * Typed as `any` internally to avoid cascading type assertions from iovalkey's
-	 * return types. The public `client` getter/setter exposes the proper `Redis | Cluster` type.
+	 * storage operations. Typed as `KeyvAny` internally to avoid cascading type
+	 * assertions from iovalkey's return types. The public `client` getter/setter
+	 * exposes the proper `Redis | Cluster` type.
 	 */
 	private _client: KeyvAny;
 
@@ -52,36 +58,40 @@ class KeyvValkey extends Hookified implements KeyvStorageAdapter {
 	private _eventsWiredClient: KeyvAny;
 
 	/**
-	 * Stable reference to the `error` listener so it can be removed from a client
-	 * when the underlying client is replaced.
+	 * Stable `error` listener so it can be removed when the client is replaced.
 	 */
 	private readonly _errorHandler = (error: Error) => this.emit("error", error);
 
 	/**
-	 * Stable reference to the `connect` listener so it can be removed from a client
-	 * when the underlying client is replaced.
+	 * Stable `connect` listener so it can be removed when the client is replaced.
 	 */
 	private readonly _connectHandler = () => this.emit("connect", this._client);
 
 	/**
-	 * Stable reference to the `reconnecting` listener so it can be removed from a client
-	 * when the underlying client is replaced.
+	 * Stable `reconnecting` listener so it can be removed when the client is replaced.
 	 */
-	private readonly _reconnectingHandler = () => this.emit("reconnecting");
+	private readonly _reconnectingHandler = (...args: KeyvAny[]) => {
+		this.emit("reconnecting", ...args);
+	};
+
+	/**
+	 * Stable `close` listener, re-emitted as `disconnect` to match Keyv's event name.
+	 */
+	private readonly _closeHandler = () => this.emit("disconnect", this._client);
 
 	/**
 	 * Creates a new KeyvValkey adapter instance.
 	 *
-	 * Accepts either a connection URI string, a pre-configured iovalkey Redis/Cluster instance,
+	 * Accepts a connection URI string, a pre-configured iovalkey Redis/Cluster instance,
 	 * or a configuration object. When a URI string is provided, a new Redis connection is created.
 	 * When an existing Redis/Cluster instance is passed, it is reused directly.
 	 *
-	 * @param {KeyvValkeyOptions | KeyvUriOptions} uri - Connection URI string (e.g. `"redis://localhost:6379"`),
+	 * @param {KeyvUriOptions} uri - Connection URI string (e.g. `"redis://localhost:6379"`),
 	 *   a pre-configured iovalkey Redis/Cluster instance, or an options object.
 	 * @param {KeyvValkeyOptions} [options] - Additional adapter options such as `useSets` and `namespace`.
 	 *   Merged with options derived from `uri` when `uri` is a string or plain options object.
 	 */
-	constructor(uri: KeyvValkeyOptions | KeyvUriOptions, options?: KeyvValkeyOptions) {
+	constructor(uri: KeyvUriOptions, options?: KeyvValkeyOptions) {
 		super({ throwOnEmptyListeners: false });
 
 		if (
@@ -96,8 +106,8 @@ class KeyvValkey extends Hookified implements KeyvStorageAdapter {
 				...(typeof uri === "string" ? { uri } : (uri as KeyvValkeyOptions)),
 				...options,
 			};
-			// biome-ignore lint/style/noNonNullAssertion: need to fix
-			this._client = new Redis(options.uri!, options);
+			this._client =
+				options.uri === undefined ? new Redis(options) : new Redis(options.uri, options);
 		}
 
 		if (options !== undefined && options.useSets !== undefined) {
@@ -112,9 +122,18 @@ class KeyvValkey extends Hookified implements KeyvStorageAdapter {
 	}
 
 	/**
+	 * Declares the v6 absolute-`expires` storage contract via `capabilities.expires`.
+	 * @returns {KeyvStorageCapability} The adapter capability descriptor, including `expires: true`.
+	 */
+	public get capabilities(): KeyvStorageCapability {
+		return keyvStorageCapability(this);
+	}
+
+	/**
 	 * Gets the namespace for the adapter. When set, all keys are prefixed with
 	 * this namespace to provide multi-tenant isolation within a shared Valkey instance.
 	 * @returns {string | undefined} The current namespace, or `undefined` if no namespace is set.
+	 * @default undefined
 	 */
 	public get namespace(): string | undefined {
 		return this._namespace;
@@ -191,16 +210,13 @@ class KeyvValkey extends Hookified implements KeyvStorageAdapter {
 	 * @template Value - The type of the stored value.
 	 * @param {string} key - The key to look up.
 	 * @returns {Promise<KeyvStorageGetResult<Value>>} The stored data if found, or `undefined` if the key does not exist.
+	 *   Never returns `null`.
 	 */
 	public async get<Value>(key: string): Promise<KeyvStorageGetResult<Value>> {
 		key = this.getKeyName(key);
 
 		const value = await this._client.get(key);
-		if (value === null) {
-			return undefined;
-		}
-
-		return value;
+		return value ?? undefined;
 	}
 
 	/**
@@ -210,7 +226,7 @@ class KeyvValkey extends Hookified implements KeyvStorageAdapter {
 	 * @template Value - The type of the stored values.
 	 * @param {string[]} keys - An array of keys to look up.
 	 * @returns {Promise<Array<KeyvStorageGetResult<Value | undefined>>>} An array of stored data in the same order as the input keys.
-	 *   Each element is the stored value or `undefined` if the corresponding key does not exist.
+	 *   Each element is the stored value or `undefined` if the corresponding key does not exist. Never `null`.
 	 */
 	public async getMany<Value>(
 		keys: string[],
@@ -247,7 +263,7 @@ class KeyvValkey extends Hookified implements KeyvStorageAdapter {
 	 * When `useSets` is enabled, the key is also added to the namespace tracking set
 	 * within an atomic transaction.
 	 * @param {string} key - The key under which to store the value.
-	 * @param {any} value - The value to store. If `undefined`, the operation is a no-op.
+	 * @param {KeyvAny} value - The value to store. If `undefined`, the operation is a no-op.
 	 * @param {number} [expires] - Absolute expiry as Unix ms since epoch, or `undefined` for no expiry.
 	 *   When provided, the key is set to expire at that timestamp via `PXAT`.
 	 * @returns {Promise<boolean>} `true` if the value was stored, `false` if the value was
@@ -409,9 +425,9 @@ class KeyvValkey extends Hookified implements KeyvStorageAdapter {
 	}
 
 	/**
-	 * Deletes multiple keys from the Valkey store by deleting each key individually.
-	 * Each element in the returned array indicates whether that specific key was
-	 * successfully deleted.
+	 * Deletes multiple keys from the Valkey store. Each key is deleted individually so the
+	 * operation is cluster-safe without CROSSSLOT errors. Each element in the returned array
+	 * indicates whether that specific key was successfully deleted.
 	 * @param {string[]} keys - An array of keys to delete.
 	 * @returns {Promise<boolean[]>} An array of booleans in the same order as the input keys.
 	 *   Each element is `true` if the corresponding key existed and was deleted, `false` otherwise.
@@ -422,6 +438,17 @@ class KeyvValkey extends Hookified implements KeyvStorageAdapter {
 		}
 
 		return Promise.all(keys.map(async (key) => this.delete(key)));
+	}
+
+	/**
+	 * Checks whether a key exists in the Valkey store.
+	 * @param {string} key - The key to check for existence.
+	 * @returns {Promise<boolean>} `true` if the key exists, `false` otherwise.
+	 */
+	public async has(key: string): Promise<boolean> {
+		key = this.getKeyName(key);
+		const value: number = await this._client.exists(key);
+		return value !== 0;
 	}
 
 	/**
@@ -464,7 +491,8 @@ class KeyvValkey extends Hookified implements KeyvStorageAdapter {
 	 * When `useSets` is enabled, retrieves all tracked keys from the namespace set
 	 * and removes them along with the set itself using `UNLINK` and `SREM`.
 	 * When `useSets` is disabled, uses the `KEYS` command with a pattern match
-	 * to find and remove all keys matching the namespace prefix.
+	 * to find and remove all keys matching the namespace prefix. With no namespace
+	 * this matches every key in the current database.
 	 * @returns {Promise<void>}
 	 */
 	public async clear(): Promise<void> {
@@ -509,7 +537,7 @@ class KeyvValkey extends Hookified implements KeyvStorageAdapter {
 	 * @template Value - The type of the stored values.
 	 * @returns {AsyncGenerator<[string, Value | undefined], void, unknown>} An async generator
 	 *   yielding `[key, value]` tuples for each matching entry. The internal namespace prefix is
-	 *   stripped from each yielded key, and missing values are returned as `undefined`.
+	 *   stripped from each yielded key, and missing values are returned as `undefined` (never `null`).
 	 */
 	public async *iterator<Value>(): AsyncGenerator<[string, Value | undefined], void, unknown> {
 		const scan = this._client.scan.bind(this._client);
@@ -533,17 +561,6 @@ class KeyvValkey extends Hookified implements KeyvStorageAdapter {
 	}
 
 	/**
-	 * Checks whether a key exists in the Valkey store.
-	 * @param {string} key - The key to check for existence.
-	 * @returns {Promise<boolean>} `true` if the key exists, `false` otherwise.
-	 */
-	public async has(key: string): Promise<boolean> {
-		key = this.getKeyName(key);
-		const value: number = await this._client.exists(key);
-		return value !== 0;
-	}
-
-	/**
 	 * Disconnects the underlying iovalkey client from the Valkey server.
 	 * After calling this method, the adapter can no longer perform operations
 	 * and any subsequent calls will throw an error.
@@ -554,11 +571,12 @@ class KeyvValkey extends Hookified implements KeyvStorageAdapter {
 	}
 
 	/**
-	 * Wires the underlying iovalkey client events (`error`, `connect`, `reconnecting`) so they
-	 * are re-emitted on this adapter via Hookified. Listeners are only attached once per client
-	 * instance, so repeated calls (such as when the client is replaced) do not create duplicates.
-	 * When the client is replaced, the listeners are removed from the previous client to avoid
-	 * leaking listeners and re-emitting events from a discarded client.
+	 * Wires the underlying iovalkey client events (`error`, `connect`, `reconnecting`, `close`)
+	 * so they are re-emitted on this adapter via Hookified. `close` is re-emitted as `disconnect`.
+	 * Listeners are only attached once per client instance, so repeated calls (such as when the
+	 * client is replaced) do not create duplicates. When the client is replaced, the listeners
+	 * are removed from the previous client to avoid leaking listeners and re-emitting events from
+	 * a discarded client.
 	 * @returns {void}
 	 */
 	private initClient(): void {
@@ -570,6 +588,7 @@ class KeyvValkey extends Hookified implements KeyvStorageAdapter {
 			this._eventsWiredClient.removeListener("error", this._errorHandler);
 			this._eventsWiredClient.removeListener("connect", this._connectHandler);
 			this._eventsWiredClient.removeListener("reconnecting", this._reconnectingHandler);
+			this._eventsWiredClient.removeListener("close", this._closeHandler);
 		}
 
 		this._eventsWiredClient = this._client;
@@ -577,6 +596,7 @@ class KeyvValkey extends Hookified implements KeyvStorageAdapter {
 		this._client.on("error", this._errorHandler);
 		this._client.on("connect", this._connectHandler);
 		this._client.on("reconnecting", this._reconnectingHandler);
+		this._client.on("close", this._closeHandler);
 	}
 
 	/**
@@ -670,9 +690,9 @@ class KeyvValkey extends Hookified implements KeyvStorageAdapter {
 /**
  * Creates a new {@link Keyv} instance pre-configured with the Valkey storage adapter.
  * This is a convenience factory function that handles adapter instantiation and wiring.
- * @param {KeyvValkeyOptions | KeyvUriOptions} [connect="redis://localhost:6379"] - Connection configuration.
- *   Can be a Redis URI string (e.g. `"redis://localhost:6379"`) or an options object with
- *   connection details and adapter settings.
+ * @param {KeyvUriOptions} [connect="redis://localhost:6379"] - Connection configuration.
+ *   Can be a Redis URI string (e.g. `"redis://localhost:6379"`), an options object, or an
+ *   existing iovalkey Redis/Cluster instance.
  * @param {KeyvValkeyOptions} [options] - Additional adapter options such as `useSets` and `namespace`.
  * @returns {Keyv} A fully configured Keyv instance backed by the Valkey adapter.
  * @example
@@ -682,10 +702,7 @@ class KeyvValkey extends Hookified implements KeyvStorageAdapter {
  * console.log(await keyv.get("greeting")); // "hello"
  * ```
  */
-export function createKeyv(
-	connect?: KeyvValkeyOptions | KeyvUriOptions,
-	options?: KeyvValkeyOptions,
-): Keyv {
+export function createKeyv(connect?: KeyvUriOptions, options?: KeyvValkeyOptions): Keyv {
 	connect ??= "redis://localhost:6379";
 	const adapter = new KeyvValkey(connect, options);
 	// Use the adapter's resolved namespace so it is preserved whether the namespace
@@ -695,4 +712,4 @@ export function createKeyv(
 }
 
 export default KeyvValkey;
-export type { KeyvValkeyOptions } from "./types.js";
+export type { KeyvUriOptions, KeyvValkeyOptions } from "./types.js";

--- a/storage/valkey/src/types.ts
+++ b/storage/valkey/src/types.ts
@@ -1,12 +1,30 @@
 import type { Cluster, Redis, RedisOptions } from "iovalkey";
 
+/**
+ * Configuration options for the {@link KeyvValkey} adapter. Extends iovalkey
+ * {@link RedisOptions} so any client connection setting can be passed through.
+ */
 export type KeyvValkeyOptions = RedisOptions & {
-	/** Valkey connection URI such as `redis://localhost:6379`. */
+	/**
+	 * Valkey connection URI such as `redis://localhost:6379` or `valkey://localhost:6379`.
+	 * @default undefined
+	 */
 	uri?: string;
-	/** Whether to use Valkey sets for namespace key tracking. @default false */
+	/**
+	 * Whether to use Valkey sets for namespace key tracking. When `true`, a set is
+	 * maintained per namespace so `clear()` can remove keys without scanning.
+	 * @default false
+	 */
 	useSets?: boolean;
-	/** Namespace used to prefix keys for multi-tenant isolation. @default undefined */
+	/**
+	 * Namespace used to prefix keys for multi-tenant isolation.
+	 * @default undefined
+	 */
 	namespace?: string;
 };
 
+/**
+ * Values accepted as the first argument to the {@link KeyvValkey} constructor:
+ * a connection URI string, an options object, or an existing iovalkey `Redis` / `Cluster` instance.
+ */
 export type KeyvUriOptions = string | KeyvValkeyOptions | Redis | Cluster;

--- a/storage/valkey/test/cluster.test.ts
+++ b/storage/valkey/test/cluster.test.ts
@@ -20,7 +20,7 @@ async function createReadyCluster(): Promise<Cluster> {
 describe("cluster", () => {
 	test("should setMany without CROSSSLOT errors", { retry: 3 }, async () => {
 		const cluster = await createReadyCluster();
-		const keyv = new KeyvValkey(cluster);
+		const store = new KeyvValkey(cluster);
 
 		const key1 = faker.string.alphanumeric(10);
 		const key2 = faker.string.alphanumeric(10);
@@ -31,21 +31,21 @@ describe("cluster", () => {
 		const val3 = faker.string.alphanumeric(10);
 		const val4 = faker.string.alphanumeric(10);
 
-		await keyv.setMany([
+		await store.setMany([
 			{ key: key1, value: val1 },
 			{ key: key2, value: val2 },
 			{ key: key3, value: val3 },
 			{ key: key4, value: val4 },
 		]);
 
-		expect(await keyv.getMany([key1, key2, key3, key4])).toEqual([val1, val2, val3, val4]);
+		expect(await store.getMany([key1, key2, key3, key4])).toEqual([val1, val2, val3, val4]);
 
-		await keyv.disconnect();
+		await store.disconnect();
 	});
 
 	test("should getMany without CROSSSLOT errors", { retry: 3 }, async () => {
 		const cluster = await createReadyCluster();
-		const keyv = new KeyvValkey(cluster);
+		const store = new KeyvValkey(cluster);
 
 		const key1 = faker.string.alphanumeric(10);
 		const key2 = faker.string.alphanumeric(10);
@@ -54,18 +54,20 @@ describe("cluster", () => {
 		const val2 = faker.string.alphanumeric(10);
 		const val3 = faker.string.alphanumeric(10);
 
-		await keyv.set(key1, val1);
-		await keyv.set(key2, val2);
-		await keyv.set(key3, val3);
+		await store.set(key1, val1);
+		await store.set(key2, val2);
+		await store.set(key3, val3);
 
-		expect(await keyv.getMany([key1, key2, key3])).toEqual([val1, val2, val3]);
+		const values = await store.getMany([key1, key2, key3]);
+		expect(values).toEqual([val1, val2, val3]);
+		expect(values.every((value) => value !== null)).toBe(true);
 
-		await keyv.disconnect();
+		await store.disconnect();
 	});
 
 	test("should deleteMany without CROSSSLOT errors", { retry: 3 }, async () => {
 		const cluster = await createReadyCluster();
-		const keyv = new KeyvValkey(cluster);
+		const store = new KeyvValkey(cluster);
 
 		const key1 = faker.string.alphanumeric(10);
 		const key2 = faker.string.alphanumeric(10);
@@ -74,21 +76,21 @@ describe("cluster", () => {
 		const val2 = faker.string.alphanumeric(10);
 		const val3 = faker.string.alphanumeric(10);
 
-		await keyv.set(key1, val1);
-		await keyv.set(key2, val2);
-		await keyv.set(key3, val3);
+		await store.set(key1, val1);
+		await store.set(key2, val2);
+		await store.set(key3, val3);
 
-		expect(await keyv.deleteMany([key1, key2, key3])).toEqual([true, true, true]);
-		expect(await keyv.get(key1)).toBe(undefined);
-		expect(await keyv.get(key2)).toBe(undefined);
-		expect(await keyv.get(key3)).toBe(undefined);
+		expect(await store.deleteMany([key1, key2, key3])).toEqual([true, true, true]);
+		expect(await store.get(key1)).toBeUndefined();
+		expect(await store.get(key2)).toBeUndefined();
+		expect(await store.get(key3)).toBeUndefined();
 
-		await keyv.disconnect();
+		await store.disconnect();
 	});
 
 	test("should hasMany without CROSSSLOT errors", { retry: 3 }, async () => {
 		const cluster = await createReadyCluster();
-		const keyv = new KeyvValkey(cluster);
+		const store = new KeyvValkey(cluster);
 
 		const key1 = faker.string.alphanumeric(10);
 		const key2 = faker.string.alphanumeric(10);
@@ -96,11 +98,11 @@ describe("cluster", () => {
 		const val1 = faker.string.alphanumeric(10);
 		const val2 = faker.string.alphanumeric(10);
 
-		await keyv.set(key1, val1);
-		await keyv.set(key2, val2);
+		await store.set(key1, val1);
+		await store.set(key2, val2);
 
-		expect(await keyv.hasMany([key1, key2, key3])).toEqual([true, true, false]);
+		expect(await store.hasMany([key1, key2, key3])).toEqual([true, true, false]);
 
-		await keyv.disconnect();
+		await store.disconnect();
 	});
 });

--- a/storage/valkey/test/delete.test.ts
+++ b/storage/valkey/test/delete.test.ts
@@ -8,77 +8,77 @@ const valkeyUri = process.env.VALKEY_URI ?? "redis://localhost:6370";
 
 describe("delete", () => {
 	test("should delete a value when useSets is false", async () => {
-		const keyv = new KeyvValkey(new Redis(valkeyUri), { useSets: false });
+		const store = new KeyvValkey(new Redis(valkeyUri), { useSets: false });
 		const key = faker.string.alphanumeric(10);
 		const value = faker.string.alphanumeric(10);
-		await keyv.set(key, value);
-		await keyv.delete(key);
-		expect(await keyv.get(key)).toBe(undefined);
-		await keyv.disconnect();
+		await store.set(key, value);
+		await store.delete(key);
+		expect(await store.get(key)).toBeUndefined();
+		await store.disconnect();
 	});
 
 	test("should delete a value and report success when useSets is true", async () => {
-		const keyv = new KeyvValkey(new Redis(valkeyUri), { useSets: true });
-		keyv.namespace = `del-sets-${faker.string.alphanumeric(8)}`;
+		const store = new KeyvValkey(new Redis(valkeyUri), { useSets: true });
+		store.namespace = faker.string.alphanumeric(8);
 		const key = faker.string.alphanumeric(10);
 		const value = faker.string.alphanumeric(10);
-		await keyv.set(key, value);
-		expect(await keyv.get(key)).toBe(value);
+		await store.set(key, value);
+		expect(await store.get(key)).toBe(value);
 
-		expect(await keyv.delete(key)).toBe(true);
-		expect(await keyv.get(key)).toBe(undefined);
-		await keyv.disconnect();
+		expect(await store.delete(key)).toBe(true);
+		expect(await store.get(key)).toBeUndefined();
+		await store.disconnect();
 	});
 
 	test("should return false when deleting a key that does not exist", async () => {
-		const keyv = new KeyvValkey(new Redis(valkeyUri), { useSets: true });
-		keyv.namespace = `del-missing-${faker.string.alphanumeric(8)}`;
-		expect(await keyv.delete(faker.string.alphanumeric(10))).toBe(false);
-		await keyv.disconnect();
+		const store = new KeyvValkey(new Redis(valkeyUri), { useSets: true });
+		store.namespace = faker.string.alphanumeric(8);
+		expect(await store.delete(faker.string.alphanumeric(10))).toBe(false);
+		await store.disconnect();
 	});
 });
 
 describe("deleteMany", () => {
-	test("should batch delete keys", async () => {
-		const keyv = new KeyvValkey(valkeyUri);
+	test("should delete multiple keys", async () => {
+		const store = new KeyvValkey(valkeyUri);
 		const key1 = faker.string.alphanumeric(10);
 		const key2 = faker.string.alphanumeric(10);
 		const val1 = faker.string.alphanumeric(10);
 		const val2 = faker.string.alphanumeric(10);
-		await keyv.set(key1, val1);
-		await keyv.set(key2, val2);
-		expect(await keyv.deleteMany([key1, key2])).toEqual([true, true]);
-		expect(await keyv.get(key1)).toBe(undefined);
-		expect(await keyv.get(key2)).toBe(undefined);
-		await keyv.disconnect();
+		await store.set(key1, val1);
+		await store.set(key2, val2);
+		expect(await store.deleteMany([key1, key2])).toEqual([true, true]);
+		expect(await store.get(key1)).toBeUndefined();
+		expect(await store.get(key2)).toBeUndefined();
+		await store.disconnect();
 	});
 
 	test("should return false for keys that do not exist", async () => {
-		const keyv = new KeyvValkey(valkeyUri);
+		const store = new KeyvValkey(valkeyUri);
 		const key1 = faker.string.alphanumeric(10);
 		const key2 = faker.string.alphanumeric(10);
-		expect(await keyv.deleteMany([key1, key2])).toEqual([false, false]);
-		await keyv.disconnect();
+		expect(await store.deleteMany([key1, key2])).toEqual([false, false]);
+		await store.disconnect();
 	});
 
 	test("should return an empty array for an empty input", async () => {
-		const keyv = new KeyvValkey(valkeyUri);
-		expect(await keyv.deleteMany([])).toEqual([]);
-		await keyv.disconnect();
+		const store = new KeyvValkey(valkeyUri);
+		expect(await store.deleteMany([])).toEqual([]);
+		await store.disconnect();
 	});
 
 	test("should remove keys from the tracking set when useSets is true", async () => {
-		const keyv = new KeyvValkey(valkeyUri, { useSets: true });
-		keyv.namespace = `delmany-${faker.string.alphanumeric(8)}`;
+		const store = new KeyvValkey(valkeyUri, { useSets: true });
+		store.namespace = faker.string.alphanumeric(8);
 		const key1 = faker.string.alphanumeric(10);
 		const key2 = faker.string.alphanumeric(10);
 		const val1 = faker.string.alphanumeric(10);
 		const val2 = faker.string.alphanumeric(10);
-		await keyv.set(key1, val1);
-		await keyv.set(key2, val2);
-		await keyv.deleteMany([key1, key2]);
-		expect(await keyv.get(key1)).toBe(undefined);
-		expect(await keyv.get(key2)).toBe(undefined);
-		await keyv.disconnect();
+		await store.set(key1, val1);
+		await store.set(key2, val2);
+		await store.deleteMany([key1, key2]);
+		expect(await store.get(key1)).toBeUndefined();
+		expect(await store.get(key2)).toBeUndefined();
+		await store.disconnect();
 	});
 });

--- a/storage/valkey/test/events.test.ts
+++ b/storage/valkey/test/events.test.ts
@@ -1,5 +1,6 @@
 import process from "node:process";
 import { faker } from "@faker-js/faker";
+import { Hookified } from "hookified";
 import Redis from "iovalkey";
 import { describe, expect, test } from "vitest";
 import KeyvValkey from "../src/index.js";
@@ -7,91 +8,122 @@ import KeyvValkey from "../src/index.js";
 const valkeyUri = process.env.VALKEY_URI ?? "redis://localhost:6370";
 
 describe("events", () => {
-	test("should expose the hookified event methods", () => {
-		const keyv = new KeyvValkey(valkeyUri);
-		expect(typeof keyv.on).toBe("function");
-		expect(typeof keyv.once).toBe("function");
-		expect(typeof keyv.emit).toBe("function");
+	test("should extend Hookified", async () => {
+		const store = new KeyvValkey(valkeyUri);
+		expect(store).toBeInstanceOf(Hookified);
+		await store.disconnect();
+	});
+
+	test("should expose the hookified event methods", async () => {
+		const store = new KeyvValkey(valkeyUri);
+		expect(typeof store.on).toBe("function");
+		expect(typeof store.once).toBe("function");
+		expect(typeof store.emit).toBe("function");
+		expect(typeof store.off).toBe("function");
+		await store.disconnect();
 	});
 
 	test("should re-emit the client error event on the adapter", async () => {
-		const keyv = new KeyvValkey(valkeyUri);
+		const store = new KeyvValkey(valkeyUri);
 		const error = new Error(faker.lorem.sentence());
 		let received: Error | undefined;
-		keyv.on("error", (emitted) => {
+		store.on("error", (emitted) => {
 			received = emitted as Error;
 		});
 
-		keyv.client.emit("error", error);
+		store.client.emit("error", error);
 
 		expect(received).toBe(error);
-		await keyv.disconnect();
+		await store.disconnect();
 	});
 
 	test("should re-emit the client connect event on the adapter", async () => {
-		const keyv = new KeyvValkey(valkeyUri);
+		const store = new KeyvValkey(valkeyUri);
 		let received: unknown;
-		keyv.on("connect", (client) => {
+		store.on("connect", (client) => {
 			received = client;
 		});
 
-		keyv.client.emit("connect");
+		store.client.emit("connect");
 
-		expect(received).toBe(keyv.client);
-		await keyv.disconnect();
+		expect(received).toBe(store.client);
+		await store.disconnect();
 	});
 
 	test("should re-emit the client reconnecting event on the adapter", async () => {
-		const keyv = new KeyvValkey(valkeyUri);
+		const store = new KeyvValkey(valkeyUri);
 		let received = false;
-		keyv.on("reconnecting", () => {
+		store.on("reconnecting", () => {
 			received = true;
 		});
 
-		keyv.client.emit("reconnecting");
+		store.client.emit("reconnecting");
 
 		expect(received).toBe(true);
-		await keyv.disconnect();
+		await store.disconnect();
 	});
 
-	test("should wire a single error listener on the client", async () => {
-		const keyv = new KeyvValkey(valkeyUri);
-		expect(keyv.client.listenerCount("error")).toBe(1);
-		await keyv.disconnect();
+	test("should re-emit the client close event as disconnect", async () => {
+		const store = new KeyvValkey(valkeyUri);
+		let received: unknown;
+		store.on("disconnect", (client) => {
+			received = client;
+		});
+
+		store.client.emit("close");
+
+		expect(received).toBe(store.client);
+		await store.disconnect();
 	});
 
-	test("should re-wire the error listener when the client is replaced", async () => {
-		const keyv = new KeyvValkey(valkeyUri);
-		const oldClient = keyv.client;
+	test("should wire a single listener per client event", async () => {
+		const store = new KeyvValkey(valkeyUri);
+		expect(store.client.listenerCount("error")).toBe(1);
+		expect(store.client.listenerCount("connect")).toBe(1);
+		expect(store.client.listenerCount("reconnecting")).toBe(1);
+		expect(store.client.listenerCount("close")).toBeGreaterThanOrEqual(1);
+		await store.disconnect();
+	});
+
+	test("should re-wire listeners when the client is replaced", async () => {
+		const store = new KeyvValkey(valkeyUri);
+		const oldClient = store.client;
 		const newClient = new Redis(valkeyUri);
-		keyv.client = newClient;
+		store.client = newClient;
 
 		const error = new Error(faker.lorem.sentence());
 		let received: Error | undefined;
-		keyv.on("error", (emitted) => {
+		let disconnectedFromOld = false;
+		store.on("error", (emitted) => {
 			received = emitted as Error;
+		});
+		store.on("disconnect", () => {
+			disconnectedFromOld = true;
 		});
 
 		newClient.emit("error", error);
+		oldClient.emit("close");
 
 		expect(received).toBe(error);
+		expect(disconnectedFromOld).toBe(false);
 		expect(newClient.listenerCount("error")).toBe(1);
-		// The old client's listener must be removed so it no longer drives the adapter.
 		expect(oldClient.listenerCount("error")).toBe(0);
 		await oldClient.disconnect();
-		await keyv.disconnect();
+		await store.disconnect();
 	});
 
 	test("should not attach duplicate listeners when the same client is reused", async () => {
 		const client = new Redis(valkeyUri);
-		const keyv = new KeyvValkey(client);
+		const store = new KeyvValkey(client);
 		const errorCount = client.listenerCount("error");
 		const connectCount = client.listenerCount("connect");
+		const closeCount = client.listenerCount("close");
 
-		keyv.client = client;
+		store.client = client;
 
 		expect(client.listenerCount("error")).toBe(errorCount);
 		expect(client.listenerCount("connect")).toBe(connectCount);
-		await keyv.disconnect();
+		expect(client.listenerCount("close")).toBe(closeCount);
+		await store.disconnect();
 	});
 });

--- a/storage/valkey/test/get.test.ts
+++ b/storage/valkey/test/get.test.ts
@@ -7,64 +7,67 @@ const valkeyUri = process.env.VALKEY_URI ?? "redis://localhost:6370";
 
 describe("get", () => {
 	test("should get a value that exists", async () => {
-		const keyv = new KeyvValkey(valkeyUri);
+		const store = new KeyvValkey(valkeyUri);
 		const key = faker.string.alphanumeric(10);
 		const value = faker.string.alphanumeric(10);
-		await keyv.set(key, value);
-		expect(await keyv.get(key)).toBe(value);
-		await keyv.disconnect();
+		await store.set(key, value);
+		expect(await store.get(key)).toBe(value);
+		await store.disconnect();
 	});
 
 	test("should return undefined for a key that does not exist", async () => {
-		const keyv = new KeyvValkey(valkeyUri);
-		const result = await keyv.get(faker.string.alphanumeric(10));
-		expect(result).toBe(undefined);
-		await keyv.disconnect();
+		const store = new KeyvValkey(valkeyUri);
+		const result = await store.get(faker.string.alphanumeric(10));
+		expect(result).toBeUndefined();
+		expect(result).not.toBeNull();
+		await store.disconnect();
 	});
 
 	test("should get many values", async () => {
-		const keyv = new KeyvValkey(valkeyUri);
+		const store = new KeyvValkey(valkeyUri);
 		const key1 = faker.string.alphanumeric(10);
 		const key2 = faker.string.alphanumeric(10);
 		const key3 = faker.string.alphanumeric(10);
 		const val1 = faker.string.alphanumeric(10);
 		const val2 = faker.string.alphanumeric(10);
 		const val3 = faker.string.alphanumeric(10);
-		await keyv.setMany([
+		await store.setMany([
 			{ key: key1, value: val1 },
 			{ key: key2, value: val2 },
 			{ key: key3, value: val3 },
 		]);
-		const values = await keyv.getMany([key1, key2, key3]);
+		const values = await store.getMany([key1, key2, key3]);
 		expect(values).toEqual([val1, val2, val3]);
-		await keyv.disconnect();
+		await store.disconnect();
 	});
 
 	test("should return undefined for missing keys in getMany", async () => {
-		const keyv = new KeyvValkey(valkeyUri);
+		const store = new KeyvValkey(valkeyUri);
 		const key1 = faker.string.alphanumeric(10);
 		const val1 = faker.string.alphanumeric(10);
 		const missing = faker.string.alphanumeric(10);
-		await keyv.set(key1, val1);
-		const values = await keyv.getMany([key1, missing]);
+		await store.set(key1, val1);
+		const values = await store.getMany([key1, missing]);
 		expect(values[0]).toBe(val1);
-		expect(values[1]).toBe(undefined);
-		await keyv.disconnect();
+		expect(values[1]).toBeUndefined();
+		expect(values[1]).not.toBeNull();
+		await store.disconnect();
 	});
 
 	test("should return all undefined when no keys exist in getMany", async () => {
-		const keyv = new KeyvValkey(valkeyUri);
-		const values = await keyv.getMany([
+		const store = new KeyvValkey(valkeyUri);
+		const values = await store.getMany([
 			faker.string.alphanumeric(10),
 			faker.string.alphanumeric(10),
 		]);
 		expect(values).toEqual([undefined, undefined]);
-		await keyv.disconnect();
+		expect(values.every((value) => value !== null)).toBe(true);
+		await store.disconnect();
 	});
 
 	test("should return an empty array for getMany with an empty input", async () => {
-		const keyv = new KeyvValkey(valkeyUri);
-		expect(await keyv.getMany([])).toEqual([]);
-		await keyv.disconnect();
+		const store = new KeyvValkey(valkeyUri);
+		expect(await store.getMany([])).toEqual([]);
+		await store.disconnect();
 	});
 });

--- a/storage/valkey/test/has.test.ts
+++ b/storage/valkey/test/has.test.ts
@@ -7,46 +7,46 @@ const valkeyUri = process.env.VALKEY_URI ?? "redis://localhost:6370";
 
 describe("has", () => {
 	test("should return true for an existing key", async () => {
-		const keyv = new KeyvValkey(valkeyUri);
+		const store = new KeyvValkey(valkeyUri);
 		const key = faker.string.alphanumeric(10);
-		await keyv.set(key, faker.string.alphanumeric(10));
-		expect(await keyv.has(key)).toBe(true);
-		await keyv.delete(key);
-		await keyv.disconnect();
+		await store.set(key, faker.string.alphanumeric(10));
+		expect(await store.has(key)).toBe(true);
+		await store.delete(key);
+		await store.disconnect();
 	});
 
 	test("should return false for a key that does not exist", async () => {
-		const keyv = new KeyvValkey(valkeyUri);
-		expect(await keyv.has(faker.string.alphanumeric(10))).toBe(false);
-		await keyv.disconnect();
+		const store = new KeyvValkey(valkeyUri);
+		expect(await store.has(faker.string.alphanumeric(10))).toBe(false);
+		await store.disconnect();
 	});
 
 	test("should return false after a key is deleted", async () => {
-		const keyv = new KeyvValkey(valkeyUri);
+		const store = new KeyvValkey(valkeyUri);
 		const key = faker.string.alphanumeric(10);
-		await keyv.set(key, faker.string.alphanumeric(10));
-		expect(await keyv.has(key)).toBe(true);
-		await keyv.delete(key);
-		expect(await keyv.has(key)).toBe(false);
-		await keyv.disconnect();
+		await store.set(key, faker.string.alphanumeric(10));
+		expect(await store.has(key)).toBe(true);
+		await store.delete(key);
+		expect(await store.has(key)).toBe(false);
+		await store.disconnect();
 	});
 });
 
 describe("hasMany", () => {
 	test("should return an array of booleans", async () => {
-		const keyv = new KeyvValkey(valkeyUri);
+		const store = new KeyvValkey(valkeyUri);
 		const key1 = faker.string.alphanumeric(10);
 		const key2 = faker.string.alphanumeric(10);
 		const key3 = faker.string.alphanumeric(10);
-		await keyv.set(key1, faker.string.alphanumeric(10));
-		await keyv.set(key2, faker.string.alphanumeric(10));
-		expect(await keyv.hasMany([key1, key2, key3])).toEqual([true, true, false]);
-		await keyv.disconnect();
+		await store.set(key1, faker.string.alphanumeric(10));
+		await store.set(key2, faker.string.alphanumeric(10));
+		expect(await store.hasMany([key1, key2, key3])).toEqual([true, true, false]);
+		await store.disconnect();
 	});
 
 	test("should return an empty array for an empty input", async () => {
-		const keyv = new KeyvValkey(valkeyUri);
-		expect(await keyv.hasMany([])).toEqual([]);
-		await keyv.disconnect();
+		const store = new KeyvValkey(valkeyUri);
+		expect(await store.hasMany([])).toEqual([]);
+		await store.disconnect();
 	});
 });

--- a/storage/valkey/test/iterator.test.ts
+++ b/storage/valkey/test/iterator.test.ts
@@ -7,7 +7,7 @@ const valkeyUri = process.env.VALKEY_URI ?? "redis://localhost:6370";
 
 describe("iterator", () => {
 	test("should iterate over entries within the namespace without passing one in", async () => {
-		const namespace = `iterator-${faker.string.alphanumeric(8)}`;
+		const namespace = faker.string.alphanumeric(8);
 		const store = new KeyvValkey(valkeyUri, { namespace });
 		await store.clear();
 
@@ -21,6 +21,7 @@ describe("iterator", () => {
 
 		const collected = new Map<string, string>();
 		for await (const [key, value] of store.iterator()) {
+			expect(value).not.toBeNull();
 			collected.set(key, value as string);
 		}
 
@@ -34,7 +35,7 @@ describe("iterator", () => {
 	});
 
 	test("should iterate over entries when useSets is true", async () => {
-		const namespace = `iter-sets-${faker.string.alphanumeric(8)}`;
+		const namespace = faker.string.alphanumeric(8);
 		const store = new KeyvValkey(valkeyUri, { useSets: true, namespace });
 		await store.clear();
 
@@ -45,6 +46,7 @@ describe("iterator", () => {
 
 		const collected = new Map<string, string>();
 		for await (const [key, value] of store.iterator()) {
+			expect(value).not.toBeNull();
 			collected.set(key, value as string);
 		}
 
@@ -54,11 +56,12 @@ describe("iterator", () => {
 	});
 
 	test("should yield undefined when the namespace is empty", async () => {
-		const namespace = `iter-empty-${faker.string.alphanumeric(8)}`;
+		const namespace = faker.string.alphanumeric(8);
 		const store = new KeyvValkey(valkeyUri, { namespace });
 		await store.clear();
 		const first = await store.iterator().next();
-		expect(first.value).toBe(undefined);
+		expect(first.value).toBeUndefined();
+		expect(first.value).not.toBeNull();
 		await store.disconnect();
 	});
 
@@ -66,6 +69,10 @@ describe("iterator", () => {
 		const store = new KeyvValkey(valkeyUri);
 		const result = await store.iterator().next();
 		expect(result.done === true || Array.isArray(result.value)).toBe(true);
+		if (Array.isArray(result.value)) {
+			expect(result.value[1]).not.toBeNull();
+		}
+
 		await store.disconnect();
 	});
 });

--- a/storage/valkey/test/main.test.ts
+++ b/storage/valkey/test/main.test.ts
@@ -2,7 +2,7 @@ import process from "node:process";
 import { faker } from "@faker-js/faker";
 import Redis, { type Cluster } from "iovalkey";
 import { describe, expect, test } from "vitest";
-import KeyvValkey, { createKeyv } from "../src/index.js";
+import KeyvValkey, { createKeyv, KeyvValkey as NamedKeyvValkey } from "../src/index.js";
 
 const valkeyUri = process.env.VALKEY_URI ?? "redis://localhost:6370";
 
@@ -11,82 +11,104 @@ describe("KeyvValkey", () => {
 		expect(KeyvValkey).toBeInstanceOf(Function);
 	});
 
-	test("should expose the client instance", () => {
-		const keyv = new KeyvValkey(valkeyUri);
-		expect(keyv.client).toBeInstanceOf(Redis);
+	test("should be available as a named export", () => {
+		expect(NamedKeyvValkey).toBe(KeyvValkey);
+	});
+
+	test("should declare expires capability", async () => {
+		const store = new KeyvValkey(valkeyUri);
+		expect(store.capabilities.expires).toBe(true);
+		await store.disconnect();
+	});
+
+	test("should expose the client instance", async () => {
+		const store = new KeyvValkey(valkeyUri);
+		expect(store.client).toBeInstanceOf(Redis);
+		await store.disconnect();
 	});
 
 	test("should reuse an existing valkey instance", async () => {
 		const redis = new Redis(valkeyUri);
+		const marker = faker.string.alphanumeric(10);
 		// @ts-expect-error foo doesn't exist on Redis
-		redis.foo = "bar";
-		const keyv = new KeyvValkey(redis);
-		expect(keyv.client.foo).toBe("bar");
+		redis.foo = marker;
+		const store = new KeyvValkey(redis);
+		expect(store.client.foo).toBe(marker);
 
 		const key = faker.string.alphanumeric(10);
 		const value = faker.string.alphanumeric(10);
-		await keyv.set(key, value);
-		expect(await keyv.get(key)).toBe(value);
-		await keyv.disconnect();
+		await store.set(key, value);
+		expect(await store.get(key)).toBe(value);
+		await store.disconnect();
 	});
 
-	test("should handle options without a uri", () => {
+	test("should handle options without a uri", async () => {
 		const options = { isCluster: true };
-		const keyv = new KeyvValkey(options as Cluster);
-		expect(keyv.client).toBeInstanceOf(Redis);
+		const store = new KeyvValkey(options as Cluster);
+		expect(store.client).toBeInstanceOf(Redis);
+		await store.disconnect();
 	});
 
-	test("should handle options with a family option", () => {
+	test("should handle options with a family option", async () => {
 		const options = { options: {}, family: 4 };
-		const keyv = new KeyvValkey(options);
-		expect(keyv.client).toBeInstanceOf(Redis);
+		const store = new KeyvValkey(options);
+		expect(store.client).toBeInstanceOf(Redis);
+		await store.disconnect();
 	});
 
-	test("should handle RedisOptions", () => {
-		const options = { db: 2, connectionName: "name" };
-		const keyv = new KeyvValkey(options);
-		expect(keyv.client).toBeInstanceOf(Redis);
+	test("should handle RedisOptions", async () => {
+		const options = { db: 2, connectionName: faker.string.alphanumeric(8) };
+		const store = new KeyvValkey(options);
+		expect(store.client).toBeInstanceOf(Redis);
+		await store.disconnect();
 	});
 
-	test("should apply useSets from options when passing in a client", () => {
+	test("should apply useSets from options when passing in a client", async () => {
 		const redis = new Redis(valkeyUri);
-		const keyv = new KeyvValkey(redis, { useSets: false });
-		expect(keyv.useSets).toBe(false);
+		const store = new KeyvValkey(redis, { useSets: false });
+		expect(store.useSets).toBe(false);
+		await store.disconnect();
 	});
 
-	test("should default useSets to false", () => {
-		const keyv = new KeyvValkey(valkeyUri);
-		expect(keyv.useSets).toBe(false);
+	test("should default useSets to false", async () => {
+		const store = new KeyvValkey(valkeyUri);
+		expect(store.useSets).toBe(false);
+		await store.disconnect();
 	});
 
-	test("should get and set useSets via the setter", () => {
-		const keyv = new KeyvValkey(valkeyUri);
-		expect(keyv.useSets).toBe(false);
-		keyv.useSets = true;
-		expect(keyv.useSets).toBe(true);
+	test("should get and set useSets via the setter", async () => {
+		const store = new KeyvValkey(valkeyUri);
+		expect(store.useSets).toBe(false);
+		store.useSets = true;
+		expect(store.useSets).toBe(true);
+		await store.disconnect();
 	});
 
-	test("should support the deprecated useRedisSets getter and setter", () => {
-		const keyv = new KeyvValkey(valkeyUri);
-		expect(keyv.useRedisSets).toBe(false);
-		keyv.useRedisSets = true;
-		expect(keyv.useRedisSets).toBe(true);
-		expect(keyv.useSets).toBe(true);
+	test("should support the deprecated useRedisSets getter and setter", async () => {
+		const store = new KeyvValkey(valkeyUri);
+		expect(store.useRedisSets).toBe(false);
+		store.useRedisSets = true;
+		expect(store.useRedisSets).toBe(true);
+		expect(store.useSets).toBe(true);
+		await store.disconnect();
 	});
 
-	test("should replace the client via the setter", () => {
-		const keyv = new KeyvValkey(valkeyUri);
+	test("should replace the client via the setter", async () => {
+		const store = new KeyvValkey(valkeyUri);
+		const previous = store.client;
 		const newClient = new Redis(valkeyUri);
-		keyv.client = newClient;
-		expect(keyv.client).toBe(newClient);
+		store.client = newClient;
+		expect(store.client).toBe(newClient);
+		await previous.disconnect();
+		await store.disconnect();
 	});
 
 	test("should close the connection on disconnect", async () => {
-		const keyv = new KeyvValkey(valkeyUri);
+		const store = new KeyvValkey(valkeyUri);
 		const key = faker.string.alphanumeric(10);
-		expect(await keyv.get(key)).toBe(undefined);
-		await keyv.disconnect();
-		await expect(keyv.get(key)).rejects.toThrow();
+		expect(await store.get(key)).toBe(undefined);
+		await store.disconnect();
+		await expect(store.get(key)).rejects.toThrow();
 	});
 });
 
@@ -108,7 +130,7 @@ describe("createKeyv", () => {
 	});
 
 	test("should propagate the namespace option to the store", async () => {
-		const namespace = `ck-${faker.string.alphanumeric(8)}`;
+		const namespace = faker.string.alphanumeric(8);
 		const keyv = createKeyv(valkeyUri, { namespace });
 		expect(keyv.namespace).toBe(namespace);
 		expect(keyv.store.namespace).toBe(namespace);
@@ -116,12 +138,11 @@ describe("createKeyv", () => {
 	});
 
 	test("should preserve the namespace from the connect options object", async () => {
-		const namespace = `ck-obj-${faker.string.alphanumeric(8)}`;
+		const namespace = faker.string.alphanumeric(8);
 		const keyv = createKeyv({ uri: valkeyUri, namespace });
 		expect(keyv.namespace).toBe(namespace);
 		expect(keyv.store.namespace).toBe(namespace);
 
-		// Keys are stored under the namespace prefix natively, not un-namespaced.
 		const key = faker.string.alphanumeric(10);
 		const value = faker.string.alphanumeric(10);
 		await keyv.set(key, value);

--- a/storage/valkey/test/namespace.test.ts
+++ b/storage/valkey/test/namespace.test.ts
@@ -9,41 +9,44 @@ import KeyvValkey from "../src/index.js";
 const valkeyUri = process.env.VALKEY_URI ?? "redis://localhost:6370";
 
 describe("namespace", () => {
-	test("should default the namespace to undefined", () => {
-		const keyv = new KeyvValkey(valkeyUri);
-		expect(keyv.namespace).toBeUndefined();
+	test("should default the namespace to undefined", async () => {
+		const store = new KeyvValkey(valkeyUri);
+		expect(store.namespace).toBeUndefined();
+		await store.disconnect();
 	});
 
-	test("should get and set the namespace via the setter", () => {
-		const keyv = new KeyvValkey(valkeyUri);
-		keyv.namespace = "test-ns";
-		expect(keyv.namespace).toBe("test-ns");
+	test("should get and set the namespace via the setter", async () => {
+		const store = new KeyvValkey(valkeyUri);
+		const namespace = faker.string.alphanumeric(8);
+		store.namespace = namespace;
+		expect(store.namespace).toBe(namespace);
+		await store.disconnect();
 	});
 
 	test("should apply the namespace option natively from the constructor", async () => {
-		const namespace = `ctor-${faker.string.alphanumeric(8)}`;
-		const keyv = new KeyvValkey(valkeyUri, { namespace });
-		expect(keyv.namespace).toBe(namespace);
+		const namespace = faker.string.alphanumeric(8);
+		const store = new KeyvValkey(valkeyUri, { namespace });
+		expect(store.namespace).toBe(namespace);
 
 		const key = faker.string.alphanumeric(10);
 		const value = faker.string.alphanumeric(10);
-		await keyv.set(key, value);
-		expect(await keyv.get(key)).toBe(value);
+		await store.set(key, value);
+		expect(await store.get(key)).toBe(value);
 
-		// The key is stored natively under the namespace prefix.
 		const client = new Redis(valkeyUri);
 		expect(await client.get(`namespace:${namespace}:${key}`)).toBe(value);
 		await client.disconnect();
 
-		await keyv.clear();
-		await keyv.disconnect();
+		await store.clear();
+		await store.disconnect();
 	});
 
 	test("should clear only the keys within the namespace", async () => {
 		const namespace = faker.string.alphanumeric(8);
 		const keyv = new Keyv(new KeyvValkey(valkeyUri), { namespace });
 		const key = faker.string.alphanumeric(10);
-		await keyv.set(key, "value", 1);
+		const value = faker.string.alphanumeric(10);
+		await keyv.set(key, value, 1);
 		await delay(250);
 		await keyv.clear();
 		await keyv.disconnect();
@@ -56,129 +59,131 @@ describe("namespace", () => {
 
 describe("clear", () => {
 	test("should not error when there are no keys to clear", async () => {
-		const keyv = new KeyvValkey(valkeyUri);
-		expect(await keyv.clear()).toBeUndefined();
-		await keyv.disconnect();
+		const store = new KeyvValkey(valkeyUri);
+		expect(await store.clear()).toBeUndefined();
+		await store.disconnect();
 	});
 
 	test("should clear keys when useSets is false", async () => {
-		const keyv = new KeyvValkey(valkeyUri, { useSets: false });
+		const store = new KeyvValkey(valkeyUri, { useSets: false });
 		const key1 = faker.string.alphanumeric(10);
 		const key2 = faker.string.alphanumeric(10);
-		await keyv.set(key1, faker.string.alphanumeric(10));
-		await keyv.set(key2, faker.string.alphanumeric(10));
-		await keyv.clear();
-		expect(await keyv.get(key1)).toBe(undefined);
-		expect(await keyv.get(key2)).toBe(undefined);
-		await keyv.disconnect();
+		await store.set(key1, faker.string.alphanumeric(10));
+		await store.set(key2, faker.string.alphanumeric(10));
+		await store.clear();
+		expect(await store.get(key1)).toBeUndefined();
+		expect(await store.get(key2)).toBeUndefined();
+		await store.disconnect();
 	});
 
 	test("should not error when useSets is false and there are no keys", async () => {
-		const keyv = new KeyvValkey(valkeyUri, { useSets: false });
-		expect(await keyv.clear()).toBeUndefined();
-		await keyv.disconnect();
+		const store = new KeyvValkey(valkeyUri, { useSets: false });
+		expect(await store.clear()).toBeUndefined();
+		await store.disconnect();
 	});
 
 	test("should clear keys tracked in the set when useSets is true", async () => {
-		const keyv = new KeyvValkey(valkeyUri, { useSets: true });
-		keyv.namespace = `clear-sets-${faker.string.alphanumeric(8)}`;
+		const store = new KeyvValkey(valkeyUri, { useSets: true });
+		store.namespace = faker.string.alphanumeric(8);
 		const key1 = faker.string.alphanumeric(10);
 		const key2 = faker.string.alphanumeric(10);
-		await keyv.set(key1, faker.string.alphanumeric(10));
-		await keyv.set(key2, faker.string.alphanumeric(10));
-		await keyv.clear();
-		expect(await keyv.get(key1)).toBe(undefined);
-		expect(await keyv.get(key2)).toBe(undefined);
-		await keyv.disconnect();
+		await store.set(key1, faker.string.alphanumeric(10));
+		await store.set(key2, faker.string.alphanumeric(10));
+		await store.clear();
+		expect(await store.get(key1)).toBeUndefined();
+		expect(await store.get(key2)).toBeUndefined();
+		await store.disconnect();
 	});
 });
 
 describe("useSets", () => {
 	test("should track keys via setMany when useSets is true", async () => {
-		const keyv = new KeyvValkey(valkeyUri, { useSets: true });
-		keyv.namespace = `setmany-${faker.string.alphanumeric(8)}`;
+		const store = new KeyvValkey(valkeyUri, { useSets: true });
+		store.namespace = faker.string.alphanumeric(8);
 		const key1 = faker.string.alphanumeric(10);
 		const key2 = faker.string.alphanumeric(10);
 		const val1 = faker.string.alphanumeric(10);
 		const val2 = faker.string.alphanumeric(10);
-		await keyv.setMany([
+		await store.setMany([
 			{ key: key1, value: val1 },
 			{ key: key2, value: val2 },
 		]);
-		expect(await keyv.get(key1)).toBe(val1);
-		expect(await keyv.get(key2)).toBe(val2);
-		await keyv.clear();
-		expect(await keyv.get(key1)).toBe(undefined);
-		await keyv.disconnect();
+		expect(await store.get(key1)).toBe(val1);
+		expect(await store.get(key2)).toBe(val2);
+		await store.clear();
+		expect(await store.get(key1)).toBeUndefined();
+		await store.disconnect();
 	});
 
 	test("should use the sets: prefix for the tracking key", async () => {
 		const client = new Redis(valkeyUri);
-		const keyv = new KeyvValkey(client, { useSets: true });
-		const namespace = `sets-prefix-${faker.string.alphanumeric(8)}`;
-		keyv.namespace = namespace;
-		await keyv.set(faker.string.alphanumeric(10), "value");
+		const store = new KeyvValkey(client, { useSets: true });
+		const namespace = faker.string.alphanumeric(8);
+		store.namespace = namespace;
+		const value = faker.string.alphanumeric(10);
+		await store.set(faker.string.alphanumeric(10), value);
 
 		expect(await client.exists(`sets:${namespace}`)).toBe(1);
 		expect(await client.type(`sets:${namespace}`)).toBe("set");
-		// The legacy namespace: format must not be used.
 		expect(await client.exists(`namespace:${namespace}`)).toBe(0);
 
-		await keyv.clear();
-		await keyv.disconnect();
+		await store.clear();
+		await store.disconnect();
 	});
 
-	test("should use 'sets' as the prefix when no namespace is set", async () => {
+	test("should use sets as the prefix when no namespace is set", async () => {
 		const client = new Redis(valkeyUri);
-		const keyv = new KeyvValkey(client, { useSets: true });
+		const store = new KeyvValkey(client, { useSets: true });
 		const key = faker.string.alphanumeric(10);
-		await keyv.set(key, "value");
+		const value = faker.string.alphanumeric(10);
+		await store.set(key, value);
 
 		expect(await client.exists("sets")).toBe(1);
 		expect(await client.type("sets")).toBe("set");
 		expect(await client.exists(`sets:${key}`)).toBe(1);
-		expect(await keyv.get(key)).toBe("value");
+		expect(await store.get(key)).toBe(value);
 
-		await keyv.clear();
-		expect(await keyv.get(key)).toBe(undefined);
-		await keyv.disconnect();
+		await store.clear();
+		expect(await store.get(key)).toBeUndefined();
+		await store.disconnect();
 	});
 
 	test("should clean up legacy namespace: tracking sets on clear", async () => {
 		const client = new Redis(valkeyUri);
-		const namespace = `legacy-${faker.string.alphanumeric(8)}`;
+		const namespace = faker.string.alphanumeric(8);
+		const legacyKey = faker.string.alphanumeric(10);
+		const legacyValue = faker.string.alphanumeric(10);
 
-		// Simulate legacy data: a SET at namespace:<ns> tracking a data key.
-		const legacyDataKey = `namespace:${namespace}:oldkey`;
-		await client.set(legacyDataKey, "oldvalue");
+		const legacyDataKey = `namespace:${namespace}:${legacyKey}`;
+		await client.set(legacyDataKey, legacyValue);
 		await client.sadd(`namespace:${namespace}`, legacyDataKey);
 
-		const keyv = new KeyvValkey(client, { useSets: true });
-		keyv.namespace = namespace;
-		await keyv.clear();
+		const store = new KeyvValkey(client, { useSets: true });
+		store.namespace = namespace;
+		await store.clear();
 
 		expect(await client.exists(`namespace:${namespace}`)).toBe(0);
 		expect(await client.exists(legacyDataKey)).toBe(0);
-		await keyv.disconnect();
+		await store.disconnect();
 	});
 
 	test("should not collide with a string key at the namespace path", async () => {
 		const client = new Redis(valkeyUri);
-		const namespace = `collision-${faker.string.alphanumeric(8)}`;
+		const namespace = faker.string.alphanumeric(8);
+		const unmanagedValue = faker.string.alphanumeric(10);
 
-		// Another client stores a string at namespace:<ns>.
-		await client.set(`namespace:${namespace}`, "some-string-value");
+		await client.set(`namespace:${namespace}`, unmanagedValue);
 
-		const keyv = new KeyvValkey(client, { useSets: true });
-		keyv.namespace = namespace;
+		const store = new KeyvValkey(client, { useSets: true });
+		store.namespace = namespace;
 		const key = faker.string.alphanumeric(10);
-		await keyv.set(key, "value");
-		expect(await keyv.get(key)).toBe("value");
-		await keyv.clear();
-		expect(await keyv.get(key)).toBe(undefined);
+		const value = faker.string.alphanumeric(10);
+		await store.set(key, value);
+		expect(await store.get(key)).toBe(value);
+		await store.clear();
+		expect(await store.get(key)).toBeUndefined();
 
-		// Clean up the unmanaged string key.
 		await client.del(`namespace:${namespace}`);
-		await keyv.disconnect();
+		await store.disconnect();
 	});
 });

--- a/storage/valkey/test/set.test.ts
+++ b/storage/valkey/test/set.test.ts
@@ -8,126 +8,126 @@ const valkeyUri = process.env.VALKEY_URI ?? "redis://localhost:6370";
 
 describe("set", () => {
 	test("should set and return a stored value", async () => {
-		const keyv = new KeyvValkey(valkeyUri);
+		const store = new KeyvValkey(valkeyUri);
 		const key = faker.string.alphanumeric(10);
 		const value = faker.string.alphanumeric(10);
-		expect(await keyv.set(key, value)).toBe(true);
-		expect(await keyv.get(key)).toBe(value);
-		await keyv.disconnect();
+		expect(await store.set(key, value)).toBe(true);
+		expect(await store.get(key)).toBe(value);
+		await store.disconnect();
 	});
 
 	test("should return false when setting an undefined value", async () => {
-		const keyv = new KeyvValkey(valkeyUri);
+		const store = new KeyvValkey(valkeyUri);
 		const key = faker.string.alphanumeric(10);
-		expect(await keyv.set(key, undefined)).toBe(false);
-		expect(await keyv.get(key)).toBe(undefined);
-		await keyv.disconnect();
+		expect(await store.set(key, undefined)).toBe(false);
+		expect(await store.get(key)).toBeUndefined();
+		await store.disconnect();
 	});
 
 	test("should expire a value after its expiry", async () => {
-		const keyv = new KeyvValkey(valkeyUri);
+		const store = new KeyvValkey(valkeyUri);
 		const key = faker.string.alphanumeric(10);
 		const value = faker.string.alphanumeric(10);
-		await keyv.set(key, value, Date.now() + 100);
-		expect(await keyv.get(key)).toBe(value);
+		await store.set(key, value, Date.now() + 100);
+		expect(await store.get(key)).toBe(value);
 		await delay(200);
-		expect(await keyv.get(key)).toBe(undefined);
-		await keyv.disconnect();
+		expect(await store.get(key)).toBeUndefined();
+		await store.disconnect();
 	});
 
 	test("should set a value when useSets is false", async () => {
-		const keyv = new KeyvValkey(valkeyUri, { useSets: false });
+		const store = new KeyvValkey(valkeyUri, { useSets: false });
 		const key = faker.string.alphanumeric(10);
 		const value = faker.string.alphanumeric(10);
-		await keyv.set(key, value);
-		expect(await keyv.get(key)).toBe(value);
-		await keyv.disconnect();
+		await store.set(key, value);
+		expect(await store.get(key)).toBe(value);
+		await store.disconnect();
 	});
 });
 
 describe("setMany", () => {
 	test("should set multiple values", async () => {
-		const keyv = new KeyvValkey(valkeyUri);
+		const store = new KeyvValkey(valkeyUri);
 		const key1 = faker.string.alphanumeric(10);
 		const key2 = faker.string.alphanumeric(10);
 		const key3 = faker.string.alphanumeric(10);
 		const val1 = faker.string.alphanumeric(10);
 		const val2 = faker.string.alphanumeric(10);
 		const val3 = faker.string.alphanumeric(10);
-		await keyv.setMany([
+		await store.setMany([
 			{ key: key1, value: val1 },
 			{ key: key2, value: val2 },
 			{ key: key3, value: val3 },
 		]);
-		expect(await keyv.getMany([key1, key2, key3])).toEqual([val1, val2, val3]);
-		await keyv.disconnect();
+		expect(await store.getMany([key1, key2, key3])).toEqual([val1, val2, val3]);
+		await store.disconnect();
 	});
 
 	test("should expire values with an expiry", async () => {
-		const keyv = new KeyvValkey(valkeyUri);
+		const store = new KeyvValkey(valkeyUri);
 		const key = faker.string.alphanumeric(10);
 		const value = faker.string.alphanumeric(10);
-		await keyv.setMany([{ key, value, expires: Date.now() + 100 }]);
-		expect(await keyv.get(key)).toBe(value);
+		await store.setMany([{ key, value, expires: Date.now() + 100 }]);
+		expect(await store.get(key)).toBe(value);
 		await delay(200);
-		expect(await keyv.get(key)).toBe(undefined);
-		await keyv.disconnect();
+		expect(await store.get(key)).toBeUndefined();
+		await store.disconnect();
 	});
 
 	test("should not error on an empty array", async () => {
-		const keyv = new KeyvValkey(valkeyUri);
-		expect(await keyv.setMany([])).toEqual([]);
-		await keyv.disconnect();
+		const store = new KeyvValkey(valkeyUri);
+		expect(await store.setMany([])).toEqual([]);
+		await store.disconnect();
 	});
 
 	test("should skip undefined values", async () => {
-		const keyv = new KeyvValkey(valkeyUri);
+		const store = new KeyvValkey(valkeyUri);
 		const key1 = faker.string.alphanumeric(10);
 		const key2 = faker.string.alphanumeric(10);
 		const val1 = faker.string.alphanumeric(10);
-		await keyv.setMany([
+		await store.setMany([
 			{ key: key1, value: val1 },
 			{ key: key2, value: undefined },
 		]);
-		expect(await keyv.get(key1)).toBe(val1);
-		expect(await keyv.get(key2)).toBe(undefined);
-		await keyv.disconnect();
+		expect(await store.get(key1)).toBe(val1);
+		expect(await store.get(key2)).toBeUndefined();
+		await store.disconnect();
 	});
 
 	test("should not error when all values are undefined", async () => {
-		const keyv = new KeyvValkey(valkeyUri);
+		const store = new KeyvValkey(valkeyUri);
 		const key1 = faker.string.alphanumeric(10);
 		const key2 = faker.string.alphanumeric(10);
-		await keyv.setMany([
+		await store.setMany([
 			{ key: key1, value: undefined },
 			{ key: key2, value: undefined },
 		]);
-		expect(await keyv.get(key1)).toBe(undefined);
-		expect(await keyv.get(key2)).toBe(undefined);
-		await keyv.disconnect();
+		expect(await store.get(key1)).toBeUndefined();
+		expect(await store.get(key2)).toBeUndefined();
+		await store.disconnect();
 	});
 
 	test("should return false entries when the transaction throws", async () => {
-		const keyv = new KeyvValkey(valkeyUri);
+		const store = new KeyvValkey(valkeyUri);
 		let emittedError = false;
-		keyv.on("error", () => {
+		store.on("error", () => {
 			emittedError = true;
 		});
 		// biome-ignore lint/complexity/useLiteralKeys: accessing private property to mock the client
-		const client = keyv["_client"];
+		const client = store["_client"];
 		const originalMulti = client.multi.bind(client);
 		client.multi = () => {
-			throw new Error("multi failure");
+			throw new Error(faker.lorem.sentence());
 		};
 
-		const result = await keyv.setMany([
-			{ key: faker.string.alphanumeric(10), value: "val1" },
-			{ key: faker.string.alphanumeric(10), value: "val2" },
+		const result = await store.setMany([
+			{ key: faker.string.alphanumeric(10), value: faker.string.alphanumeric(10) },
+			{ key: faker.string.alphanumeric(10), value: faker.string.alphanumeric(10) },
 		]);
 		expect(result).toEqual([false, false]);
 		expect(emittedError).toBe(true);
 
 		client.multi = originalMulti;
-		await keyv.disconnect();
+		await store.disconnect();
 	});
 });

--- a/storage/valkey/test/suite.test.ts
+++ b/storage/valkey/test/suite.test.ts
@@ -14,6 +14,7 @@ afterAll(async () => {
 	await keyv.disconnect();
 });
 
+// The shared suite registers tests via the provided function; vitest's `it` is required here.
 keyvTestSuite(it, Keyv, store);
 keyvIteratorTests(it, Keyv, store);
-storageTestSuite(it, store, { batch: false });
+storageTestSuite(it, store);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Review cleanup of `@keyv/valkey` before v6: documentation, test uniformity, event wiring, JSDoc, and member order. No storage-behavior change except missing reads always resolve to `undefined` (never `null`) and the iovalkey `close` event is re-emitted as `disconnect`.

## Summary

- README now documents the full public API: `createKeyv`, `capabilities`, events, `undefined` (not `null`), accurate `deleteMany` / cluster notes.
- Tests use `describe`/`test` with `should ...` descriptions and `faker` for keys and values.
- Adapter extends Hookified and re-emits `error`, `connect`, `reconnecting`, and `disconnect` (from client `close`), including when `client` is replaced.
- Public JSDoc includes params, types, and return values. Properties sit under the constructor; private methods sit below public methods.
- Named `export class KeyvValkey` plus default export. Shared storage suite now includes batch tests.

## Test plan

- `cd storage/valkey && pnpm test:ci` against Valkey/Redis on `6370` and the Redis cluster on `7001-7003`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5f79ba00-2332-475a-9e85-296dfde9e7ea?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5f79ba00-2332-475a-9e85-296dfde9e7ea&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

