### PR TITLE
mono - chore: remove @types/node override

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,6 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@types/node': ^24.13.1
   writr: 6.1.5
   semver@5.7.2: 7.7.3
 
@@ -3681,7 +3680,7 @@ packages:
     resolution: {integrity: sha512-fxh3HpQ8vJtu/Mmnd4Xsur19jGjHGzRLMxptiDtOkbX7EVBgnafGSGDx1WGGVmJLClVh2LeeBMMo24IFv8wCyQ==}
     engines: {node: '>= 8.0'}
     peerDependencies:
-      '@types/node': ^24.13.1
+      '@types/node': '>= 8'
 
   named-placeholders@1.1.6:
     resolution: {integrity: sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==}
@@ -4299,7 +4298,7 @@ packages:
     peerDependencies:
       '@swc/core': '>=1.2.50'
       '@swc/wasm': '>=1.2.50'
-      '@types/node': ^24.13.1
+      '@types/node': '*'
       typescript: '>=2.7'
     peerDependenciesMeta:
       '@swc/core':
@@ -4473,7 +4472,7 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
-      '@types/node': ^24.13.1
+      '@types/node': ^20.19.0 || >=22.12.0
       jiti: '>=1.21.0'
       less: ^4.0.0
       lightningcss: ^1.21.0
@@ -4515,7 +4514,7 @@ packages:
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
-      '@types/node': ^24.13.1
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
       '@vitest/browser-playwright': 4.1.10
       '@vitest/browser-preview': 4.1.10
       '@vitest/browser-webdriverio': 4.1.10

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,12 +21,9 @@ trustPolicy: no-downgrade
 strictDepBuilds: true
 dangerouslyAllowAllBuilds: false
 blockExoticSubdeps: true
-# keep @types/node within the Node major from .nvmrc across all packages,
-# including transitive resolutions (e.g. @types/pg, @types/ws, vitest peers).
 # writr@6.1.2 and semver@5.7.2 fail trustPolicy: no-downgrade (no provenance;
 # later versions of the same packages have attestations). Pin to versions that
 # already meet the gate — do not exclude first-party packages.
 overrides:
-  "@types/node": ^24.13.1
   writr: 6.1.5
   semver@5.7.2: 7.7.3


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [ ] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** Maintenance — dependency override cleanup. No public API change.

## Summary
Remove the `@types/node` pnpm override. The root already depends on `@types/node@^24.13.1` (Node 24, matching `.nvmrc`), and `pnpm install` still resolves a single `@types/node@24.13.1` across the workspace — the parent caught up.

## Changes
- remove the `@types/node` override from `pnpm-workspace.yaml` and the lockfile
- restore published peer ranges for `mysql2`, `ts-node`, `vite`, and `vitest` that the override had rewritten

## Verification
- [x] `pnpm install` — lockfile still resolves one `@types/node@24.13.1`
- [x] `pnpm why @types/node` — Found 1 version of `@types/node`
- [x] `pnpm build` — all workspace packages built
- [x] Non-Docker package tests — keyv, bigmap, test-suite, serializers, compression, encryption, sqlite, cloudflare-kv, and root `test:scripts` (933 tests passed). Full matrix including Docker-backed adapters runs in CI.

## Breaking notes
None. Resolved `@types/node` stays at 24.13.1. Remaining overrides (`writr`, `semver@5.7.2`) are unchanged and will be reviewed in later PRs.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4f981e6-7e76-4b5a-9a50-8cb10cd46f7d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4f981e6-7e76-4b5a-9a50-8cb10cd46f7d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

