### PR TITLE
mono - chore: remove writr override

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,6 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  writr: 6.1.5
   semver@5.7.2: 7.7.3
 
 importers:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,9 +21,8 @@ trustPolicy: no-downgrade
 strictDepBuilds: true
 dangerouslyAllowAllBuilds: false
 blockExoticSubdeps: true
-# writr@6.1.2 and semver@5.7.2 fail trustPolicy: no-downgrade (no provenance;
-# later versions of the same packages have attestations). Pin to versions that
-# already meet the gate — do not exclude first-party packages.
+# semver@5.7.2 fails trustPolicy: no-downgrade (no provenance;
+# later versions of the same package have attestations). Pin to a version that
+# already meets the gate — do not exclude first-party packages.
 overrides:
-  writr: 6.1.5
   semver@5.7.2: 7.7.3


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [ ] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** Maintenance — dependency override cleanup. No public API change.

## Summary
Remove the `writr` pnpm override. `docula@2.2.0` and `ecto@4.8.7` already depend on `writr@^6.1.2`, and `pnpm install` still resolves a single `writr@6.1.5` — the parent caught up.

## Changes
- remove the `writr: 6.1.5` override from `pnpm-workspace.yaml` and the lockfile
- leave the remaining `semver@5.7.2` override in place

## Verification
- [x] `pnpm install` — lockfile still resolves one `writr@6.1.5`
- [x] `pnpm why writr` — Found 1 version of `writr`
- [x] `pnpm build` — all workspace packages built
- [x] Non-Docker package tests — keyv, bigmap, test-suite, serializers, compression, encryption, sqlite, cloudflare-kv, and root `test:scripts` (933 tests passed). Full matrix including Docker-backed adapters runs in CI.

## Breaking notes
None. Resolved `writr` stays at 6.1.5. The `semver@5.7.2` override is unchanged and will be reviewed in a later PR.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4f981e6-7e76-4b5a-9a50-8cb10cd46f7d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4f981e6-7e76-4b5a-9a50-8cb10cd46f7d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

