### PR TITLE
mono - chore: upgrade biome to 2.5.11

### DIFF
--- a/compression/compress-brotli/package.json
+++ b/compression/compress-brotli/package.json
@@ -53,7 +53,7 @@
 		"keyv": "workspace:^"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^2.5.10",
+		"@biomejs/biome": "^2.5.11",
 		"@keyv/test-suite": "workspace:^",
 		"@vitest/coverage-v8": "^4.1.11",
 		"rimraf": "^6.1.3",

--- a/compression/compress-gzip/package.json
+++ b/compression/compress-gzip/package.json
@@ -56,7 +56,7 @@
     "keyv": "workspace:^"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.10",
+    "@biomejs/biome": "^2.5.11",
     "@keyv/test-suite": "workspace:^",
     "@vitest/coverage-v8": "^4.1.11",
     "rimraf": "^6.1.3",

--- a/compression/compress-lz4/package.json
+++ b/compression/compress-lz4/package.json
@@ -58,7 +58,7 @@
 		"keyv": "workspace:^"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^2.5.10",
+		"@biomejs/biome": "^2.5.11",
 		"@keyv/test-suite": "workspace:^",
 		"@vitest/coverage-v8": "^4.1.11",
 		"rimraf": "^6.1.3",

--- a/core/bigmap/package.json
+++ b/core/bigmap/package.json
@@ -52,7 +52,7 @@
 		"hookified": "^3.0.2"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^2.5.10",
+		"@biomejs/biome": "^2.5.11",
 		"@faker-js/faker": "^10.6.0",
 		"@monstermann/tinybench-pretty-printer": "^0.3.0",
 		"@vitest/coverage-v8": "^4.1.11",

--- a/core/keyv/package.json
+++ b/core/keyv/package.json
@@ -62,7 +62,7 @@
 		"hookified": "^3.0.2"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^2.5.10",
+		"@biomejs/biome": "^2.5.11",
 		"@faker-js/faker": "^10.6.0",
 		"@vitest/coverage-v8": "^4.1.11",
 		"happy-dom": "^20.11.12",

--- a/core/test-suite/package.json
+++ b/core/test-suite/package.json
@@ -66,7 +66,7 @@
 		"keyv": "workspace:^"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^2.5.10",
+		"@biomejs/biome": "^2.5.11",
 		"@types/json-bigint": "^1.0.4",
 		"lz4-napi": "^2.9.1",
 		"rimraf": "^6.1.3"

--- a/encryption/encrypt-node/package.json
+++ b/encryption/encrypt-node/package.json
@@ -54,7 +54,7 @@
 		"keyv": "workspace:^"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^2.5.10",
+		"@biomejs/biome": "^2.5.11",
 		"@keyv/test-suite": "workspace:^",
 		"@vitest/coverage-v8": "^4.1.11",
 		"rimraf": "^6.1.3",

--- a/encryption/encrypt-web/package.json
+++ b/encryption/encrypt-web/package.json
@@ -56,7 +56,7 @@
 		"keyv": "workspace:^"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^2.5.10",
+		"@biomejs/biome": "^2.5.11",
 		"@faker-js/faker": "^10.6.0",
 		"@keyv/test-suite": "workspace:^",
 		"@vitest/coverage-v8": "^4.1.11",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test:scripts": "vitest run --config vitest.config.ts"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.10",
+    "@biomejs/biome": "^2.5.11",
     "@faker-js/faker": "^10.6.0",
     "@types/node": "^24.13.1",
     "@vitest/coverage-v8": "^4.1.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
   .:
     devDependencies:
       '@biomejs/biome':
-        specifier: ^2.5.10
-        version: 2.5.10
+        specifier: ^2.5.11
+        version: 2.5.11
       '@faker-js/faker':
         specifier: ^10.6.0
         version: 10.6.0
@@ -52,8 +52,8 @@ importers:
         version: link:../../core/keyv
     devDependencies:
       '@biomejs/biome':
-        specifier: ^2.5.10
-        version: 2.5.10
+        specifier: ^2.5.11
+        version: 2.5.11
       '@keyv/test-suite':
         specifier: workspace:^
         version: link:../../core/test-suite
@@ -77,8 +77,8 @@ importers:
         version: 3.0.1
     devDependencies:
       '@biomejs/biome':
-        specifier: ^2.5.10
-        version: 2.5.10
+        specifier: ^2.5.11
+        version: 2.5.11
       '@keyv/test-suite':
         specifier: workspace:^
         version: link:../../core/test-suite
@@ -105,8 +105,8 @@ importers:
         version: 2.9.1
     devDependencies:
       '@biomejs/biome':
-        specifier: ^2.5.10
-        version: 2.5.10
+        specifier: ^2.5.11
+        version: 2.5.11
       '@keyv/test-suite':
         specifier: workspace:^
         version: link:../../core/test-suite
@@ -133,8 +133,8 @@ importers:
         version: link:../keyv
     devDependencies:
       '@biomejs/biome':
-        specifier: ^2.5.10
-        version: 2.5.10
+        specifier: ^2.5.11
+        version: 2.5.11
       '@faker-js/faker':
         specifier: ^10.6.0
         version: 10.6.0
@@ -167,8 +167,8 @@ importers:
         version: 3.0.2
     devDependencies:
       '@biomejs/biome':
-        specifier: ^2.5.10
-        version: 2.5.10
+        specifier: ^2.5.11
+        version: 2.5.11
       '@faker-js/faker':
         specifier: ^10.6.0
         version: 10.6.0
@@ -228,8 +228,8 @@ importers:
         version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.1)(@vitest/coverage-v8@4.1.11)(happy-dom@20.11.12)(vite@7.3.1(@types/node@24.13.1)(jiti@2.7.0)(terser@5.37.0)(tsx@4.23.1))
     devDependencies:
       '@biomejs/biome':
-        specifier: ^2.5.10
-        version: 2.5.10
+        specifier: ^2.5.11
+        version: 2.5.11
       '@types/json-bigint':
         specifier: ^1.0.4
         version: 1.0.4
@@ -247,8 +247,8 @@ importers:
         version: link:../../core/keyv
     devDependencies:
       '@biomejs/biome':
-        specifier: ^2.5.10
-        version: 2.5.10
+        specifier: ^2.5.11
+        version: 2.5.11
       '@keyv/test-suite':
         specifier: workspace:^
         version: link:../../core/test-suite
@@ -269,8 +269,8 @@ importers:
         version: link:../../core/keyv
     devDependencies:
       '@biomejs/biome':
-        specifier: ^2.5.10
-        version: 2.5.10
+        specifier: ^2.5.11
+        version: 2.5.11
       '@faker-js/faker':
         specifier: ^10.6.0
         version: 10.6.0
@@ -297,8 +297,8 @@ importers:
         version: 2.0.5
     devDependencies:
       '@biomejs/biome':
-        specifier: ^2.5.10
-        version: 2.5.10
+        specifier: ^2.5.11
+        version: 2.5.11
       '@keyv/test-suite':
         specifier: workspace:^
         version: link:../../core/test-suite
@@ -328,8 +328,8 @@ importers:
         version: 2.2.6
     devDependencies:
       '@biomejs/biome':
-        specifier: ^2.5.10
-        version: 2.5.10
+        specifier: ^2.5.11
+        version: 2.5.11
       '@keyv/test-suite':
         specifier: workspace:^
         version: link:../../core/test-suite
@@ -429,8 +429,8 @@ importers:
         version: 7.5.0
     devDependencies:
       '@biomejs/biome':
-        specifier: ^2.5.10
-        version: 2.5.10
+        specifier: ^2.5.11
+        version: 2.5.11
       '@faker-js/faker':
         specifier: ^10.6.0
         version: 10.6.0
@@ -460,8 +460,8 @@ importers:
         version: 3.23.2(@types/node@24.13.1)
     devDependencies:
       '@biomejs/biome':
-        specifier: ^2.5.10
-        version: 2.5.10
+        specifier: ^2.5.11
+        version: 2.5.11
       '@faker-js/faker':
         specifier: ^10.6.0
         version: 10.6.0
@@ -500,8 +500,8 @@ importers:
         version: 8.22.0
     devDependencies:
       '@biomejs/biome':
-        specifier: ^2.5.10
-        version: 2.5.10
+        specifier: ^2.5.11
+        version: 2.5.11
       '@faker-js/faker':
         specifier: ^10.6.0
         version: 10.6.0
@@ -587,8 +587,8 @@ importers:
         version: 0.4.0(supports-color@10.2.2)
     devDependencies:
       '@biomejs/biome':
-        specifier: ^2.5.10
-        version: 2.5.10
+        specifier: ^2.5.11
+        version: 2.5.11
       '@faker-js/faker':
         specifier: ^10.6.0
         version: 10.6.0
@@ -903,59 +903,59 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@biomejs/biome@2.5.10':
-    resolution: {integrity: sha512-WRKXARA3kTuiV5sxqTpobJ/I0MVd4vk3pOL6wnp5az4LntFIhWTj1RWZq3DI9PCEN3lXcqy7p5aqUHzvq8AXyQ==}
+  '@biomejs/biome@2.5.11':
+    resolution: {integrity: sha512-Tj0dnkLPdW0ASjHfj2D/ZkkvPU2wrFmnE1jWTD2xzV1ycapV1DutbYXk4NDnR3rYTi1ZCbNFD4G2gRMEY65WaA==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.5.10':
-    resolution: {integrity: sha512-ItCrxKK6SXVT6flYs0qIuBd4AA3TTTl4d66Re6YI2FuGZnN85NmuYNzkiTJUyYw8qBLv69L5zTUB6uyWd++h3Q==}
+  '@biomejs/cli-darwin-arm64@2.5.11':
+    resolution: {integrity: sha512-6SGZxoKbXvUjMn1t6A98HqWISPnGNbYs0R/Rt2JarmXBSev+lva4QxUMWEBX9lX1Wo1XTJ78uk5xVDtG58SRZg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.5.10':
-    resolution: {integrity: sha512-yLsPU9pAmtChXDu8vhKAzErqe+LeeYuwuUB2FZMkRitsmdodxsYRa9KHrFispsUHzzOu+9HB3nP/TQxyia+Sjw==}
+  '@biomejs/cli-darwin-x64@2.5.11':
+    resolution: {integrity: sha512-nYkXY7tLBEgnGbYapDKAyKzgt44ZEyG+AKalvTXtCWKYgepI9dw327q+cVgedxm+Udi1ZzHKUyZrIusHi/KQbw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.5.10':
-    resolution: {integrity: sha512-t1QAKZwQJRB4dvgJSgFiQ4BNfNPChg69BNonz854qLVxnjT3UvDzQg9mbkTJRu35ZqU0Rw10A73J8Urgbg2RPw==}
+  '@biomejs/cli-linux-arm64-musl@2.5.11':
+    resolution: {integrity: sha512-qhyZUMyCbWYFV2bAwRNVvfMVZ+hv7WYl6mossGrxC+uiQQXhvsuWWU8zz6jYX0mChZd9MgQZbm4vozTmG/5iGw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-arm64@2.5.10':
-    resolution: {integrity: sha512-VG8uQW/86a1roLaIFvtIbEigxIdzdJ190oGyg1tV7VYeQtOS+x10sflk7WbuXgw91EtZX5DlIIIej1YqkNLlcg==}
+  '@biomejs/cli-linux-arm64@2.5.11':
+    resolution: {integrity: sha512-3PVLSTD9RR73rvVPt5G3T1gc+ycggWEGfTD7RvzzbtcDPD27NxgxBbAFfpm7DXJKW6VLHWE1lLMGvFt2Qxjcow==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-linux-x64-musl@2.5.10':
-    resolution: {integrity: sha512-pgDDqp9JybHm2I0KRgzN6i4+lt8xu4iqxUwLzglUMmOmyRTU1AYBGKzh9sNMOtIjah7xoWvKHlLVetvyifzoiQ==}
+  '@biomejs/cli-linux-x64-musl@2.5.11':
+    resolution: {integrity: sha512-oRRlrchG5EfrEL/EmtT1qUjSNHk3/5LGeZhQqADBBAJF1b1ET6964xEKe7aGlGARzDfza8H/seEsFJl7S6Ql9w==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-x64@2.5.10':
-    resolution: {integrity: sha512-4O6T0eq2heoHZN0a9UX+rWQoxXEBaKf+lRi2hbsGlHneUz9BWXM76nEWMK7Eeq8gzMxR1khQB6BFpAASpeXqGg==}
+  '@biomejs/cli-linux-x64@2.5.11':
+    resolution: {integrity: sha512-JOytptlsgM33B2MMFUg8iBrb4IKpbD5JnJrSeYiaFEeAj4vuXx0iQSQZ4qK7sqyMtfjZxxPdNdMZZVL4y/mFyA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-win32-arm64@2.5.10':
-    resolution: {integrity: sha512-pxAbxduPO4xq/Cvgaa2lOrs9BB0hEXmmDqfMNP4ZOffGOkUrD1/QGw9UAMpFQpX2P8MqTIIRuQKcmetum4Oa6A==}
+  '@biomejs/cli-win32-arm64@2.5.11':
+    resolution: {integrity: sha512-e49E6K9hzH/ohJNx8Y26mY8HaV4I4ZViIeoqhKsmoXLKHhQnMeBAVqCgsGf2Wa3lXlS7RkporDXMHHWkzvZzFw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.5.10':
-    resolution: {integrity: sha512-M+2dgBsl3lXRiTfgPVc2p3anS4Tocojke4rzFLScZ2Y/wmF+36dRb1iHCLiyGqOzQGyTplZH1HnEYviiAqi3nA==}
+  '@biomejs/cli-win32-x64@2.5.11':
+    resolution: {integrity: sha512-QSQr/KjOgXA7OzXJUWS+oguKyAZ3Q0l/lnlDGbu397eKo83atuWUjBPJrsqbKNF6CARGw8XXJLGzpHC8Ryhd4Q==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -4953,39 +4953,39 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@biomejs/biome@2.5.10':
+  '@biomejs/biome@2.5.11':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.5.10
-      '@biomejs/cli-darwin-x64': 2.5.10
-      '@biomejs/cli-linux-arm64': 2.5.10
-      '@biomejs/cli-linux-arm64-musl': 2.5.10
-      '@biomejs/cli-linux-x64': 2.5.10
-      '@biomejs/cli-linux-x64-musl': 2.5.10
-      '@biomejs/cli-win32-arm64': 2.5.10
-      '@biomejs/cli-win32-x64': 2.5.10
+      '@biomejs/cli-darwin-arm64': 2.5.11
+      '@biomejs/cli-darwin-x64': 2.5.11
+      '@biomejs/cli-linux-arm64': 2.5.11
+      '@biomejs/cli-linux-arm64-musl': 2.5.11
+      '@biomejs/cli-linux-x64': 2.5.11
+      '@biomejs/cli-linux-x64-musl': 2.5.11
+      '@biomejs/cli-win32-arm64': 2.5.11
+      '@biomejs/cli-win32-x64': 2.5.11
 
-  '@biomejs/cli-darwin-arm64@2.5.10':
+  '@biomejs/cli-darwin-arm64@2.5.11':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.5.10':
+  '@biomejs/cli-darwin-x64@2.5.11':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.5.10':
+  '@biomejs/cli-linux-arm64-musl@2.5.11':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.5.10':
+  '@biomejs/cli-linux-arm64@2.5.11':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.5.10':
+  '@biomejs/cli-linux-x64-musl@2.5.11':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.5.10':
+  '@biomejs/cli-linux-x64@2.5.11':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.5.10':
+  '@biomejs/cli-win32-arm64@2.5.11':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.5.10':
+  '@biomejs/cli-win32-x64@2.5.11':
     optional: true
 
   '@cacheable/memory@2.0.9':

--- a/serialization/msgpackr/package.json
+++ b/serialization/msgpackr/package.json
@@ -53,7 +53,7 @@
     "keyv": "workspace:^"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.10",
+    "@biomejs/biome": "^2.5.11",
     "@keyv/test-suite": "workspace:^",
     "@vitest/coverage-v8": "^4.1.11",
     "rimraf": "^6.1.3",

--- a/serialization/superjson/package.json
+++ b/serialization/superjson/package.json
@@ -52,7 +52,7 @@
     "keyv": "workspace:^"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.10",
+    "@biomejs/biome": "^2.5.11",
     "@keyv/test-suite": "workspace:^",
     "@vitest/coverage-v8": "^4.1.11",
     "rimraf": "^6.1.3",

--- a/storage/mongo/package.json
+++ b/storage/mongo/package.json
@@ -54,7 +54,7 @@
 		"mongodb": "^7.5.0"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^2.5.10",
+		"@biomejs/biome": "^2.5.11",
 		"@faker-js/faker": "^10.6.0",
 		"@keyv/test-suite": "workspace:^",
 		"@vitest/coverage-v8": "^4.1.11",

--- a/storage/mysql/package.json
+++ b/storage/mysql/package.json
@@ -55,7 +55,7 @@
 		"mysql2": "^3.23.2"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^2.5.10",
+		"@biomejs/biome": "^2.5.11",
 		"@faker-js/faker": "^10.6.0",
 		"@keyv/test-suite": "workspace:^",
 		"@vitest/coverage-v8": "^4.1.11",

--- a/storage/postgres/package.json
+++ b/storage/postgres/package.json
@@ -58,7 +58,7 @@
 		"keyv": "workspace:^"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^2.5.10",
+		"@biomejs/biome": "^2.5.11",
 		"@faker-js/faker": "^10.6.0",
 		"@keyv/test-suite": "workspace:^",
 		"@types/pg": "^8.20.0",

--- a/storage/valkey/package.json
+++ b/storage/valkey/package.json
@@ -58,7 +58,7 @@
 		"iovalkey": "^0.4.0"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^2.5.10",
+		"@biomejs/biome": "^2.5.11",
 		"@faker-js/faker": "^10.6.0",
 		"@keyv/test-suite": "workspace:^",
 		"@vitest/coverage-v8": "^4.1.11",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [ ] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** Maintenance — code quality dependency upgrade. No public API change.

## Summary
Upgrade `@biomejs/biome` to the Latest version allowed by `minimumReleaseAge` (2.5.10 → 2.5.11). This is the remaining outdated code-quality dep after #2073.

The `semver@5.7.2 → 7.7.3` override was retried this iteration; removal still fails `trustPolicy: no-downgrade`, so it stays.

## Changes
- `@biomejs/biome` 2.5.10 → 2.5.11 across the workspace packages that depend on it

## Artifact diffs
- [@biomejs/biome 2.5.10 → 2.5.11](https://drydock.org/diff/@biomejs/biome/2.5.10/2.5.11)

## Verification
- [x] `pnpm build` — all workspace packages built
- [x] Non-Docker package tests including `biome check --error-on-warnings` — 933 tests passed, no lint fixes needed. Full matrix including Docker-backed adapters runs in CI.

## Breaking notes
None.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4f981e6-7e76-4b5a-9a50-8cb10cd46f7d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4f981e6-7e76-4b5a-9a50-8cb10cd46f7d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

