### PR TITLE
mono - chore: upgrade pnpm

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,7 +26,7 @@ hardening checklist; progress is tracked in [DEFENSE_IN_DEPTH.md](./DEFENSE_IN_D
 - All changes land through pull requests — direct pushes to `main` are blocked, and merging requires passing status checks.
 - Tags can only be created by repository admins; published GitHub Releases are immutable (assets and tags cannot be changed after publish).
 - Workflow runs from outside collaborators always require maintainer approval, and only allowlisted GitHub Actions can run.
-- pnpm is pinned via `packageManager` (`pnpm@11.18.0`).
+- pnpm is pinned via `packageManager` (`pnpm@11.24.0`).
 - Dependencies install through pnpm with a 7-day cooldown on new versions, lifecycle scripts blocked by default, and `trustPolicy: no-downgrade`.
 - The lockfile is committed and CI installs with `--frozen-lockfile`. There is no Dependabot config; dependency updates go through reviewed PRs.
 - CI runs with read-only permissions (only the release job gets `id-token: write`); every action is pinned to a full commit SHA; Socket Firewall (`sfw`) wraps `pnpm install` / `npm install`; workflows are security-linted with zizmor on every PR.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "Jared Wray <me@jaredwray.com>",
   "license": "MIT",
   "private": true,
-  "packageManager": "pnpm@11.18.0+sha512.33d83c77da82f49fba836925c6f1b841181ec3132b670639bd012f7075f5c7cf634c5f870147c19aae7478fac01df09d8892e880454896edd23ee9b33757563c",
+  "packageManager": "pnpm@11.24.0+sha512.bd27e345e976dcb0be0b7a1228217b049a817e21b1f355c90dbe7dc46671895a8bc1e6d06c24554505ea93ea0b45f489a27ec1bfbc8de6a9659fca0f16fa0000",
   "engines": {
     "node": ">= 22.19.0"
   },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [ ] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** Maintenance — package manager pin. No public API change.

## Summary
Upgrade the pinned `packageManager` from pnpm 11.18.0 to 11.24.0, the newest 11.x release that is at least 7 days old (`minimumReleaseAge`). npm `latest` is 11.25.0 (published 2026-08-29, ~5 days old) and is left for a later resume.

The remaining `semver@5.7.2 → 7.7.3` override was tried first this iteration: removal fails `trustPolicy: no-downgrade`, and rewriting it to `>=7.7.3` still resolves `7.7.3`, so that pin is kept.

## Changes
- `packageManager` pnpm 11.18.0 → 11.24.0 (SHA-pinned)
- `SECURITY.md` pin citation updated to match

## Artifact diffs
- [pnpm 11.18.0 → 11.24.0](https://drydock.org/diff/pnpm/11.18.0/11.24.0)

## Verification
- [x] `pnpm install --frozen-lockfile` with pnpm 11.24.0
- [x] `pnpm build` — all workspace packages built
- [x] Non-Docker package tests — keyv, bigmap, test-suite, serializers, compression, encryption, sqlite, cloudflare-kv, and root `test:scripts` (933 tests passed on pnpm 11.24.0). Full matrix including Docker-backed adapters runs in CI.

## Breaking notes
None.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4f981e6-7e76-4b5a-9a50-8cb10cd46f7d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4f981e6-7e76-4b5a-9a50-8cb10cd46f7d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

