### PR TITLE
mono - chore: upgrade pnpm

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,7 +26,7 @@ hardening checklist; progress is tracked in [DEFENSE_IN_DEPTH.md](./DEFENSE_IN_D
 - All changes land through pull requests — direct pushes to `main` are blocked, and merging requires passing status checks.
 - Tags can only be created by repository admins; published GitHub Releases are immutable (assets and tags cannot be changed after publish).
 - Workflow runs from outside collaborators always require maintainer approval, and only allowlisted GitHub Actions can run.
-- pnpm is pinned via `packageManager` (`pnpm@11.24.0`).
+- pnpm is pinned via `packageManager` (`pnpm@11.25.0`).
 - Dependencies install through pnpm with a 7-day cooldown on new versions, lifecycle scripts blocked by default, and `trustPolicy: no-downgrade`.
 - The lockfile is committed and CI installs with `--frozen-lockfile`. There is no Dependabot config; dependency updates go through reviewed PRs.
 - CI runs with read-only permissions (only the release job gets `id-token: write`); every action is pinned to a full commit SHA; Socket Firewall (`sfw`) wraps `pnpm install` / `npm install`; workflows are security-linted with zizmor on every PR.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "Jared Wray <me@jaredwray.com>",
   "license": "MIT",
   "private": true,
-  "packageManager": "pnpm@11.24.0+sha512.bd27e345e976dcb0be0b7a1228217b049a817e21b1f355c90dbe7dc46671895a8bc1e6d06c24554505ea93ea0b45f489a27ec1bfbc8de6a9659fca0f16fa0000",
+  "packageManager": "pnpm@11.25.0+sha512.5cde925b4f075f725eb71fbae18a42ffe784524789f19b61c731cb8721ec28aaee160e01a8d5af4fedb2a42cdbf300efe23db356b0d4a17b4d63e11f8ab7c956",
   "engines": {
     "node": ">= 22.19.0"
   },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [ ] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** Maintenance — package manager pin. No public API change.

## Summary
Pin `packageManager` to pnpm 11.25.0, the newest 11.x release that meets the 7-day `minimumReleaseAge` gate. pnpm 12.x is a major and is not in this PR.

The `semver@5.7.2 → 7.7.3` override was retried this iteration (remove, then `>=7.7.3`); both still land on 7.7.3 / fail `trustPolicy: no-downgrade`, so it stays.

## Changes
- `packageManager` pnpm 11.24.0 → 11.25.0
- `SECURITY.md` pin citation updated to `pnpm@11.25.0`

## Artifact diffs
- [pnpm 11.24.0 → 11.25.0](https://drydock.org/diff/pnpm/11.24.0/11.25.0)

## Verification
- [x] `pnpm -v` reports 11.25.0 via Safe Chain shims
- [x] `pnpm install --frozen-lockfile` and `pnpm build` — lockfile unchanged, all workspace packages built
- [x] Non-Docker package tests including `biome check --error-on-warnings` — 933 tests passed, no lint fixes needed. Full matrix including Docker-backed adapters runs in CI.

## Breaking notes
None.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4f981e6-7e76-4b5a-9a50-8cb10cd46f7d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4f981e6-7e76-4b5a-9a50-8cb10cd46f7d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

