### PR TITLE
mono - chore: upgrade GitHub Actions

### DIFF
--- a/.github/workflows/browser-compat.yaml
+++ b/.github/workflows/browser-compat.yaml
@@ -28,7 +28,7 @@ jobs:
           firewall-version: "1.15.1"
 
       - name: Install pnpm
-        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413 # v6.1.0
 
       - name: Setup node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/bun-test.yaml
+++ b/.github/workflows/bun-test.yaml
@@ -33,7 +33,7 @@ jobs:
           bun-version: latest
 
       - name: Install pnpm
-        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413 # v6.1.0
 
       - name: Setup node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/cloudflare-keyv-integration.yaml
+++ b/.github/workflows/cloudflare-keyv-integration.yaml
@@ -6,9 +6,10 @@ name: cloudflare-keyv-integration
 # secrets below are absent, so it never fails on forks or when secrets are not configured.
 #
 # Required repository secrets:
-#   CLOUDFLARE_ACCOUNT_ID       - the Cloudflare account ID that owns the KV namespace
-#   CLOUDFLARE_KV_NAMESPACE_ID  - the KV namespace ID (not the binding name)
-#   CLOUDFLARE_API_TOKEN        - an API token with the "Workers KV Storage" Edit permission
+#   CLOUDFLARE_ACCOUNT_ID            - the Cloudflare account ID that owns the KV namespace
+#   CLOUDFLARE_KV_NAMESPACE_ID       - the KV namespace ID (not the binding name)
+#   CLOUDFLARE_API_TOKEN_KV_TESTS    - an API token with the "Workers KV Storage" Edit permission
+#                                      (dedicated to this workflow; not CLOUDFLARE_API_TOKEN)
 
 on:
   workflow_dispatch:
@@ -61,5 +62,5 @@ jobs:
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_KV_NAMESPACE_ID: ${{ secrets.CLOUDFLARE_KV_NAMESPACE_ID }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN_KV_TESTS }}
         run: pnpm test:live

--- a/.github/workflows/cloudflare-keyv-integration.yaml
+++ b/.github/workflows/cloudflare-keyv-integration.yaml
@@ -43,7 +43,7 @@ jobs:
           firewall-version: "1.15.1"
 
       - name: Install pnpm
-        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413 # v6.1.0
 
       - name: Setup node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -28,7 +28,7 @@ jobs:
           firewall-version: "1.15.1"
 
       - name: Install pnpm
-        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413 # v6.1.0
 
       - name: Setup node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/deploy-website.yaml
+++ b/.github/workflows/deploy-website.yaml
@@ -27,7 +27,7 @@ jobs:
           firewall-version: "1.15.1"
 
       - name: Install pnpm
-        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413 # v6.1.0
 
       - name: Use Node.js 24
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,7 @@ jobs:
           firewall-version: "1.15.1"
 
       - name: Install pnpm
-        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413 # v6.1.0
 
       - name: Setup node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -97,7 +97,7 @@ jobs:
           firewall-version: "1.15.1"
 
       - name: Install pnpm
-        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413 # v6.1.0
 
       - name: Setup node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -149,7 +149,7 @@ jobs:
           firewall-version: "1.15.1"
 
       - name: Install pnpm
-        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413 # v6.1.0
 
       - name: Setup node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,7 +32,7 @@ jobs:
           firewall-version: "1.15.1"
 
       - name: Install pnpm
-        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413 # v6.1.0
 
       - name: Setup node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/storage/cloudflare-kv/README.md
+++ b/storage/cloudflare-kv/README.md
@@ -180,7 +180,7 @@ This local server emulates Cloudflare's live REST environment. We keep it in syn
 Cloudflare API and additionally run a **live integration test** (the `cloudflare-keyv-integration`
 GitHub workflow) against the real Cloudflare KV API, so we notice if the live behavior ever drifts
 from the emulation. That workflow requires the `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_KV_NAMESPACE_ID`,
-and `CLOUDFLARE_API_TOKEN` repository secrets and self-skips when they are absent.
+and `CLOUDFLARE_API_TOKEN_KV_TESTS` repository secrets and self-skips when they are absent.
 
 ## How Values Are Stored
 

--- a/storage/cloudflare-kv/test/live/live.test.ts
+++ b/storage/cloudflare-kv/test/live/live.test.ts
@@ -3,8 +3,9 @@ import { afterAll, describe, expect, it } from "vitest";
 import KeyvCloudflareKV from "../../src/index.js";
 
 // Live integration test against the real Cloudflare KV REST API. It is skipped unless all three
-// credentials are present, so it is a no-op locally and on forks. The scheduled
-// `cloudflare-keyv-integration` GitHub workflow provides them from repository secrets.
+// credentials are present, so it is a no-op locally and on forks. The
+// `cloudflare-keyv-integration` GitHub workflow maps repository secret
+// CLOUDFLARE_API_TOKEN_KV_TESTS onto CLOUDFLARE_API_TOKEN.
 const accountId = process.env.CLOUDFLARE_ACCOUNT_ID;
 const namespaceId = process.env.CLOUDFLARE_KV_NAMESPACE_ID;
 const apiToken = process.env.CLOUDFLARE_API_TOKEN;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [ ] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** Maintenance — GitHub Actions pin plus a dedicated Cloudflare KV live-test secret. No public API change.

## Summary
Upgrade `pnpm/action-setup` to the latest available version (v6.0.10 → v6.1.0). Other `uses:` pins and Socket Firewall `firewall-version` 1.15.1 are already current.

The live Cloudflare job now reads repository secret `CLOUDFLARE_API_TOKEN_KV_TESTS` (mapped to `CLOUDFLARE_API_TOKEN` for the existing live tests). `CLOUDFLARE_API_TOKEN` stays for website deploy (`deploy-website.yaml`).

The `semver@5.7.2 → 7.7.3` override was retried this iteration (remove, then `>=7.7.3`); both still land on 7.7.3 / fail `trustPolicy: no-downgrade`, so it stays.

## Changes
- `pnpm/action-setup` `0977fd9` (v6.0.10) → `ea17c68` (v6.1.0) in all 7 workflows that use it
- `cloudflare-keyv-integration` uses `secrets.CLOUDFLARE_API_TOKEN_KV_TESTS`

## Verification
- [x] Workflow YAML still parses (`js-yaml` load of every file under `.github/workflows/`)
- [ ] Full CI matrix including Docker-backed adapters runs in GitHub Actions
- [ ] `cloudflare-keyv-integration` live REST tests with `CLOUDFLARE_API_TOKEN_KV_TESTS`

## Breaking notes
None.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4f981e6-7e76-4b5a-9a50-8cb10cd46f7d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4f981e6-7e76-4b5a-9a50-8cb10cd46f7d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

