### PR TITLE
mono - chore: pin Dev Container images

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
   "name": "Node.js",
-  "image": "mcr.microsoft.com/devcontainers/javascript-node:latest",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:5.1.2-24-trixie@sha256:757b22963a35e3673da4bece29c4948c815637085947259b80910e951e3ba64a",
   "postCreateCommand": "bash ./scripts/setup-cloud-environment.sh"
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [ ] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** Maintenance — Dev Container image pin. No public API change.

## Summary
Pin the Dev Container image from floating `javascript-node:latest` to the newest Node 24 + Debian trixie digest that is at least 7 days old. That currently matches `latest` (`5.1.2-24-trixie`, created 2026-08-27).

The `semver@5.7.2 → 7.7.3` override was retried this iteration (remove, then `>=7.7.3`); both still land on 7.7.3 / fail `trustPolicy: no-downgrade`, so it stays.

## Changes
- `.devcontainer/devcontainer.json` image → `mcr.microsoft.com/devcontainers/javascript-node:5.1.2-24-trixie@sha256:757b22963a35e3673da4bece29c4948c815637085947259b80910e951e3ba64a`

## Verification
- [x] `.devcontainer/devcontainer.json` still parses as JSON
- [x] Pin is the multi-arch index digest; `Created` is 2026-08-27 (≥7 days)
- [x] Node lineage matches `.nvmrc` (24). Sandbox has no Docker daemon, so the image was not `docker pull`ed.

## Breaking notes
None.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4f981e6-7e76-4b5a-9a50-8cb10cd46f7d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4f981e6-7e76-4b5a-9a50-8cb10cd46f7d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

