### PR TITLE
mono - chore: upgrade hookified

### DIFF
--- a/core/bigmap/package.json
+++ b/core/bigmap/package.json
@@ -49,7 +49,7 @@
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
 		"hashery": "^3.0.1",
-		"hookified": "^3.0.2"
+		"hookified": "^3.0.3"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.5.11",

--- a/core/keyv/package.json
+++ b/core/keyv/package.json
@@ -59,7 +59,7 @@
 	},
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
-		"hookified": "^3.0.2"
+		"hookified": "^3.0.3"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.5.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,8 +126,8 @@ importers:
         specifier: ^3.0.1
         version: 3.0.1
       hookified:
-        specifier: ^3.0.2
-        version: 3.0.2
+        specifier: ^3.0.3
+        version: 3.0.3
       keyv:
         specifier: workspace:^
         version: link:../keyv
@@ -163,8 +163,8 @@ importers:
   core/keyv:
     dependencies:
       hookified:
-        specifier: ^3.0.2
-        version: 3.0.2
+        specifier: ^3.0.3
+        version: 3.0.3
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.5.11
@@ -352,8 +352,8 @@ importers:
   storage/cloudflare-kv:
     dependencies:
       hookified:
-        specifier: ^3.0.2
-        version: 3.0.2
+        specifier: ^3.0.3
+        version: 3.0.3
       keyv:
         specifier: workspace:^
         version: link:../../core/keyv
@@ -374,8 +374,8 @@ importers:
         specifier: ^3.1097.0
         version: 3.1097.0(@aws-sdk/client-dynamodb@3.1097.0)
       hookified:
-        specifier: ^3.0.2
-        version: 3.0.2
+        specifier: ^3.0.3
+        version: 3.0.3
       keyv:
         specifier: workspace:^
         version: link:../../core/keyv
@@ -387,8 +387,8 @@ importers:
   storage/etcd:
     dependencies:
       hookified:
-        specifier: ^3.0.2
-        version: 3.0.2
+        specifier: ^3.0.3
+        version: 3.0.3
       keyv:
         specifier: workspace:^
         version: link:../../core/keyv
@@ -400,8 +400,8 @@ importers:
   storage/memcache:
     dependencies:
       hookified:
-        specifier: ^3.0.2
-        version: 3.0.2
+        specifier: ^3.0.3
+        version: 3.0.3
       keyv:
         specifier: workspace:^
         version: link:../../core/keyv
@@ -419,8 +419,8 @@ importers:
   storage/mongo:
     dependencies:
       hookified:
-        specifier: ^3.0.2
-        version: 3.0.2
+        specifier: ^3.0.3
+        version: 3.0.3
       keyv:
         specifier: workspace:^
         version: link:../../core/keyv
@@ -453,8 +453,8 @@ importers:
   storage/mysql:
     dependencies:
       hookified:
-        specifier: ^3.0.2
-        version: 3.0.2
+        specifier: ^3.0.3
+        version: 3.0.3
       mysql2:
         specifier: ^3.23.2
         version: 3.23.2(@types/node@24.13.1)
@@ -490,8 +490,8 @@ importers:
   storage/postgres:
     dependencies:
       hookified:
-        specifier: ^3.0.2
-        version: 3.0.2
+        specifier: ^3.0.3
+        version: 3.0.3
       keyv:
         specifier: workspace:^
         version: link:../../core/keyv
@@ -533,8 +533,8 @@ importers:
         specifier: ^1.1.2
         version: 1.1.2
       hookified:
-        specifier: ^3.0.2
-        version: 3.0.2
+        specifier: ^3.0.3
+        version: 3.0.3
       keyv:
         specifier: workspace:^
         version: link:../../core/keyv
@@ -552,8 +552,8 @@ importers:
         specifier: ^13.0.2
         version: 13.0.2
       hookified:
-        specifier: ^3.0.2
-        version: 3.0.2
+        specifier: ^3.0.3
+        version: 3.0.3
       keyv:
         specifier: workspace:^
         version: link:../../core/keyv
@@ -580,8 +580,8 @@ importers:
         specifier: ^1.1.0
         version: 1.1.2
       hookified:
-        specifier: ^3.0.2
-        version: 3.0.2
+        specifier: ^3.0.3
+        version: 3.0.3
       iovalkey:
         specifier: ^0.4.0
         version: 0.4.0(supports-color@10.2.2)
@@ -3091,6 +3091,10 @@ packages:
 
   hookified@3.0.2:
     resolution: {integrity: sha512-FpIcRHpFlW7yh68lmL0h1/Vodv77TogpHlt4qqakE/0RyQMjgNxs53acH9NJPeyRZutP7GnlqiyqRNejV8/lHQ==}
+    engines: {node: '>=22.18.0'}
+
+  hookified@3.0.3:
+    resolution: {integrity: sha512-ZcbRytYgERoKtosiaXolUIPIWMgUCrSiWQEzFZ0kc8etD/LPgpy4/KOrtssFdK7ZXlTTyb4cob2veqj7osv8yA==}
     engines: {node: '>=22.18.0'}
 
   hosted-git-info@2.8.9:
@@ -6604,11 +6608,11 @@ snapshots:
 
   hashery@3.0.0:
     dependencies:
-      hookified: 3.0.2
+      hookified: 3.0.3
 
   hashery@3.0.1:
     dependencies:
-      hookified: 3.0.2
+      hookified: 3.0.3
 
   hasown@2.0.2:
     dependencies:
@@ -6731,6 +6735,8 @@ snapshots:
   hookified@2.2.0: {}
 
   hookified@3.0.2: {}
+
+  hookified@3.0.3: {}
 
   hosted-git-info@2.8.9: {}
 
@@ -7222,7 +7228,7 @@ snapshots:
   memcache@1.9.0:
     dependencies:
       hashery: 3.0.0
-      hookified: 3.0.2
+      hookified: 3.0.3
 
   memory-pager@1.5.0: {}
 

--- a/storage/cloudflare-kv/package.json
+++ b/storage/cloudflare-kv/package.json
@@ -54,7 +54,7 @@
   },
   "homepage": "https://github.com/jaredwray/keyv",
   "dependencies": {
-    "hookified": "^3.0.2"
+    "hookified": "^3.0.3"
   },
   "devDependencies": {
     "@keyv/test-suite": "workspace:^",

--- a/storage/dynamo/package.json
+++ b/storage/dynamo/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.1097.0",
     "@aws-sdk/lib-dynamodb": "^3.1097.0",
-    "hookified": "^3.0.2"
+    "hookified": "^3.0.3"
   },
   "devDependencies": {
     "@keyv/test-suite": "workspace:^"

--- a/storage/etcd/package.json
+++ b/storage/etcd/package.json
@@ -49,7 +49,7 @@
 	},
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
-		"hookified": "^3.0.2"
+		"hookified": "^3.0.3"
 	},
 	"devDependencies": {
 		"@keyv/test-suite": "workspace:^"

--- a/storage/memcache/package.json
+++ b/storage/memcache/package.json
@@ -49,7 +49,7 @@
 	},
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
-		"hookified": "^3.0.2",
+		"hookified": "^3.0.3",
 		"memcache": "^1.9.0"
 	},
 	"peerDependencies": {

--- a/storage/mongo/package.json
+++ b/storage/mongo/package.json
@@ -50,7 +50,7 @@
 	},
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
-		"hookified": "^3.0.2",
+		"hookified": "^3.0.3",
 		"mongodb": "^7.5.0"
 	},
 	"devDependencies": {

--- a/storage/mysql/package.json
+++ b/storage/mysql/package.json
@@ -51,7 +51,7 @@
 	},
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
-		"hookified": "^3.0.2",
+		"hookified": "^3.0.3",
 		"mysql2": "^3.23.2"
 	},
 	"devDependencies": {

--- a/storage/postgres/package.json
+++ b/storage/postgres/package.json
@@ -51,7 +51,7 @@
 	},
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
-		"hookified": "^3.0.2",
+		"hookified": "^3.0.3",
 		"pg": "^8.22.0"
 	},
 	"peerDependencies": {

--- a/storage/redis/package.json
+++ b/storage/redis/package.json
@@ -51,7 +51,7 @@
 	"dependencies": {
 		"@redis/client": "^6.1.0",
 		"cluster-key-slot": "^1.1.2",
-		"hookified": "^3.0.2"
+		"hookified": "^3.0.3"
 	},
 	"peerDependencies": {
 		"keyv": "workspace:^"

--- a/storage/sqlite/package.json
+++ b/storage/sqlite/package.json
@@ -53,7 +53,7 @@
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
 		"better-sqlite3": "^13.0.2",
-		"hookified": "^3.0.2"
+		"hookified": "^3.0.3"
 	},
 	"peerDependencies": {
 		"keyv": "workspace:^"

--- a/storage/valkey/package.json
+++ b/storage/valkey/package.json
@@ -54,7 +54,7 @@
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
 		"cluster-key-slot": "^1.1.0",
-		"hookified": "^3.0.2",
+		"hookified": "^3.0.3",
 		"iovalkey": "^0.4.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Bump the shared `hookified` runtime dependency from 3.0.2 to 3.0.3 across `keyv`, `@keyv/bigmap`, and every storage adapter that declares it. Patch release of the event/hook layer used by the core store and adapters.

## Changes
- Upgrade `hookified` `^3.0.2` → `^3.0.3` in 12 workspace packages and refresh the lockfile
- Transitive `hookified@3.0.3` is now what `keyv` and adapters resolve; leftover `hookified@3.0.2` is only via `writr` (not a direct dependency)

## Artifact diffs
- [hookified 3.0.2 → 3.0.3](https://drydock.org/diff/hookified/3.0.2/3.0.3)

## Verification
- [x] `pnpm build` (all workspace packages)
- [x] Non-Docker tests: 933 passed, 4 todo (`keyv`, `bigmap`, `test-suite`, serializers, compression, encryption, `sqlite`, `cloudflare-kv`, root `test:scripts`)
- Sandbox has no Docker daemon; Redis/MySQL/Postgres/Mongo/Memcache/Valkey/Etcd/Dynamo adapter tests run in CI

## Breaking notes
None. Patch bump within the existing `^3` range.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4f981e6-7e76-4b5a-9a50-8cb10cd46f7d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4f981e6-7e76-4b5a-9a50-8cb10cd46f7d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

