### PR TITLE
memcache - chore: upgrade memcache

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -406,8 +406,8 @@ importers:
         specifier: workspace:^
         version: link:../../core/keyv
       memcache:
-        specifier: ^1.9.0
-        version: 1.9.0
+        specifier: ^1.10.0
+        version: 1.10.0
     devDependencies:
       '@keyv/compress-gzip':
         specifier: workspace:^
@@ -3094,10 +3094,6 @@ packages:
   hookified@2.2.0:
     resolution: {integrity: sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==}
 
-  hookified@3.0.2:
-    resolution: {integrity: sha512-FpIcRHpFlW7yh68lmL0h1/Vodv77TogpHlt4qqakE/0RyQMjgNxs53acH9NJPeyRZutP7GnlqiyqRNejV8/lHQ==}
-    engines: {node: '>=22.18.0'}
-
   hookified@3.0.3:
     resolution: {integrity: sha512-ZcbRytYgERoKtosiaXolUIPIWMgUCrSiWQEzFZ0kc8etD/LPgpy4/KOrtssFdK7ZXlTTyb4cob2veqj7osv8yA==}
     engines: {node: '>=22.18.0'}
@@ -3478,8 +3474,8 @@ packages:
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
-  memcache@1.9.0:
-    resolution: {integrity: sha512-tysDsbWZjQDrxKU3absG6nl1AWlf1+V1+3yA/jSTMSUWtToqx6KY9psqlBIly45F46DVBT/P2YBhpA2pu1LU9Q==}
+  memcache@1.10.0:
+    resolution: {integrity: sha512-USVidZugkSeQuWK8qoI2UUVvTzs1i4tgZ0RhD1Jlw0Ep/02depgMLBoZRIae0YgnRbV4qOVW+QJlijmcoe6DzQ==}
     engines: {node: '>=22.19.0', pnpm: '>=11'}
 
   memory-pager@1.5.0:
@@ -6748,8 +6744,6 @@ snapshots:
 
   hookified@2.2.0: {}
 
-  hookified@3.0.2: {}
-
   hookified@3.0.3: {}
 
   hosted-git-info@2.8.9: {}
@@ -7239,9 +7233,9 @@ snapshots:
 
   mdurl@2.0.0: {}
 
-  memcache@1.9.0:
+  memcache@1.10.0:
     dependencies:
-      hashery: 3.0.0
+      hashery: 3.0.1
       hookified: 3.0.3
 
   memory-pager@1.5.0: {}
@@ -8675,7 +8669,7 @@ snapshots:
       ai: 7.0.66(zod@4.4.3)
       cacheable: 2.5.0
       hashery: 3.0.1
-      hookified: 3.0.2
+      hookified: 3.0.3
       html-react-parser: 6.1.7(react@19.2.7)
       js-yaml: 5.2.2
       react: 19.2.7

--- a/storage/memcache/package.json
+++ b/storage/memcache/package.json
@@ -50,7 +50,7 @@
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
 		"hookified": "^3.0.3",
-		"memcache": "^1.9.0"
+		"memcache": "^1.10.0"
 	},
 	"peerDependencies": {
 		"keyv": "workspace:^"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Bump `memcache` in `@keyv/memcache` from 1.9.0 to 1.10.0. Minor release of the Memcache client used by the adapter.

## Changes
- Upgrade `memcache` `^1.9.0` → `^1.10.0` and refresh the lockfile (transitive `hashery` 3.0.0 → 3.0.1 via `memcache`)

## Artifact diffs
- [memcache 1.9.0 → 1.10.0](https://drydock.org/diff/memcache/1.9.0/1.10.0)

## Verification
- [x] `pnpm --filter keyv --filter @keyv/test-suite --filter @keyv/compress-gzip --filter @keyv/memcache build`
- [x] `@keyv/memcache` `lint:ci` (2 files)
- [x] GitHub Actions `tests` node-22/24/26 passed (Memcached service in CI)
- Sandbox has no Docker daemon; full adapter suite needs Memcached on `:11211`

## Breaking notes
None. Minor bump within the existing `^1` range.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4f981e6-7e76-4b5a-9a50-8cb10cd46f7d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4f981e6-7e76-4b5a-9a50-8cb10cd46f7d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

