### PR TITLE
mongo - chore: upgrade mongodb

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -425,8 +425,8 @@ importers:
         specifier: workspace:^
         version: link:../../core/keyv
       mongodb:
-        specifier: ^7.5.0
-        version: 7.5.0
+        specifier: ^7.6.0
+        version: 7.6.0
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.5.11
@@ -3647,8 +3647,8 @@ packages:
     resolution: {integrity: sha512-ZoS07RoFqpKYQwAk59qmrx8+jJHNHU30UjlU96QktiGn1ltvDr+vCznLX5DiUBLEpMAHatHNWV1nM/74ul66kA==}
     engines: {node: '>=20.19.0'}
 
-  mongodb@7.5.0:
-    resolution: {integrity: sha512-5FnrEDLnvp6ycUOGLNLLU33BfCx2qmp2mJjGPDwKLruYsVzXVSK5fsGpoDXvsXJwBfBsD7ebMRdawbDxC2814g==}
+  mongodb@7.6.0:
+    resolution: {integrity: sha512-WbZ6OCjYw2c53LOjfkQa+reXr7kIiOVpXXglnASFuiMtif0BvsMwHe3ClJHLm1/r7wJFwaasfFtD6iYIktB01g==}
     engines: {node: '>=20.19.0'}
     peerDependencies:
       '@aws-sdk/credential-providers': ^3.806.0
@@ -7587,7 +7587,7 @@ snapshots:
       '@types/whatwg-url': 13.0.0
       whatwg-url: 14.2.0
 
-  mongodb@7.5.0:
+  mongodb@7.6.0:
     dependencies:
       '@mongodb-js/saslprep': 1.4.13
       bson: 7.2.0

--- a/storage/mongo/package.json
+++ b/storage/mongo/package.json
@@ -51,7 +51,7 @@
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
 		"hookified": "^3.0.3",
-		"mongodb": "^7.5.0"
+		"mongodb": "^7.6.0"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.5.11",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Bump `mongodb` in `@keyv/mongo` from 7.5.0 to 7.6.0. Minor release of the MongoDB driver used by the adapter.

## Changes
- Upgrade `mongodb` `^7.5.0` → `^7.6.0` and refresh the lockfile

## Artifact diffs
- [mongodb 7.5.0 → 7.6.0](https://drydock.org/diff/mongodb/7.5.0/7.6.0)

## Verification
- [x] `pnpm --filter keyv --filter @keyv/test-suite --filter @keyv/mongo build`
- [x] `@keyv/mongo` `lint:ci` (3 files)
- [x] GitHub Actions `tests` node-22/24/26 passed (MongoDB service in CI; `@keyv/mongo` 139 passed)
- Sandbox has no Docker daemon; full adapter suite needs MongoDB on `:27017`

## Breaking notes
None. Minor bump within the existing `^7` range.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4f981e6-7e76-4b5a-9a50-8cb10cd46f7d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4f981e6-7e76-4b5a-9a50-8cb10cd46f7d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

