### PR TITLE
mysql - chore: upgrade mysql2

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -456,8 +456,8 @@ importers:
         specifier: ^3.0.3
         version: 3.0.3
       mysql2:
-        specifier: ^3.23.2
-        version: 3.23.2(@types/node@24.13.1)
+        specifier: ^3.24.2
+        version: 3.24.2(@types/node@24.13.1)
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.5.11
@@ -3130,8 +3130,8 @@ packages:
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
 
-  iconv-lite@0.7.2:
-    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+  iconv-lite@0.7.3:
+    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
     engines: {node: '>=0.10.0'}
 
   ignore@5.3.2:
@@ -3684,8 +3684,8 @@ packages:
   msgpackr@2.0.5:
     resolution: {integrity: sha512-cef05H/dSYpLpqp3sj/qyZh5vhUYCalnaLO7j1yOmpsR0y/XwLVtK7r5gn+U/F7CTEfMowcGhlUQJDLcLf7jcA==}
 
-  mysql2@3.23.2:
-    resolution: {integrity: sha512-fxh3HpQ8vJtu/Mmnd4Xsur19jGjHGzRLMxptiDtOkbX7EVBgnafGSGDx1WGGVmJLClVh2LeeBMMo24IFv8wCyQ==}
+  mysql2@3.24.2:
+    resolution: {integrity: sha512-l9kXeKGwd6VCbSjmpO/bLWb+YCYpbvE4whte8ec6InXebvCNyEEydyRCnRU+TSHNqRLJ8B+Tk1uWb+vMCJgJzA==}
     engines: {node: '>= 8.0'}
     peerDependencies:
       '@types/node': '>= 8'
@@ -6778,7 +6778,7 @@ snapshots:
 
   http-cache-semantics@4.2.0: {}
 
-  iconv-lite@0.7.2:
+  iconv-lite@0.7.3:
     dependencies:
       safer-buffer: 2.1.2
 
@@ -7611,13 +7611,12 @@ snapshots:
     optionalDependencies:
       msgpackr-extract: 3.0.4
 
-  mysql2@3.23.2(@types/node@24.13.1):
+  mysql2@3.24.2(@types/node@24.13.1):
     dependencies:
       '@types/node': 24.13.1
       aws-ssl-profiles: 1.1.2
-      denque: 2.1.0
       generate-function: 2.3.1
-      iconv-lite: 0.7.2
+      iconv-lite: 0.7.3
       long: 5.3.2
       lru.min: 1.1.4
       named-placeholders: 1.1.6

--- a/storage/mysql/package.json
+++ b/storage/mysql/package.json
@@ -52,7 +52,7 @@
 	"homepage": "https://github.com/jaredwray/keyv",
 	"dependencies": {
 		"hookified": "^3.0.3",
-		"mysql2": "^3.23.2"
+		"mysql2": "^3.24.2"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.5.11",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Bump `mysql2` in `@keyv/mysql` from 3.23.2 to 3.24.2. Minor release of the MySQL driver used by the adapter.

## Changes
- Upgrade `mysql2` `^3.23.2` → `^3.24.2` and refresh the lockfile (transitive `iconv-lite` 0.7.2 → 0.7.3; `denque` no longer pulled by this version)

## Artifact diffs
- [mysql2 3.23.2 → 3.24.2](https://drydock.org/diff/mysql2/3.23.2/3.24.2)

## Verification
- [x] `pnpm --filter keyv --filter @keyv/test-suite --filter @keyv/mysql build`
- [x] `@keyv/mysql` `lint:ci` (5 files)
- [x] GitHub Actions `tests` node-22/24/26 passed (MySQL service in CI; `@keyv/mysql` 156 passed)
- Sandbox has no Docker daemon; full adapter suite needs MySQL

## Breaking notes
None. Minor bump within the existing `^3` range.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4f981e6-7e76-4b5a-9a50-8cb10cd46f7d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4f981e6-7e76-4b5a-9a50-8cb10cd46f7d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

