### PR TITLE
mono - chore: pin Docker postgres service image

### DIFF
--- a/scripts/docker-compose-arm64.yaml
+++ b/scripts/docker-compose-arm64.yaml
@@ -1,6 +1,6 @@
 services:
   keyv_postgres:
-    image: postgres:latest
+    image: postgres:18.6-trixie@sha256:4ef4dbc939d61acea57712655ddb4b4ab27419c913f94cca0cd57cb3ea3c2280
     command: postgres -c 'max_connections=200'
     environment:
       POSTGRES_DB: keyv_test

--- a/scripts/docker-compose.yaml
+++ b/scripts/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   keyv_postgres:
-    image: postgres:latest
+    image: postgres:18.6-trixie@sha256:4ef4dbc939d61acea57712655ddb4b4ab27419c913f94cca0cd57cb3ea3c2280
     command: postgres -c 'max_connections=200'
     environment:
       POSTGRES_DB: keyv_test

--- a/storage/postgres/Dockerfile.ssl
+++ b/storage/postgres/Dockerfile.ssl
@@ -1,4 +1,4 @@
-FROM postgres:latest
+FROM postgres:18.6-trixie@sha256:4ef4dbc939d61acea57712655ddb4b4ab27419c913f94cca0cd57cb3ea3c2280
 
 RUN mkdir -p /keyv_postgres_ssl
 COPY ./tls/server.key /keyv_postgres_ssl


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Pin the floating `postgres:latest` test-service image to `postgres:18.6-trixie` at the multi-arch index digest. Same lineage as Hub `latest` today (PostgreSQL 18.6 on Debian trixie). Image created 2026-08-25, past the 7-day age gate.

`keyv_postgres_1` builds from `storage/postgres/Dockerfile.ssl`, so the SSL fixture uses the same pin.

## Changes
- Pin `postgres:latest` → `postgres:18.6-trixie@sha256:4ef4dbc939d61acea57712655ddb4b4ab27419c913f94cca0cd57cb3ea3c2280` in `scripts/docker-compose.yaml`, `scripts/docker-compose-arm64.yaml`, and `storage/postgres/Dockerfile.ssl`

## Verification
- [x] `crane digest` / `crane config` — index digest matches `latest`/`18`/`18.6`/`18.6-trixie`; `Created` 2026-08-25T00:41:16Z (≥ 7 days)
- [x] PyYAML parse of both Compose files
- [x] GitHub Actions `tests` node-22/24/26, bun, browser, codecov, CodeQL, zizmor, Socket — first `codecov/project` miss was two hits in `core/keyv` iterator expiry (unrelated to this pin); green after empty-commit retrigger
- Sandbox has no Docker daemon — could not `docker build` `Dockerfile.ssl` locally; CI built the SSL fixture and ran `@keyv/postgres` (163 tests, 100% package coverage)

## Breaking notes
None. First digest pin of the existing floating `latest` tag (already PostgreSQL 18), not a major bump from a pinned older major.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4f981e6-7e76-4b5a-9a50-8cb10cd46f7d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4f981e6-7e76-4b5a-9a50-8cb10cd46f7d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

