### PR TITLE
mono - chore: pin Docker mysql service image

### DIFF
--- a/scripts/docker-compose-arm64.yaml
+++ b/scripts/docker-compose-arm64.yaml
@@ -20,7 +20,7 @@ services:
     ports:
       - 5433:5432/tcp
   keyv_mysql:
-    image: mysql/mysql-server:latest
+    image: mysql/mysql-server:8.0.32@sha256:d6c8301b7834c5b9c2b733b10b7e630f441af7bc917c74dba379f24eeeb6a313
     command: [ "mysqld",
                "--character-set-server=utf8mb4",
                "--collation-server=utf8mb4_unicode_ci",
@@ -35,7 +35,7 @@ services:
       MYSQL_USER: mysql
       MYSQL_ROOT_HOST: '%'
   keyv_mysql_1:
-    image: "mysql/mysql-server:latest"
+    image: "mysql/mysql-server:8.0.32@sha256:d6c8301b7834c5b9c2b733b10b7e630f441af7bc917c74dba379f24eeeb6a313"
     command: [ "mysqld",
                "--character-set-server=utf8mb4",
                "--collation-server=utf8mb4_unicode_ci",

--- a/scripts/docker-compose.yaml
+++ b/scripts/docker-compose.yaml
@@ -20,7 +20,7 @@ services:
     ports:
       - 5433:5432/tcp
   keyv_mysql:
-    image: mysql/mysql-server:latest
+    image: mysql/mysql-server:8.0.32@sha256:d6c8301b7834c5b9c2b733b10b7e630f441af7bc917c74dba379f24eeeb6a313
     command: [ "mysqld",
                "--character-set-server=utf8mb4",
                "--collation-server=utf8mb4_unicode_ci",
@@ -35,7 +35,7 @@ services:
       MYSQL_USER: mysql
       MYSQL_ROOT_HOST: '%'
   keyv_mysql_1:
-    image: "mysql/mysql-server:latest"
+    image: "mysql/mysql-server:8.0.32@sha256:d6c8301b7834c5b9c2b733b10b7e630f441af7bc917c74dba379f24eeeb6a313"
     command: [ "mysqld",
                "--character-set-server=utf8mb4",
                "--collation-server=utf8mb4_unicode_ci",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Pin the floating `mysql/mysql-server:latest` test-service image to `mysql/mysql-server:8.0.32` at the multi-arch index digest. Same lineage as Hub `latest` / `8.0` today. Image created 2023-01-18, past the 7-day age gate.

This Hub repo stopped publishing after 8.0.32, so the pin freezes current `latest` rather than moving to `docker.io/library/mysql` (a different image, and a possible major).

## Changes
- Pin `mysql/mysql-server:latest` → `mysql/mysql-server:8.0.32@sha256:d6c8301b7834c5b9c2b733b10b7e630f441af7bc917c74dba379f24eeeb6a313` for `keyv_mysql` and `keyv_mysql_1` in `scripts/docker-compose.yaml` and `scripts/docker-compose-arm64.yaml`

## Verification
- [x] `crane digest` / `crane config` — index digest matches `latest`/`8.0`/`8.0.32`; `Created` 2023-01-18T06:00:30Z (≥ 7 days)
- [x] PyYAML parse of both Compose files
- [x] GitHub Actions `tests` node-22/24/26, bun, browser, codecov (100%), CodeQL, zizmor, Socket
- Sandbox has no Docker daemon — could not start MySQL locally; CI ran `@keyv/mysql` via `pnpm test:services:start`

## Breaking notes
None. First digest pin of the existing floating `latest` tag (already MySQL 8.0.32), not a major bump.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4f981e6-7e76-4b5a-9a50-8cb10cd46f7d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4f981e6-7e76-4b5a-9a50-8cb10cd46f7d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

