### PR TITLE
mono - chore: pin Docker valkey service image

### DIFF
--- a/scripts/docker-compose-arm64.yaml
+++ b/scripts/docker-compose-arm64.yaml
@@ -57,7 +57,7 @@ services:
       MYSQL_DATABASE: keyv_test
       MYSQL_ROOT_HOST: '%'
   keyv_valkey:
-    image: valkey/valkey:latest
+    image: valkey/valkey:9.1.0-trixie@sha256:8e8d64b405ce18f41b8e5ee20aa4687a8ed0022d1298f2ce31cdcf3a76e09411
     command: redis-server --port 6370
     environment:
       REDIS_HOST: redis

--- a/scripts/docker-compose.yaml
+++ b/scripts/docker-compose.yaml
@@ -57,7 +57,7 @@ services:
       MYSQL_DATABASE: keyv_test
       MYSQL_ROOT_HOST: '%'
   keyv_valkey:
-    image: valkey/valkey:latest
+    image: valkey/valkey:9.1.0-trixie@sha256:8e8d64b405ce18f41b8e5ee20aa4687a8ed0022d1298f2ce31cdcf3a76e09411
     command: redis-server --port 6370
     environment:
       REDIS_HOST: redis


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Pin the floating `valkey/valkey:latest` test-service image to `valkey/valkey:9.1.0-trixie` at the multi-arch index digest.

Hub `latest` is currently Valkey 9.1.2 (created 2026-09-03, 2 days old) and `9.1.1` is 5 days old — both fail the 7-day age gate. `9.1.0-trixie` (created 2026-07-14) is the newest 9.1 debian image that qualifies.

## Changes
- Pin `valkey/valkey:latest` → `valkey/valkey:9.1.0-trixie@sha256:8e8d64b405ce18f41b8e5ee20aa4687a8ed0022d1298f2ce31cdcf3a76e09411` in `scripts/docker-compose.yaml` and `scripts/docker-compose-arm64.yaml`

## Verification
- [x] `crane digest` / `crane config` — walked 9.1 debian lineage; pin is `9.1.0`/`9.1.0-trixie`; `Created` 2026-07-14T22:47:26Z (≥ 7 days)
- [x] PyYAML parse of both Compose files
- [x] GitHub Actions `tests` node-22/24/26, bun, browser, codecov (100%), CodeQL, zizmor, Socket
- Sandbox has no Docker daemon — could not start Valkey locally; CI ran `@keyv/valkey` via `pnpm test:services:start`

## Breaking notes
None. First digest pin within Valkey 9 / debian trixie. Not a major bump.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4f981e6-7e76-4b5a-9a50-8cb10cd46f7d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4f981e6-7e76-4b5a-9a50-8cb10cd46f7d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

