### PR TITLE
mono - chore: pin Docker mongo service image

### DIFF
--- a/scripts/docker-compose-arm64.yaml
+++ b/scripts/docker-compose-arm64.yaml
@@ -79,7 +79,7 @@ services:
     volumes:
       - ../storage/redis/tls:/tls
   keyv_mongo:
-    image: mongo:latest
+    image: mongo:8.3.8@sha256:5211c51171f57ae60842b11664bb244628971b3d35325762a97888337b9bb0db
     restart: always
     ports:
       - 27017:27017

--- a/scripts/docker-compose.yaml
+++ b/scripts/docker-compose.yaml
@@ -79,7 +79,7 @@ services:
     volumes:
       - ../storage/redis/tls:/tls
   keyv_mongo:
-    image: mongo:latest
+    image: mongo:8.3.8@sha256:5211c51171f57ae60842b11664bb244628971b3d35325762a97888337b9bb0db
     restart: always
     ports:
       - 27017:27017


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Pin the floating `mongo:latest` test-service image to `mongo:8.3.8` at the multi-arch index digest. Same lineage as Hub `latest` / `8` / `8.3` today (MongoDB 8.3.8). Image created 2026-08-18, past the 7-day age gate.

`mongo:8.3.8-noble` is a linux-only index with the same linux blobs but a different digest; this pin matches current `latest` (linux + Windows entries).

## Changes
- Pin `mongo:latest` → `mongo:8.3.8@sha256:5211c51171f57ae60842b11664bb244628971b3d35325762a97888337b9bb0db` in `scripts/docker-compose.yaml` and `scripts/docker-compose-arm64.yaml`

## Verification
- [x] `crane digest` / `crane config` — index digest matches `latest`/`8`/`8.3`/`8.3.8`; `Created` 2026-08-18T19:24:32Z (≥ 7 days)
- [x] PyYAML parse of both Compose files
- [x] GitHub Actions `tests` node-22/24/26, bun, browser, codecov (100%), CodeQL, zizmor, Socket
- Sandbox has no Docker daemon — could not start MongoDB locally; CI ran `@keyv/mongo` via `pnpm test:services:start`

## Breaking notes
None. First digest pin of the existing floating `latest` tag (already MongoDB 8.3.8), not a major bump.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4f981e6-7e76-4b5a-9a50-8cb10cd46f7d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4f981e6-7e76-4b5a-9a50-8cb10cd46f7d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

