### PR TITLE
mono - chore: pin Docker memcached service image

### DIFF
--- a/scripts/docker-compose-arm64.yaml
+++ b/scripts/docker-compose-arm64.yaml
@@ -84,7 +84,7 @@ services:
     ports:
       - 27017:27017
   keyv_memcached:
-    image: memcached:latest
+    image: memcached:1.6.45-trixie@sha256:75c93cc91e76853da7c029e74d6e8dbd44774dd3713c93be8cd1971ad26120a4
     ports:
       - "11211:11211"
   keyv_etcd:

--- a/scripts/docker-compose.yaml
+++ b/scripts/docker-compose.yaml
@@ -84,7 +84,7 @@ services:
     ports:
       - 27017:27017
   keyv_memcached:
-    image: memcached:latest
+    image: memcached:1.6.45-trixie@sha256:75c93cc91e76853da7c029e74d6e8dbd44774dd3713c93be8cd1971ad26120a4
     ports:
       - "11211:11211"
   keyv_etcd:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Pin the floating `memcached:latest` test-service image to `memcached:1.6.45-trixie` at the multi-arch index digest. Same lineage as Hub `latest` / `1` / `1.6` today (Memcached 1.6.45 on Debian trixie). Image created 2026-08-25, past the 7-day age gate.

## Changes
- Pin `memcached:latest` → `memcached:1.6.45-trixie@sha256:75c93cc91e76853da7c029e74d6e8dbd44774dd3713c93be8cd1971ad26120a4` in `scripts/docker-compose.yaml` and `scripts/docker-compose-arm64.yaml`

## Verification
- [x] `crane digest` / `crane config` — index digest matches `latest`/`1`/`1.6`/`1.6.45`/`1.6.45-trixie`; `Created` 2026-08-25T00:24:50Z (≥ 7 days)
- [x] PyYAML parse of both Compose files
- [ ] GitHub Actions (Compose consumed by `pnpm test:services:start`)
- Sandbox has no Docker daemon — could not start Memcached or run `@keyv/memcache` adapter tests locally

## Breaking notes
None. First digest pin of the existing floating `latest` tag (already Memcached 1.6.45), not a major bump.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4f981e6-7e76-4b5a-9a50-8cb10cd46f7d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4f981e6-7e76-4b5a-9a50-8cb10cd46f7d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

