### PR TITLE
mono - chore: pin Docker etcd service image

### DIFF
--- a/scripts/docker-compose-arm64.yaml
+++ b/scripts/docker-compose-arm64.yaml
@@ -88,7 +88,7 @@ services:
     ports:
       - "11211:11211"
   keyv_etcd:
-    image: registry.k8s.io/etcd:3.6.12-0
+    image: registry.k8s.io/etcd:3.6.14-0@sha256:a491baeaa0cb0c9cd89c0062ac44ece53886e3e5bddad18d2daf36678ce665b6
     platform: linux/arm64/v8
     command:
       - etcd

--- a/scripts/docker-compose.yaml
+++ b/scripts/docker-compose.yaml
@@ -88,7 +88,7 @@ services:
     ports:
       - "11211:11211"
   keyv_etcd:
-    image: registry.k8s.io/etcd:3.6.12-0
+    image: registry.k8s.io/etcd:3.6.14-0@sha256:a491baeaa0cb0c9cd89c0062ac44ece53886e3e5bddad18d2daf36678ce665b6
     command:
       - etcd
       - --listen-client-urls=http://0.0.0.0:2379


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Pin and refresh the etcd test-service image from `registry.k8s.io/etcd:3.6.12-0` (no digest) to `3.6.14-0` at the multi-arch index digest. Newest 3.6 lineage tag that passes the 7-day age gate (created 2026-07-23).

etcd 3.7.x exists on the registry; that is a major and is not included.

## Changes
- Pin `registry.k8s.io/etcd:3.6.12-0` → `registry.k8s.io/etcd:3.6.14-0@sha256:a491baeaa0cb0c9cd89c0062ac44ece53886e3e5bddad18d2daf36678ce665b6` in `scripts/docker-compose.yaml` and `scripts/docker-compose-arm64.yaml`

## Verification
- [x] `crane digest` / `crane config` — `3.6.14-0` created 2026-07-23T12:21:52-07:00 (≥ 7 days); `3.6.13-0` and `3.6.12-0` are older in the same lineage
- [x] PyYAML parse of both Compose files
- [ ] GitHub Actions (Compose consumed by `pnpm test:services:start`)
- Sandbox has no Docker daemon — could not start etcd or run `@keyv/etcd` adapter tests locally

## Breaking notes
None. Patch bump within etcd 3.6 plus first digest pin. Not a 3.7 major.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4f981e6-7e76-4b5a-9a50-8cb10cd46f7d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4f981e6-7e76-4b5a-9a50-8cb10cd46f7d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

