### PR TITLE
mono - chore: pin Docker dynamodb-local service image

### DIFF
--- a/scripts/docker-compose-arm64.yaml
+++ b/scripts/docker-compose-arm64.yaml
@@ -98,7 +98,7 @@ services:
       - 2379:2379
       - 2380:2380
   keyv_dynamo:
-    image: amazon/dynamodb-local:latest
+    image: amazon/dynamodb-local:3.3.1@sha256:ff89bd48ff32cd8d9be5fee8873b65b8854dc408f1afe881be6eb00247bc0dab
     ports:
       - 8000:8000
     healthcheck:

--- a/scripts/docker-compose.yaml
+++ b/scripts/docker-compose.yaml
@@ -97,7 +97,7 @@ services:
       - 2379:2379
       - 2380:2380
   keyv_dynamo:
-    image: amazon/dynamodb-local:latest
+    image: amazon/dynamodb-local:3.3.1@sha256:ff89bd48ff32cd8d9be5fee8873b65b8854dc408f1afe881be6eb00247bc0dab
     ports:
       - 8000:8000
     healthcheck:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Pin the floating `amazon/dynamodb-local:latest` test-service image to `amazon/dynamodb-local:3.3.1` at the multi-arch index digest. Same lineage as Hub `latest` today. Image created 2026-07-31, past the 7-day age gate.

This is the last Compose service image still on a floating `latest` tag.

## Changes
- Pin `amazon/dynamodb-local:latest` → `amazon/dynamodb-local:3.3.1@sha256:ff89bd48ff32cd8d9be5fee8873b65b8854dc408f1afe881be6eb00247bc0dab` in `scripts/docker-compose.yaml` and `scripts/docker-compose-arm64.yaml`

## Verification
- [x] `crane digest` / `crane config` — index digest matches `latest`/`3.3.1`; `Created` 2026-07-31T16:47:51Z (≥ 7 days)
- [x] PyYAML parse of both Compose files
- [x] GitHub Actions `tests` node-22/24/26, bun, browser, codecov (100%), CodeQL, zizmor, Socket
- Sandbox has no Docker daemon — could not start DynamoDB Local locally; CI ran `@keyv/dynamo` via `pnpm test:services:start`

## Breaking notes
None. First digest pin of the existing floating `latest` tag (already DynamoDB Local 3.3.1), not a major bump from a pinned older major.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4f981e6-7e76-4b5a-9a50-8cb10cd46f7d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4f981e6-7e76-4b5a-9a50-8cb10cd46f7d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

