### PR TITLE
mono - chore: defense - cover /.vscode/ in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,7 @@
 # High-risk paths. Last matching pattern wins.
 # Root-anchored so nested copies (e.g. skills/**/scripts/) are not owned here.
 /.github/ @jaredwray
+/.vscode/ @jaredwray
 /.cursor/ @jaredwray
 /.devcontainer/ @jaredwray
 /scripts/ @jaredwray

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -9,8 +9,10 @@ Profile: npm library · public
 - [x] `DEFENSE_IN_DEPTH.md` present (this file) — PR #2053
 
 ## 2. CODEOWNERS and cloud bootstrap
-- [x] `.github/CODEOWNERS` covers `/.github/`, `/.cursor/`, `/.devcontainer/`, `/scripts/` with owners the maintainer names — PR #2059
+- [ ] VS Code / Cursor `task.allowAutomaticTasks` is `off` or `prompt` in User settings (global, not workspace) (manual)
+- [ ] `.github/CODEOWNERS` covers `/.github/`, `/.vscode/`, `/.cursor/`, `/.devcontainer/`, `/scripts/` with owners the maintainer names (PR pending)
 - [x] Codespaces and Cursor Cloud Agents bootstrap Aikido Safe Chain via scripts/setup-cloud-environment.sh (--ci shims, frozen lockfile) — PR #2054
+- [x] Dev Container `image` pinned by digest (`name:<tag>@sha256:<digest>`; not a floating tag) — PR #2082
 
 ## 3. Dependencies (pnpm)
 - [x] `packageManager: pnpm@11.3+` pinned in `package.json` — verified 2026-08-24

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -10,7 +10,7 @@ Profile: npm library · public
 
 ## 2. CODEOWNERS and cloud bootstrap
 - [ ] VS Code / Cursor `task.allowAutomaticTasks` is `off` or `prompt` in User settings (global, not workspace) (manual)
-- [ ] `.github/CODEOWNERS` covers `/.github/`, `/.vscode/`, `/.cursor/`, `/.devcontainer/`, `/scripts/` with owners the maintainer names (PR pending)
+- [ ] `.github/CODEOWNERS` covers `/.github/`, `/.vscode/`, `/.cursor/`, `/.devcontainer/`, `/scripts/` with owners the maintainer names (PR #2102 pending)
 - [x] Codespaces and Cursor Cloud Agents bootstrap Aikido Safe Chain via scripts/setup-cloud-environment.sh (--ci shims, frozen lockfile) — PR #2054
 - [x] Dev Container `image` pinned by digest (`name:<tag>@sha256:<digest>`; not a floating tag) — PR #2082
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,9 +29,10 @@ hardening checklist; progress is tracked in [DEFENSE_IN_DEPTH.md](./DEFENSE_IN_D
 - pnpm is pinned via `packageManager` (`pnpm@11.25.0`).
 - Dependencies install through pnpm with a 7-day cooldown on new versions, lifecycle scripts blocked by default, and `trustPolicy: no-downgrade`.
 - The lockfile is committed and CI installs with `--frozen-lockfile`. There is no Dependabot config; dependency updates go through reviewed PRs.
-- CI runs with read-only permissions (only the release job gets `id-token: write`); every action is pinned to a full commit SHA; Socket Firewall (`sfw`) wraps `pnpm install` / `npm install`; workflows are security-linted with zizmor on every PR.
+- CI runs with read-only permissions (only jobs whose purpose is mutating the repo get `contents: write`); generated output is an artifact, never committed back; every action is pinned to a full commit SHA; Socket Firewall (`sfw`) wraps `pnpm install` / `npm install`; workflows are security-linted with zizmor on every PR.
 - Workflows do not use `pull_request_target`.
-- npm releases are staged, never published directly: CI stages via stage-only OIDC trusted publishing after an Aikido `scan-release` gate, Drydock reviews the staged artifact, and a maintainer promotes it with 2FA. There are no npm tokens.
+- npm releases are staged, never published directly: CI stages via stage-only OIDC trusted publishing after an Aikido `scan-release` gate, Drydock reviews the staged artifact, and a maintainer promotes it with 2FA. There are no npm publish tokens.
 - Published packages set `repository.url` to this repo so provenance can map back.
 - Socket reviews every pull request that changes dependencies; Aikido scans every build.
 - Codespaces and Cursor Cloud Agents install through Aikido Safe Chain; package-manager shims must not be bypassed.
+- The Codespaces Dev Container image is pinned by digest (`name:<tag>@sha256:<digest>`), not a floating tag.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Cover `/.vscode/` in `.github/CODEOWNERS` so a later `tasks.json` (including silent `folderOpen` tasks) cannot land without a CODEOWNERS review. Catalog § 2.

## Status
`DEFENSE_IN_DEPTH.md`: CODEOWNERS `/.vscode/` → `(PR #2102 pending)`. Dev Container digest pin reconciled as done (PR #2082). VS Code / Cursor `task.allowAutomaticTasks` stays `(manual)`.

## Changes
- Add `/.vscode/ @jaredwray` to `.github/CODEOWNERS` (directory does not exist yet; cover it anyway)
- Refresh `DEFENSE_IN_DEPTH.md` to the current defense-in-depth-nodejs catalog
- Add the live Dev Container digest-pin bullet to `SECURITY.md`; say “no npm publish tokens” instead of “no npm tokens”

## Verification
- [x] CODEOWNERS lists `/.github/`, `/.vscode/`, `/.cursor/`, `/.devcontainer/`, `/scripts/` with `@jaredwray`
- [x] No `.vscode/**/tasks.json` (`folderOpen` grep empty)
- [x] Dev Container `image` already digest-pinned (`javascript-node:5.1.2-24-trixie@sha256:757b2296…`)
- [x] GitHub Actions green on `f39fecc5` — tests node-22/24/26, bun, browser, codecov/project, CodeQL, zizmor, Socket PR alerts

## Manual (not this PR)
Set **Task: Allow Automatic Tasks In Folder** to `off` or `prompt` in **User** settings (workspace is ignored). Then tick that line in `DEFENSE_IN_DEPTH.md`.

Reference: `defense-in-depth-nodejs` § 2
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4f981e6-7e76-4b5a-9a50-8cb10cd46f7d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4f981e6-7e76-4b5a-9a50-8cb10cd46f7d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

