### PR TITLE
redis - fix: share in-flight connect so concurrent ops are not dropped

### DIFF
--- a/storage/redis/README.md
+++ b/storage/redis/README.md
@@ -221,7 +221,7 @@ const keyv = createKeyv('redis://user:pass@localhost:6379', {namespace: 'my-name
 
 # Using the `createKeyvNonBlocking` function
 
-The `createKeyvNonBlocking` function is a convenience function that creates a new `Keyv` instance with the `@keyv/redis` store does what `createKeyv` does but also disables throwing errors, removes the offline queue redis functionality, and reconnect strategy so that when used as a secondary cache in libraries such as [cacheable](https://npmjs.org/package/cacheable) it does not block the primary cache. This is useful when you want to use Redis as a secondary cache and do not want to block the primary cache on connection errors or timeouts when using `nonBlocking`. Here is an example of how to use it:
+The `createKeyvNonBlocking` function is a convenience function that creates a new `Keyv` instance with the `@keyv/redis` store does what `createKeyv` does but also disables throwing errors, removes the offline queue redis functionality, and reconnect strategy so that when used as a secondary cache in libraries such as [cacheable](https://npmjs.org/package/cacheable) it does not block the primary cache. This is useful when you want to use Redis as a secondary cache and do not want to block the primary cache on connection errors or timeouts when using `nonBlocking`. Concurrent operations share the in-flight Redis connect so they are not dropped while the client is still opening. Here is an example of how to use it:
 
 ```js
 import { createKeyvNonBlocking } from '@keyv/redis';
@@ -528,7 +528,7 @@ const keyv = new Keyv({ store: new KeyvRedis(tlsOptions) });
 
 ## Methods
 * **constructor([connect], [options])** - `connect` is a URI string, client/cluster/sentinel options (`KeyvRedisConnect`), or an existing connection. See [Keyv Redis Options](#keyv-redis-options).
-* **getClient()** - Return the connected client, connecting first if needed. Returns `Promise<RedisClientConnectionType>`.
+* **getClient()** - Return the ready client, connecting first if needed. Concurrent callers share the in-flight connect and wait until `isReady` (not only `isOpen`). Returns `Promise<RedisClientConnectionType>`.
 * **set(key, value, [expires])** - Set a key. `expires` is an absolute Unix timestamp in milliseconds. Returns `Promise<boolean>`. Through Keyv, pass a relative millisecond `ttl` to `keyv.set` — Keyv converts it to `expires`.
 * **setMany(entries)** - Set `KeyvStorageEntry` objects (`{ key, value, expires? }`) via `MULTI/EXEC`. Returns `Promise<boolean[]>` (per-entry success). Cluster mode groups by hash slot.
 * **get(key)** - Get a key. Returns the value or `undefined` if missing (Redis `null` is mapped to `undefined`).
@@ -548,7 +548,7 @@ const keyv = new Keyv({ store: new KeyvRedis(tlsOptions) });
 
 ## Helpers
 * **createKeyv([connect], [options])** - Keyv instance with this adapter. Applies `namespace` on both Keyv and the store. `connect` accepts the same `KeyvRedisConnect` types as the constructor (including cluster/sentinel). Defaults to `"redis://localhost:6379"` when `connect` is omitted.
-* **createKeyvNonBlocking([connect], [options])** - Same as `createKeyv`, then disables throws, the offline queue, and reconnect for secondary-cache use.
+* **createKeyvNonBlocking([connect], [options])** - Same as `createKeyv`, then disables throws, the offline queue, and reconnect for secondary-cache use. Concurrent operations wait for the shared in-flight connect instead of being dropped.
 * **defaultReconnectStrategy(attempts)** - Default socket reconnect delay when a URI string is passed to the constructor. Exponential backoff capped at 2s, plus up to ±50ms of jitter. Returns a delay in milliseconds.
 
 # Events

--- a/storage/redis/src/index.ts
+++ b/storage/redis/src/index.ts
@@ -120,6 +120,11 @@ export default class KeyvRedis<T> extends Hookified implements KeyvStorageAdapte
 	 * repeated initialization does not attach duplicate listeners.
 	 */
 	private _eventsWiredClient: RedisClientConnectionType | undefined;
+	/**
+	 * In-flight `connect()` / wait-until-ready so concurrent `getClient()` callers
+	 * share one attempt instead of returning a not-yet-ready client.
+	 */
+	private _connectPromise: Promise<RedisClientConnectionType> | undefined;
 
 	/**
 	 * Stable `error` listener so it can be removed when the underlying client is replaced.
@@ -225,6 +230,7 @@ export default class KeyvRedis<T> extends Hookified implements KeyvStorageAdapte
 	 * @param {RedisClientConnectionType} value - The Redis client connection to use.
 	 */
 	public set client(value: RedisClientConnectionType) {
+		this._connectPromise = undefined;
 		this._client = value;
 		this._pxatSupported = undefined;
 		this.initClient();
@@ -387,21 +393,55 @@ export default class KeyvRedis<T> extends Hookified implements KeyvStorageAdapte
 
 	/**
 	 * Get the connected Redis client. Connects first if the client is not already
-	 * connected, respecting `connectionTimeout`. On failure, emits `error` and, when
-	 * `throwOnConnectError` is true, throws {@link RedisErrorMessages.RedisClientNotConnectedThrown}.
+	 * ready, respecting `connectionTimeout`. Concurrent callers share the in-flight
+	 * connect so commands are not issued while `isOpen && !isReady` (which rejects
+	 * with `ClientOfflineError` when the offline queue is disabled). On failure,
+	 * emits `error` and, when `throwOnConnectError` is true, throws
+	 * {@link RedisErrorMessages.RedisClientNotConnectedThrown}.
 	 * @returns {Promise<RedisClientConnectionType>} The connected Redis client, cluster, or sentinel.
 	 * @throws {Error} When connect fails and `throwOnConnectError` is true.
 	 */
 	public async getClient(): Promise<RedisClientConnectionType> {
-		if (this._client.isOpen) {
+		if (this._client.isReady) {
 			return this._client;
 		}
 
+		if (this._connectPromise) {
+			return this._connectPromise;
+		}
+
+		const attempt = this.connectClient().finally(() => {
+			if (this._connectPromise === attempt) {
+				this._connectPromise = undefined;
+			}
+		});
+		this._connectPromise = attempt;
+		return attempt;
+	}
+
+	/**
+	 * Connect the current client, or wait until an already-open client becomes ready.
+	 * Concurrent `getClient()` callers share this promise via `_connectPromise`.
+	 * @returns {Promise<RedisClientConnectionType>} The client after connect succeeds or is swallowed.
+	 * @throws {Error} When connect fails and `throwOnConnectError` is true.
+	 */
+	private async connectClient(): Promise<RedisClientConnectionType> {
 		try {
+			if (this._client.isReady) {
+				return this._client;
+			}
+
+			const connecting = this._client.isOpen
+				? this.waitUntilReady(this._client)
+				: this._client.connect();
+			connecting.catch(() => {
+				/* handled by the await below or by connectionTimeout */
+			});
+
 			if (this._connectionTimeout === undefined) {
-				await this._client.connect();
+				await connecting;
 			} else {
-				await this.raceWithTimeout(this._client.connect(), this._connectionTimeout);
+				await this.raceWithTimeout(connecting, this._connectionTimeout);
 			}
 		} catch (error) {
 			this.emit("error", error);
@@ -416,6 +456,71 @@ export default class KeyvRedis<T> extends Hookified implements KeyvStorageAdapte
 		this.initClient();
 
 		return this._client;
+	}
+
+	/**
+	 * Wait until an already-open client becomes ready. Used when `isOpen` is true
+	 * but `isReady` is not — calling `connect()` again throws in node-redis.
+	 * Standalone clients emit `ready`; cluster emits `connect` once discovery finishes.
+	 * @param {RedisClientConnectionType} client - The Redis client, cluster, or sentinel connection.
+	 * @returns {Promise<void>} Resolves when `client.isReady` is true.
+	 */
+	private async waitUntilReady(client: RedisClientConnectionType): Promise<void> {
+		if (client.isReady) {
+			return;
+		}
+
+		await new Promise<void>((resolve, reject) => {
+			const emitter = client as KeyvAny;
+
+			const cleanup = (): void => {
+				emitter.removeListener("ready", onReady);
+				emitter.removeListener("connect", onConnect);
+				emitter.removeListener("end", onEnd);
+				emitter.removeListener("error", onError);
+			};
+
+			const succeed = (): void => {
+				cleanup();
+				resolve();
+			};
+
+			const fail = (error: Error): void => {
+				cleanup();
+				reject(error);
+			};
+
+			const onReady = (): void => {
+				succeed();
+			};
+
+			const onConnect = (): void => {
+				if (client.isReady) {
+					succeed();
+				}
+			};
+
+			const onEnd = (): void => {
+				fail(new Error("Redis client closed before it became ready"));
+			};
+
+			const onError = (error: Error): void => {
+				if (!client.isOpen) {
+					fail(error);
+				}
+			};
+
+			emitter.on("ready", onReady);
+			emitter.on("connect", onConnect);
+			emitter.on("end", onEnd);
+			emitter.on("error", onError);
+
+			if (client.isReady) {
+				succeed();
+			} else if (!client.isOpen) {
+				fail(new Error("Redis client closed before it became ready"));
+			}
+		});
 	}
 
 	/**

--- a/storage/redis/test/create-keyv.test.ts
+++ b/storage/redis/test/create-keyv.test.ts
@@ -63,4 +63,52 @@ describe("createKeyvNonBlocking", () => {
 		expect(keyv.namespace).toBeUndefined();
 		expect(keyv.store.namespace).toBeUndefined();
 	});
+
+	test("should persist concurrent sets during the initial Redis connect", async () => {
+		const keyv = createKeyvNonBlocking(redisUri);
+		const errors: Error[] = [];
+		const onError = (error: unknown) => {
+			errors.push(error as Error);
+		};
+		keyv.on("error", onError);
+		keyv.store.on("error", onError);
+
+		const prefix = `keyv-concurrent-connect-${Date.now()}`;
+		const keys = Array.from({ length: 50 }, (_, index) => `${prefix}:${index}`);
+		const results = await Promise.all(keys.map((key, index) => keyv.set(key, index, 60_000)));
+		const values = await Promise.all(keys.map((key) => keyv.get<number>(key)));
+
+		expect(results.every((result) => result === true)).toBe(true);
+		expect(values).toEqual(keys.map((_, index) => index));
+		expect(errors.filter((error) => error.name === "ClientOfflineError")).toHaveLength(0);
+
+		await keyv.deleteMany(keys);
+		await keyv.disconnect();
+	});
+
+	test("should persist concurrent sets after disconnect and reconnect", async () => {
+		const keyv = createKeyvNonBlocking(redisUri);
+		const errors: Error[] = [];
+		const onError = (error: unknown) => {
+			errors.push(error as Error);
+		};
+		keyv.on("error", onError);
+		keyv.store.on("error", onError);
+
+		const warmupKey = `keyv-concurrent-reconnect-warmup-${Date.now()}`;
+		await keyv.set(warmupKey, "warmup", 60_000);
+		await keyv.disconnect();
+
+		const prefix = `keyv-concurrent-reconnect-${Date.now()}`;
+		const keys = Array.from({ length: 50 }, (_, index) => `${prefix}:${index}`);
+		const results = await Promise.all(keys.map((key, index) => keyv.set(key, index, 60_000)));
+		const values = await Promise.all(keys.map((key) => keyv.get<number>(key)));
+
+		expect(results.every((result) => result === true)).toBe(true);
+		expect(values).toEqual(keys.map((_, index) => index));
+		expect(errors.filter((error) => error.name === "ClientOfflineError")).toHaveLength(0);
+
+		await keyv.deleteMany(keys);
+		await keyv.disconnect();
+	});
 });

--- a/storage/redis/test/get-client.test.ts
+++ b/storage/redis/test/get-client.test.ts
@@ -1,16 +1,108 @@
+import { EventEmitter } from "node:events";
 import process from "node:process";
 import { faker } from "@faker-js/faker";
+import type { RedisClientType } from "@redis/client";
 import { describe, expect, test } from "vitest";
 import KeyvRedis, { createKeyv, RedisErrorMessages } from "../src/index.js";
 
 const redisUri = process.env.REDIS_URI ?? "redis://localhost:6379";
 const redisBadUri = process.env.REDIS_BAD_URI ?? "redis://localhost:6378";
 
+class ClientOfflineError extends Error {
+	constructor() {
+		super("The client is offline");
+		this.name = "ClientOfflineError";
+	}
+}
+
+/**
+ * Stand-in for `@redis/client` that matches node-redis connect timing:
+ * `isOpen` becomes true synchronously in `connect()`, `isReady` only after a delay.
+ */
+class FakeRedisClient extends EventEmitter {
+	isOpen = false;
+	isReady = false;
+	store = new Map<string, string>();
+	connectCalls = 0;
+	connectDelayMs = 25;
+	failConnect = false;
+
+	async connect(): Promise<this> {
+		this.connectCalls += 1;
+		if (this.isOpen) {
+			throw new Error("Socket already opened");
+		}
+
+		this.isOpen = true;
+		this.emit("connect");
+
+		if (this.failConnect) {
+			this.isOpen = false;
+			const error = new Error("connect failed");
+			this.emit("error", error);
+			throw error;
+		}
+
+		await new Promise((resolve) => {
+			setTimeout(resolve, this.connectDelayMs);
+		});
+		this.isReady = true;
+		this.emit("ready");
+		return this;
+	}
+
+	async set(key: string, value: string): Promise<string> {
+		if (!this.isOpen) {
+			throw new Error("The client is closed");
+		}
+
+		if (!this.isReady) {
+			throw new ClientOfflineError();
+		}
+
+		this.store.set(key, value);
+		return "OK";
+	}
+
+	async get(key: string): Promise<string | null> {
+		if (!this.isReady) {
+			throw new ClientOfflineError();
+		}
+
+		const value = this.store.get(key);
+		return value === undefined ? null : value;
+	}
+
+	async close(): Promise<void> {
+		this.isOpen = false;
+		this.isReady = false;
+		this.emit("end");
+	}
+
+	async destroy(): Promise<void> {
+		this.isOpen = false;
+		this.isReady = false;
+		this.emit("end");
+	}
+}
+
+function createAdapter(
+	client: FakeRedisClient,
+	options?: { connectionTimeout?: number },
+): KeyvRedis<string> {
+	const keyvRedis = new KeyvRedis(client as unknown as RedisClientType, options);
+	keyvRedis.throwOnConnectError = false;
+	keyvRedis.throwOnErrors = false;
+	keyvRedis.on("error", () => {});
+	return keyvRedis;
+}
+
 describe("getClient", () => {
 	test("should get client that is connected", async () => {
 		const keyvRedis = new KeyvRedis(redisUri);
 		const client = await keyvRedis.getClient();
 		expect(client).toBeDefined();
+		await keyvRedis.disconnect();
 	});
 
 	test("should get client that is connected with default timeout", async () => {
@@ -20,6 +112,7 @@ describe("getClient", () => {
 		expect(keyvRedis.connectionTimeout).toBe(undefined);
 		const client = await keyvRedis.getClient();
 		expect(client).toBeDefined();
+		await keyvRedis.disconnect();
 	});
 
 	test("should get client that is connected with timeout", async () => {
@@ -27,6 +120,7 @@ describe("getClient", () => {
 		expect(keyvRedis.connectionTimeout).toBe(2000);
 		const client = await keyvRedis.getClient();
 		expect(client).toBeDefined();
+		await keyvRedis.disconnect();
 	});
 
 	test("should throw an error if not connected", async () => {
@@ -48,6 +142,7 @@ describe("getClient", () => {
 			throwOnErrors: true,
 			connectionTimeout: 500,
 		});
+		keyv.on("error", () => {});
 		let didError = false;
 		try {
 			await keyv.get(faker.string.alphanumeric(10));
@@ -63,6 +158,7 @@ describe("getClient", () => {
 			throwOnConnectError: true,
 			connectionTimeout: 500,
 		});
+		keyv.on("error", () => {});
 		let didError = false;
 		try {
 			await keyv.get(faker.string.alphanumeric(10));
@@ -71,5 +167,194 @@ describe("getClient", () => {
 		}
 
 		expect(didError).toBe(true);
+	});
+
+	test("should share one connect across concurrent getClient callers", async () => {
+		const client = new FakeRedisClient();
+		const keyvRedis = createAdapter(client);
+
+		const clients = await Promise.all([
+			keyvRedis.getClient(),
+			keyvRedis.getClient(),
+			keyvRedis.getClient(),
+		]);
+
+		expect(client.connectCalls).toBe(1);
+		expect(client.isReady).toBe(true);
+		expect(new Set(clients).size).toBe(1);
+	});
+
+	test("should persist concurrent sets while the initial connect is in flight", async () => {
+		const client = new FakeRedisClient();
+		const keyvRedis = createAdapter(client);
+		const errors: Error[] = [];
+		keyvRedis.on("error", (error) => {
+			errors.push(error as Error);
+		});
+
+		const keys = Array.from({ length: 50 }, (_, index) => `concurrent:${index}`);
+		const results = await Promise.all(keys.map((key, index) => keyvRedis.set(key, String(index))));
+		const values = await Promise.all(keys.map((key) => keyvRedis.get(key)));
+
+		expect(client.connectCalls).toBe(1);
+		expect(results.every((result) => result === true)).toBe(true);
+		expect(values).toEqual(keys.map((_, index) => String(index)));
+		expect(errors.filter((error) => error.name === "ClientOfflineError")).toHaveLength(0);
+	});
+
+	test("should persist concurrent sets after disconnect reconnects the client", async () => {
+		const client = new FakeRedisClient();
+		const keyvRedis = createAdapter(client);
+
+		await keyvRedis.getClient();
+		await keyvRedis.disconnect();
+		client.connectCalls = 0;
+		client.store.clear();
+
+		const keys = Array.from({ length: 50 }, (_, index) => `reconnect:${index}`);
+		const results = await Promise.all(keys.map((key, index) => keyvRedis.set(key, String(index))));
+		const values = await Promise.all(keys.map((key) => keyvRedis.get(key)));
+
+		expect(client.connectCalls).toBe(1);
+		expect(results.every((result) => result === true)).toBe(true);
+		expect(values).toEqual(keys.map((_, index) => String(index)));
+	});
+
+	test("should wait for an already-open client to become ready instead of calling connect again", async () => {
+		const client = new FakeRedisClient();
+		client.isOpen = true;
+		const keyvRedis = createAdapter(client);
+
+		const ready = new Promise<void>((resolve) => {
+			setTimeout(() => {
+				client.isReady = true;
+				client.emit("ready");
+				resolve();
+			}, 20);
+		});
+
+		const connected = keyvRedis.getClient();
+		await ready;
+		await connected;
+
+		expect(client.connectCalls).toBe(0);
+		expect(client.isReady).toBe(true);
+	});
+
+	test("should treat cluster connect as ready when isReady becomes true", async () => {
+		const client = new FakeRedisClient();
+		client.isOpen = true;
+		const keyvRedis = createAdapter(client);
+
+		const connected = keyvRedis.getClient();
+		setTimeout(() => {
+			client.isReady = true;
+			client.emit("connect");
+		}, 20);
+
+		await connected;
+		expect(client.connectCalls).toBe(0);
+		expect(client.isReady).toBe(true);
+	});
+
+	test("should ignore transient errors while waiting for an open client to become ready", async () => {
+		const client = new FakeRedisClient();
+		client.isOpen = true;
+		const keyvRedis = createAdapter(client);
+
+		const connected = keyvRedis.getClient();
+		setTimeout(() => {
+			client.emit("error", new Error("transient"));
+		}, 10);
+		setTimeout(() => {
+			client.isReady = true;
+			client.emit("ready");
+		}, 30);
+
+		await connected;
+		expect(client.isReady).toBe(true);
+	});
+
+	test("should fail if an already-open client closes before it becomes ready", async () => {
+		const client = new FakeRedisClient();
+		client.isOpen = true;
+		const keyvRedis = new KeyvRedis(client as unknown as RedisClientType, {
+			connectionTimeout: 500,
+		});
+		keyvRedis.on("error", () => {});
+
+		const pending = keyvRedis.getClient();
+		setTimeout(() => {
+			client.isOpen = false;
+			client.emit("end");
+		}, 10);
+
+		await expect(pending).rejects.toThrow(RedisErrorMessages.RedisClientNotConnectedThrown);
+	});
+
+	test("should fail if an already-open client errors and closes before it becomes ready", async () => {
+		const client = new FakeRedisClient();
+		client.isOpen = true;
+		const keyvRedis = new KeyvRedis(client as unknown as RedisClientType, {
+			connectionTimeout: 500,
+		});
+		keyvRedis.on("error", () => {});
+
+		const pending = keyvRedis.getClient();
+		setTimeout(() => {
+			client.isOpen = false;
+			client.emit("error", new Error("socket gone"));
+		}, 10);
+
+		await expect(pending).rejects.toThrow(RedisErrorMessages.RedisClientNotConnectedThrown);
+	});
+
+	test("should time out while waiting for an already-open client to become ready", async () => {
+		const client = new FakeRedisClient();
+		client.isOpen = true;
+		const keyvRedis = new KeyvRedis(client as unknown as RedisClientType, {
+			connectionTimeout: 50,
+		});
+		keyvRedis.on("error", () => {});
+
+		await expect(keyvRedis.getClient()).rejects.toThrow(
+			RedisErrorMessages.RedisClientNotConnectedThrown,
+		);
+	});
+
+	test("should not throw on connect failure when throwOnConnectError is false", async () => {
+		const client = new FakeRedisClient();
+		client.failConnect = true;
+		const keyvRedis = createAdapter(client);
+
+		const connected = await keyvRedis.getClient();
+		expect(connected).toBe(client);
+		expect(client.isReady).toBe(false);
+	});
+
+	test("should retry connect after a previous attempt fails", async () => {
+		const client = new FakeRedisClient();
+		client.failConnect = true;
+		const keyvRedis = createAdapter(client);
+
+		await keyvRedis.getClient();
+		client.failConnect = false;
+		client.connectCalls = 0;
+
+		const connected = await keyvRedis.getClient();
+		expect(client.connectCalls).toBe(1);
+		expect(connected).toBe(client);
+		expect(client.isReady).toBe(true);
+	});
+
+	test("should return immediately when the client is already ready", async () => {
+		const client = new FakeRedisClient();
+		client.isOpen = true;
+		client.isReady = true;
+		const keyvRedis = createAdapter(client);
+
+		const connected = await keyvRedis.getClient();
+		expect(connected).toBe(client);
+		expect(client.connectCalls).toBe(0);
 	});
 });

--- a/storage/redis/test/get-client.test.ts
+++ b/storage/redis/test/get-client.test.ts
@@ -142,7 +142,6 @@ describe("getClient", () => {
 			throwOnErrors: true,
 			connectionTimeout: 500,
 		});
-		keyv.on("error", () => {});
 		let didError = false;
 		try {
 			await keyv.get(faker.string.alphanumeric(10));
@@ -158,7 +157,6 @@ describe("getClient", () => {
 			throwOnConnectError: true,
 			connectionTimeout: 500,
 		});
-		keyv.on("error", () => {});
 		let didError = false;
 		try {
 			await keyv.get(faker.string.alphanumeric(10));
@@ -356,5 +354,83 @@ describe("getClient", () => {
 		const connected = await keyvRedis.getClient();
 		expect(connected).toBe(client);
 		expect(client.connectCalls).toBe(0);
+	});
+
+	test("should return if the client becomes ready after getClient starts connectClient", async () => {
+		const client = new FakeRedisClient();
+		let readyChecks = 0;
+		Object.defineProperty(client, "isReady", {
+			configurable: true,
+			get: () => {
+				readyChecks += 1;
+				return readyChecks > 1;
+			},
+		});
+		const keyvRedis = createAdapter(client);
+
+		const connected = await keyvRedis.getClient();
+		expect(connected).toBe(client);
+		expect(client.connectCalls).toBe(0);
+	});
+
+	test("should return from waitUntilReady if the client is already ready", async () => {
+		const client = new FakeRedisClient();
+		client.isOpen = true;
+		let readyChecks = 0;
+		Object.defineProperty(client, "isReady", {
+			configurable: true,
+			get: () => {
+				readyChecks += 1;
+				return readyChecks >= 3;
+			},
+		});
+		const keyvRedis = createAdapter(client);
+
+		const connected = await keyvRedis.getClient();
+		expect(connected).toBe(client);
+		expect(client.connectCalls).toBe(0);
+	});
+
+	test("should resolve waitUntilReady if the client becomes ready while listeners are attached", async () => {
+		const client = new FakeRedisClient();
+		client.isOpen = true;
+		let readyChecks = 0;
+		Object.defineProperty(client, "isReady", {
+			configurable: true,
+			get: () => {
+				readyChecks += 1;
+				return readyChecks >= 4;
+			},
+		});
+		const keyvRedis = createAdapter(client);
+
+		const connected = await keyvRedis.getClient();
+		expect(connected).toBe(client);
+		expect(client.connectCalls).toBe(0);
+	});
+
+	test("should fail waitUntilReady if the client closes while listeners are attached", async () => {
+		const client = new FakeRedisClient();
+		let openChecks = 0;
+		Object.defineProperty(client, "isOpen", {
+			configurable: true,
+			get: () => {
+				openChecks += 1;
+				return openChecks === 1;
+			},
+			set: () => {},
+		});
+		Object.defineProperty(client, "isReady", {
+			configurable: true,
+			get: () => false,
+		});
+		const keyvRedis = new KeyvRedis(client as unknown as RedisClientType, {
+			connectionTimeout: 500,
+		});
+		keyvRedis.on("error", () => {});
+
+		await expect(keyvRedis.getClient()).rejects.toThrow(
+			RedisErrorMessages.RedisClientNotConnectedThrown,
+		);
 	});
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix for https://github.com/jaredwray/keyv/issues/2068.

`createKeyvNonBlocking` disables the Redis offline queue. `getClient()` previously returned as soon as `client.isOpen` was true, which happens in node-redis while `connect()` is still in progress and `isReady` is still false. Concurrent `set()` calls then rejected with `ClientOfflineError`, which Keyv swallowed, so the operations resolved while most values were never written.

**What this PR does**
- Return from `getClient()` only when `client.isReady`.
- Share one in-flight connect promise across concurrent callers.
- If the client is already `isOpen` but not ready (user-started connect, cluster handshake, reconnect), wait for readiness instead of calling `connect()` again.
- Keep existing `connectionTimeout` / `throwOnConnectError` behavior.
- Cover the race with a fake client (no Redis required) and with live `createKeyvNonBlocking` tests against Redis.

**Validation**
- `pnpm exec vitest run --exclude test/cluster.test.ts --exclude test/sentinel.test.ts` in `storage/redis`: 12 files, 193 tests passed (cluster/sentinel not run in this environment).
- Live reproduction of the issue script against Redis 8.10.1: 50/50 sets persisted, 0 `ClientOfflineError`, both on first connect and after disconnect/reconnect.

**Checklist**
- [x] Followed contributing and code of conduct
- [x] Tests added for the bug fix

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be9e0360-1f14-4443-be7a-1ac2403ad231?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be9e0360-1f14-4443-be7a-1ac2403ad231&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

