### PR TITLE
redis - fix: Prevent duplicate event listeners after reconnects

### DIFF
--- a/packages/redis/src/index.ts
+++ b/packages/redis/src/index.ts
@@ -47,6 +47,7 @@ export default class KeyvRedis<T>
 	implements KeyvStoreAdapter
 {
 	private _client!: RedisClientConnectionType;
+	private _boundClient: RedisClientConnectionType | undefined;
 	private _namespace: string | undefined;
 	private _keyPrefixSeparator = "::";
 	private _clearBatchSize = 1000;
@@ -110,7 +111,7 @@ export default class KeyvRedis<T>
 		}
 
 		this.setOptions(options);
-		this.initClient();
+		this.bindClientEvents();
 	}
 
 	/**
@@ -125,7 +126,7 @@ export default class KeyvRedis<T>
 	 */
 	public set client(value: RedisClientConnectionType) {
 		this._client = value;
-		this.initClient();
+		this.bindClientEvents();
 	}
 
 	/**
@@ -329,7 +330,7 @@ export default class KeyvRedis<T>
 			}
 		}
 
-		this.initClient();
+		this.bindClientEvents();
 
 		return this._client;
 	}
@@ -987,24 +988,45 @@ export default class KeyvRedis<T>
 		}
 	}
 
-	private initClient(): void {
-		this._client.on("error", (error) => {
-			this.emit("error", error);
-		});
+	private readonly onClientError = (error: Error): void => {
+		this.emit("error", error);
+	};
 
-		this._client.on("connect", () => {
-			this.emit("connect", this._client);
-		});
+	private readonly onClientConnect = (): void => {
+		this.emit("connect", this._client);
+	};
 
-		/* v8 ignore next -- @preserve */
-		this._client.on("disconnect", () => {
-			this.emit("disconnect", this._client);
-		});
+	private readonly onClientDisconnect = (): void => {
+		this.emit("disconnect", this._client);
+	};
 
-		/* v8 ignore next -- @preserve */
-		this._client.on("reconnecting", (reconnectInfo) => {
-			this.emit("reconnecting", reconnectInfo);
-		});
+	private readonly onClientReconnecting = (reconnectInfo: unknown): void => {
+		this.emit("reconnecting", reconnectInfo);
+	};
+
+	private bindClientEvents(): void {
+		if (this._boundClient === this._client) {
+			return;
+		}
+
+		this.unbindClientEvents();
+		this._client.on("error", this.onClientError);
+		this._client.on("connect", this.onClientConnect);
+		this._client.on("disconnect", this.onClientDisconnect);
+		this._client.on("reconnecting", this.onClientReconnecting);
+		this._boundClient = this._client;
+	}
+
+	private unbindClientEvents(): void {
+		if (this._boundClient === undefined) {
+			return;
+		}
+
+		this._boundClient.off("error", this.onClientError);
+		this._boundClient.off("connect", this.onClientConnect);
+		this._boundClient.off("disconnect", this.onClientDisconnect);
+		this._boundClient.off("reconnecting", this.onClientReconnecting);
+		this._boundClient = undefined;
 	}
 
 	private async createTimeoutPromise(timeoutMs: number): Promise<never> {

--- a/packages/redis/test/get-client.test.ts
+++ b/packages/redis/test/get-client.test.ts
@@ -1,7 +1,12 @@
+import { EventEmitter } from "node:events";
 import process from "node:process";
 import { faker } from "@faker-js/faker";
 import { describe, expect, test } from "vitest";
-import KeyvRedis, { createKeyv, RedisErrorMessages } from "../src/index.js";
+import KeyvRedis, {
+	createKeyv,
+	type RedisClientType,
+	RedisErrorMessages,
+} from "../src/index.js";
 
 const redisUri = process.env.REDIS_URI ?? "redis://localhost:6379";
 const redisBadUri = process.env.REDIS_BAD_URI ?? "redis://localhost:6378";
@@ -81,5 +86,135 @@ describe("getClient", () => {
 		}
 
 		expect(didError).toBe(true);
+	});
+
+	test("should not accumulate listeners after reconnects", async () => {
+		const keyvRedis = new KeyvRedis(redisUri);
+		const client = keyvRedis.client as RedisClientType;
+
+		expect(client.listenerCount("error")).toBe(1);
+		expect(client.listenerCount("connect")).toBe(1);
+		expect(client.listenerCount("disconnect")).toBe(1);
+		expect(client.listenerCount("reconnecting")).toBe(1);
+
+		for (let index = 0; index < 12; index++) {
+			await keyvRedis.getClient();
+			await keyvRedis.disconnect();
+			expect(client.listenerCount("error")).toBe(1);
+			expect(client.listenerCount("connect")).toBe(1);
+			expect(client.listenerCount("disconnect")).toBe(1);
+			expect(client.listenerCount("reconnecting")).toBe(1);
+		}
+
+		await keyvRedis.getClient();
+		await keyvRedis.set("listener-reconnect-key", "ok");
+		expect(await keyvRedis.get("listener-reconnect-key")).toBe("ok");
+		await keyvRedis.delete("listener-reconnect-key");
+		await keyvRedis.disconnect();
+	});
+});
+
+class FakeRedisClient extends EventEmitter {
+	isOpen = false;
+
+	async connect(): Promise<void> {
+		this.isOpen = true;
+		this.emit("connect");
+	}
+
+	async close(): Promise<void> {
+		this.isOpen = false;
+		this.emit("disconnect");
+	}
+
+	async destroy(): Promise<void> {
+		this.isOpen = false;
+		this.emit("disconnect");
+	}
+}
+
+describe("client event listeners", () => {
+	test("should attach listeners once across reconnects", async () => {
+		const client = new FakeRedisClient();
+		const store = new KeyvRedis(client as unknown as RedisClientType);
+		const listenerCounts = [client.listenerCount("error")];
+
+		for (let index = 0; index < 12; index++) {
+			await store.getClient();
+			await store.disconnect();
+			listenerCounts.push(client.listenerCount("error"));
+		}
+
+		expect(listenerCounts).toEqual(Array.from({ length: 13 }).fill(1));
+		expect(client.listenerCount("connect")).toBe(1);
+		expect(client.listenerCount("disconnect")).toBe(1);
+		expect(client.listenerCount("reconnecting")).toBe(1);
+	});
+
+	test("should forward a client error only once after reconnects", async () => {
+		const client = new FakeRedisClient();
+		const store = new KeyvRedis(client as unknown as RedisClientType);
+		let forwardedErrors = 0;
+		store.on("error", () => {
+			forwardedErrors++;
+		});
+
+		for (let index = 0; index < 5; index++) {
+			await store.getClient();
+			await store.disconnect();
+		}
+
+		client.emit("error", new Error("test"));
+		expect(forwardedErrors).toBe(1);
+	});
+
+	test("should forward connect, disconnect, and reconnecting events", async () => {
+		const client = new FakeRedisClient();
+		const store = new KeyvRedis(client as unknown as RedisClientType);
+		const events: unknown[] = [];
+		store.on("connect", (value) => {
+			events.push(["connect", value]);
+		});
+		store.on("disconnect", (value) => {
+			events.push(["disconnect", value]);
+		});
+		store.on("reconnecting", (value) => {
+			events.push(["reconnecting", value]);
+		});
+
+		client.emit("connect");
+		client.emit("disconnect");
+		client.emit("reconnecting", { attempt: 2 });
+
+		expect(events).toEqual([
+			["connect", client],
+			["disconnect", client],
+			["reconnecting", { attempt: 2 }],
+		]);
+	});
+
+	test("should move listeners when the client is replaced", () => {
+		const originalClient = new FakeRedisClient();
+		const replacementClient = new FakeRedisClient();
+		const store = new KeyvRedis(originalClient as unknown as RedisClientType);
+		let forwardedErrors = 0;
+		store.on("error", () => {
+			forwardedErrors++;
+		});
+
+		expect(originalClient.listenerCount("error")).toBe(1);
+
+		store.client = replacementClient as unknown as RedisClientType;
+		store.client = replacementClient as unknown as RedisClientType;
+
+		expect(originalClient.listenerCount("error")).toBe(0);
+		expect(replacementClient.listenerCount("error")).toBe(1);
+
+		originalClient.on("error", () => {});
+		originalClient.emit("error", new Error("old"));
+		expect(forwardedErrors).toBe(0);
+
+		replacementClient.emit("error", new Error("new"));
+		expect(forwardedErrors).toBe(1);
 	});
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

Fixes #2069

`KeyvRedis` was calling `initClient()` after every successful `getClient()` reconnect and registering a new set of anonymous `error` / `connect` / `disconnect` / `reconnecting` listeners on the same Redis client. After enough reconnects that produced `MaxListenersExceededWarning` and forwarded each Redis event multiple times.

Event listeners are now bound once per client instance. Reconnecting the same client is a no-op, and replacing `client` moves the listeners off the previous instance.

**Added tests**
- Fake Redis client reproducing the original listener-count and forwarded-error cases
- Client replacement does not leak listeners on the previous client
- Real Redis reconnect loop keeps one listener per event and still reads/writes after reconnects
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4f75e3c1-b1f0-42b2-8cc4-351f362e4460?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4f75e3c1-b1f0-42b2-8cc4-351f362e4460&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

