### PR TITLE
mono - chore: set pnpm minimumReleaseAge to 7 days

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,13 +29,13 @@ If you need more information on the steps to create a pull request, you can find
 
 We use `pnpm outdated` to check for outdated dependencies across the monorepo. When updating packages, we follow a cautious approach to avoid potential issues with newly released versions.
 
-## Why We Use `minimumReleaseAge: 7200`
+## Why We Use `minimumReleaseAge: 10080`
 
-In our `pnpm-workspace.yaml`, we have configured `minimumReleaseAge: 7200` (5 days in minutes). This setting ensures that when running `pnpm update`, only packages that have been published for at least 5 days will be considered for updates.
+In our `pnpm-workspace.yaml`, we have configured `minimumReleaseAge: 10080` (7 days in minutes). This setting ensures that when running `pnpm update`, only packages that have been published for at least 7 days will be considered for updates.
 
 This approach provides several benefits:
 
-1. **Stability**: Newly published packages may contain undiscovered bugs or breaking changes. Waiting 5 days allows the community to identify and report issues.
+1. **Stability**: Newly published packages may contain undiscovered bugs or breaking changes. Waiting 7 days allows the community to identify and report issues.
 2. **Security**: Malicious packages are often detected and removed within the first few days of publication. This delay provides a buffer against supply chain attacks.
 3. **Reliability**: It gives package maintainers time to publish patch releases if critical issues are found shortly after a release.
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
   - 'packages/*'
-minimumReleaseAge: 2880
+# 7 days in minutes — only install versions at least this old.
+minimumReleaseAge: 10080
 # pnpm 11 moved dependency build-script approval here (was
 # pnpm.onlyBuiltDependencies in package.json) — same set, same format as main.
 allowBuilds:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Raise the workspace `minimumReleaseAge` gate from 2 days (2880 minutes) to 7 days (10080 minutes) so `pnpm install` / `pnpm outdated` ignore packages younger than a week. Align `CONTRIBUTING.md`, which still described a 5-day `7200` setting that did not match the yaml.

This is not a Keyv library change. v5 published packages and their public APIs are untouched.

## Changes
- set `minimumReleaseAge: 10080` in `pnpm-workspace.yaml`
- document the 7-day window in `CONTRIBUTING.md`

## Verification
- [x] `pnpm install` succeeds with the new gate (e.g. `@biomejs/biome` resolves to `2.5.11` rather than `2.5.12`, which is younger than 7 days)
- [x] `pnpm build` passes
- [ ] Full `pnpm test` not run here (no Docker in this environment; CI covers it)

## Breaking notes
None. Workspace policy only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457061d6-444f-4516-9546-273a7c3a110c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457061d6-444f-4516-9546-273a7c3a110c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

