### PR TITLE
mono - chore: upgrade pnpm to 12.1.0

### DIFF
--- a/.github/workflows/bun-test.yaml
+++ b/.github/workflows/bun-test.yaml
@@ -23,7 +23,7 @@ jobs:
           bun-version: latest
 
       - name: Install pnpm
-        run: npm install -g pnpm
+        uses: pnpm/action-setup@v6
 
       - name: Start Services
         run: pnpm test:services:start

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -20,9 +20,9 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 24
-      
+
       - name: Install pnpm
-        run: npm install -g pnpm
+        uses: pnpm/action-setup@v6
 
       - name: Start Services
         run: pnpm test:services:start

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -24,7 +24,7 @@ jobs:
         node-version: 22
 
     - name: Install pnpm
-      run: npm install -g pnpm
+      uses: pnpm/action-setup@v6
 
     - name: Install Dependencies  
       run: pnpm install

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,29 +30,10 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
-      # pnpm 11.9 (packageManager) requires Node >= 22.13. Node 20 cannot use
-      # pnpm/action-setup with a different version either — it errors on the
-      # mismatch — so install pnpm 10 via npm for that job only.
+      # pnpm 12 (packageManager) is a native binary and supports Node 20, so
+      # every matrix job can use action-setup. pnpm 11 required Node >= 22.13.
       - name: Install pnpm
-        if: matrix.node != '20'
         uses: pnpm/action-setup@v6
-
-      - name: Install pnpm 10 (Node 20)
-        if: matrix.node == '20'
-        run: npm install -g pnpm@10
-
-      - name: Allow pnpm 10 on a pnpm 11 workspace
-        if: matrix.node == '20'
-        run: |
-          printf '%s\n' \
-            'manage-package-manager-versions=false' \
-            'package-manager-strict=false' \
-            'only-built-dependencies[]=esbuild' \
-            'only-built-dependencies[]=protobufjs' \
-            'only-built-dependencies[]=sqlite3' \
-            'only-built-dependencies[]=sqlite325h' \
-            'only-built-dependencies[]=unrs-resolver' \
-            > .npmrc
 
       - name: Start Services
         run: chmod +x ./scripts/test-services-start.sh && ./scripts/test-services-start.sh

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "Jared Wray <me@jaredwray.com>",
   "license": "MIT",
   "private": true,
-  "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b",
+  "packageManager": "pnpm@12.1.0+sha512.d9b8276d97f6ec86e49815877f91ee9f63cee61f2063b304e43b6dab8fa07ce8a9afd46d2facd39f921e6a9d06b3c75a81349c7b888c2d22886bae0229901037",
   "scripts": {
     "build:keyv:serialize": "pnpm recursive --filter=@keyv/serialize run build",
     "build:keyv": "pnpm recursive --filter=keyv run build",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,9 @@ packages:
   - 'packages/*'
 # 7 days in minutes — only install versions at least this old.
 minimumReleaseAge: 10080
+# Adapters and @keyv/test-suite depend on each other. pnpm 12 fails cyclic
+# `run build` unless this is set; pnpm 11 only warned.
+ignoreWorkspaceCycles: true
 # pnpm 11 moved dependency build-script approval here (was
 # pnpm.onlyBuiltDependencies in package.json) — same set, same format as main.
 allowBuilds:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Upgrade the workspace package manager from pnpm 11.9.0 to 12.1.0, the newest 12.x release that is at least 7 days old (`minimumReleaseAge: 10080`). This is tooling only — no Keyv published package APIs or runtime dependencies change.

12.3.4 is on npm but is younger than the 7-day gate, so it is not the target.

## Changes
- pin `packageManager` to `pnpm@12.1.0`
- set `ignoreWorkspaceCycles: true` so pnpm 12 can run the existing cyclic adapter / test-suite `build` graph (pnpm 11 only warned)
- install the pinned pnpm via `pnpm/action-setup@v6` in tests, codecov, bun, and website deploy (Node 20 no longer needs the pnpm 10 workaround because pnpm 12 supports Node 20)

## Artifact diffs
- [pnpm 11.9.0 → 12.1.0](https://drydock.org/diff/pnpm/11.9.0/12.1.0)

## Verification
- [x] `pnpm install` with pnpm 12.1.0
- [x] `pnpm build`
- [x] `pnpm test:release`
- [x] `@keyv/serialize` and `@keyv/bigmap` `test:ci`
- [x] workflow YAML parses
- [ ] Full `pnpm test` (no Docker here; CI covers it)

## Breaking notes
None for Keyv library consumers. pnpm 12 is a native rewrite of the package manager; v5 package majors and public APIs are unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457061d6-444f-4516-9546-273a7c3a110c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457061d6-444f-4516-9546-273a7c3a110c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

