### PR TITLE
postgres - chore: pin Docker runtime image

### DIFF
--- a/packages/keyv/test/test.ts
+++ b/packages/keyv/test/test.ts
@@ -688,9 +688,9 @@ test.it("close connection undefined", async (t) => {
 test.it("get keys, one key expired", async (t) => {
 	const keyv = new Keyv({ store: keyvMemcache });
 	await keyv.set("foo", "bar", 10_000);
-	await keyv.set("fizz", "buzz", 100);
+	await keyv.set("fizz", "buzz", 1000);
 	await keyv.set("ping", "pong", 10_000);
-	await snooze(100);
+	await snooze(1100);
 	await keyv.get(["foo", "fizz", "ping"]);
 	t.expect(await keyv.get("fizz")).toBeUndefined();
 	t.expect(await keyv.get("foo")).toBe("bar");

--- a/packages/keyv/test/test.ts
+++ b/packages/keyv/test/test.ts
@@ -688,9 +688,9 @@ test.it("close connection undefined", async (t) => {
 test.it("get keys, one key expired", async (t) => {
 	const keyv = new Keyv({ store: keyvMemcache });
 	await keyv.set("foo", "bar", 10_000);
-	await keyv.set("fizz", "buzz", 1000);
+	await keyv.set("fizz", "buzz", 500);
 	await keyv.set("ping", "pong", 10_000);
-	await snooze(1100);
+	await snooze(600);
 	await keyv.get(["foo", "fizz", "ping"]);
 	t.expect(await keyv.get("fizz")).toBeUndefined();
 	t.expect(await keyv.get("foo")).toBe("bar");

--- a/packages/postgres/Dockerfile.ssl
+++ b/packages/postgres/Dockerfile.ssl
@@ -1,4 +1,4 @@
-FROM postgres:latest
+FROM postgres:18.6-trixie@sha256:4ef4dbc939d61acea57712655ddb4b4ab27419c913f94cca0cd57cb3ea3c2280
 
 RUN mkdir -p /keyv_postgres_ssl
 COPY ./tls/server.key /keyv_postgres_ssl


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Pin the SSL test image in `packages/postgres/Dockerfile.ssl` from floating `postgres:latest` to Postgres 18.6 on Debian trixie, using the multi-arch index digest that is already 14 days old.

`postgres:latest`, `postgres:18`, `postgres:18.6`, and `postgres:18.6-trixie` currently share this digest (`Created` 2026-08-25). This is a pin of what `:latest` already resolved to, not a Keyv library change.

Also tightens a flaky memcache TTL assertion that failed on Node 20 (`get keys, one key expired`): 500ms TTL, wait 600ms.

## Changes
- rewrite `FROM postgres:latest` to `postgres:18.6-trixie@sha256:4ef4dbc939d61acea57712655ddb4b4ab27419c913f94cca0cd57cb3ea3c2280`
- expire the memcache test key after 500ms and wait 600ms

## Verification
- [x] `skopeo inspect` on `postgres:latest` / `18` / `18.6` / `18.6-trixie` (same index digest; image created 2026-08-25)
- [ ] `docker build` of `Dockerfile.ssl` (no Docker daemon in this sandbox; CI does not build this image either)
- [ ] memcache expiry test locally (needs Memcached; CI covers it)

Compose `image: postgres:latest` is unchanged — that is the postgres service-image group.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457061d6-444f-4516-9546-273a7c3a110c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457061d6-444f-4516-9546-273a7c3a110c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

