### PR TITLE
mono - chore: pin postgres Docker service image

### DIFF
--- a/scripts/docker-compose-arm64.yaml
+++ b/scripts/docker-compose-arm64.yaml
@@ -1,6 +1,6 @@
 services:
   keyv_postgres:
-    image: postgres:latest
+    image: postgres:18.6-trixie@sha256:4ef4dbc939d61acea57712655ddb4b4ab27419c913f94cca0cd57cb3ea3c2280
     command: postgres -c 'max_connections=200'
     environment:
       POSTGRES_DB: keyv_test

--- a/scripts/docker-compose.yaml
+++ b/scripts/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   keyv_postgres:
-    image: postgres:latest
+    image: postgres:18.6-trixie@sha256:4ef4dbc939d61acea57712655ddb4b4ab27419c913f94cca0cd57cb3ea3c2280
     command: postgres -c 'max_connections=200'
     environment:
       POSTGRES_DB: keyv_test


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Pin the non-SSL Postgres test service from floating `postgres:latest` to Postgres 18.6 on Debian trixie, using the same multi-arch index digest as the SSL Dockerfile from #2115.

This is test compose only — not a Keyv library change. `keyv_postgres_1` still builds from `Dockerfile.ssl`.

## Changes
- pin `scripts/docker-compose.yaml` and `scripts/docker-compose-arm64.yaml` `keyv_postgres` to `postgres:18.6-trixie@sha256:4ef4dbc939d61acea57712655ddb4b4ab27419c913f94cca0cd57cb3ea3c2280`

## Verification
- [x] `skopeo inspect`: `postgres:latest` and `18.6-trixie` share this digest (`Created` 2026-08-25, 14 days old)
- [x] compose YAML parses
- [ ] `docker compose` pull/up (no Docker daemon here; CI starts test services)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457061d6-444f-4516-9546-273a7c3a110c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457061d6-444f-4516-9546-273a7c3a110c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

