### PR TITLE
mono - chore: pin mysql Docker service image

### DIFF
--- a/scripts/docker-compose-arm64.yaml
+++ b/scripts/docker-compose-arm64.yaml
@@ -20,7 +20,7 @@ services:
     ports:
       - 5433:5432/tcp
   keyv_mysql:
-    image: mysql/mysql-server:latest
+    image: mysql/mysql-server:8.0.32@sha256:d6c8301b7834c5b9c2b733b10b7e630f441af7bc917c74dba379f24eeeb6a313
     command: [ "mysqld",
                "--character-set-server=utf8mb4",
                "--collation-server=utf8mb4_unicode_ci",
@@ -35,7 +35,7 @@ services:
       MYSQL_USER: mysql
       MYSQL_ROOT_HOST: '%'
   keyv_mysql_1:
-    image: "mysql/mysql-server:latest"
+    image: mysql/mysql-server:8.0.32@sha256:d6c8301b7834c5b9c2b733b10b7e630f441af7bc917c74dba379f24eeeb6a313
     command: [ "mysqld",
                "--character-set-server=utf8mb4",
                "--collation-server=utf8mb4_unicode_ci",

--- a/scripts/docker-compose.yaml
+++ b/scripts/docker-compose.yaml
@@ -20,7 +20,7 @@ services:
     ports:
       - 5433:5432/tcp
   keyv_mysql:
-    image: mysql/mysql-server:latest
+    image: mysql/mysql-server:8.0.32@sha256:d6c8301b7834c5b9c2b733b10b7e630f441af7bc917c74dba379f24eeeb6a313
     command: [ "mysqld",
                "--character-set-server=utf8mb4",
                "--collation-server=utf8mb4_unicode_ci",
@@ -35,7 +35,7 @@ services:
       MYSQL_USER: mysql
       MYSQL_ROOT_HOST: '%'
   keyv_mysql_1:
-    image: "mysql/mysql-server:latest"
+    image: mysql/mysql-server:8.0.32@sha256:d6c8301b7834c5b9c2b733b10b7e630f441af7bc917c74dba379f24eeeb6a313
     command: [ "mysqld",
                "--character-set-server=utf8mb4",
                "--collation-server=utf8mb4_unicode_ci",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Pin the MySQL test services from floating `mysql/mysql-server:latest` to MySQL 8.0.32, using the multi-arch index digest that `latest`, `8.0`, and `8.0.32` already share.

This is test compose only — not a Keyv library change. `mysql/mysql-server` on Docker Hub last published in January 2023; this pins that image rather than switching to `library/mysql`.

## Changes
- pin `keyv_mysql` and `keyv_mysql_1` in `scripts/docker-compose.yaml` and `scripts/docker-compose-arm64.yaml` to `mysql/mysql-server:8.0.32@sha256:d6c8301b7834c5b9c2b733b10b7e630f441af7bc917c74dba379f24eeeb6a313`

## Verification
- [x] `skopeo inspect`: `latest` / `8.0` / `8.0.32` share this digest (`Created` 2023-01-18)
- [x] compose YAML parses
- [ ] `docker compose` pull/up (no Docker daemon here; CI starts test services)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457061d6-444f-4516-9546-273a7c3a110c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457061d6-444f-4516-9546-273a7c3a110c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

