### PR TITLE
mono - chore: pin redis Docker service image

### DIFF
--- a/scripts/docker-compose-arm64.yaml
+++ b/scripts/docker-compose-arm64.yaml
@@ -64,13 +64,13 @@ services:
     ports:
       - 6370:6370
   keyv_redis:
-    image: redis:latest
+    image: redis:8.10.1-trixie@sha256:298e5b3bc566bade82f46ad5511777a4a07a294097ce16ada2f6a42be5239df5
     environment:
       REDIS_HOST: redis
     ports:
       - 6379:6379
   keyv_redis_tls_1:
-    image: redis:latest
+    image: redis:8.10.1-trixie@sha256:298e5b3bc566bade82f46ad5511777a4a07a294097ce16ada2f6a42be5239df5
     command: redis-server --port 0 --tls-port 6380 --tls-cert-file /tls/redis.crt --tls-key-file /tls/redis.key --tls-ca-cert-file /tls/ca.crt --tls-auth-clients no
     environment:
       REDIS_HOST: redis

--- a/scripts/docker-compose-redis-cluster.yaml
+++ b/scripts/docker-compose-redis-cluster.yaml
@@ -1,6 +1,6 @@
 services:
   redis-1:
-    image: redis:latest
+    image: redis:8.10.1-trixie@sha256:298e5b3bc566bade82f46ad5511777a4a07a294097ce16ada2f6a42be5239df5
     container_name: redis-cluster-1
     command: redis-server --port 7001 --cluster-enabled yes --cluster-config-file nodes.conf --cluster-node-timeout 5000 --appendonly yes --cluster-announce-ip 127.0.0.1 --cluster-announce-port 7001 --cluster-announce-bus-port 17001
     network_mode: host
@@ -8,7 +8,7 @@ services:
       - redis-1-data:/data
 
   redis-2:
-    image: redis:latest
+    image: redis:8.10.1-trixie@sha256:298e5b3bc566bade82f46ad5511777a4a07a294097ce16ada2f6a42be5239df5
     container_name: redis-cluster-2
     command: redis-server --port 7002 --cluster-enabled yes --cluster-config-file nodes.conf --cluster-node-timeout 5000 --appendonly yes --cluster-announce-ip 127.0.0.1 --cluster-announce-port 7002 --cluster-announce-bus-port 17002
     network_mode: host
@@ -16,7 +16,7 @@ services:
       - redis-2-data:/data
 
   redis-3:
-    image: redis:latest
+    image: redis:8.10.1-trixie@sha256:298e5b3bc566bade82f46ad5511777a4a07a294097ce16ada2f6a42be5239df5
     container_name: redis-cluster-3
     command: redis-server --port 7003 --cluster-enabled yes --cluster-config-file nodes.conf --cluster-node-timeout 5000 --appendonly yes --cluster-announce-ip 127.0.0.1 --cluster-announce-port 7003 --cluster-announce-bus-port 17003
     network_mode: host
@@ -24,7 +24,7 @@ services:
       - redis-3-data:/data
 
   redis-cluster-init:
-    image: redis:latest
+    image: redis:8.10.1-trixie@sha256:298e5b3bc566bade82f46ad5511777a4a07a294097ce16ada2f6a42be5239df5
     container_name: redis-cluster-init
     network_mode: host
     depends_on:

--- a/scripts/docker-compose-redis-sentinel.yaml
+++ b/scripts/docker-compose-redis-sentinel.yaml
@@ -1,6 +1,6 @@
 services:
   redis-master:
-    image: redis:latest
+    image: redis:8.10.1-trixie@sha256:298e5b3bc566bade82f46ad5511777a4a07a294097ce16ada2f6a42be5239df5
     container_name: redis-master
     command: redis-server --port 6389
     network_mode: host
@@ -8,7 +8,7 @@ services:
       - redis-master-data:/data
 
   redis-replica:
-    image: redis:latest
+    image: redis:8.10.1-trixie@sha256:298e5b3bc566bade82f46ad5511777a4a07a294097ce16ada2f6a42be5239df5
     container_name: redis-replica
     command: redis-server --port 6390 --replicaof 127.0.0.1 6389
     network_mode: host
@@ -18,7 +18,7 @@ services:
       - redis-replica-data:/data
 
   redis-sentinel-1:
-    image: redis:latest
+    image: redis:8.10.1-trixie@sha256:298e5b3bc566bade82f46ad5511777a4a07a294097ce16ada2f6a42be5239df5
     container_name: redis-sentinel-1
     command: sh -c "echo 'port 26379' > /tmp/sentinel.conf && echo 'sentinel monitor mymaster 127.0.0.1 6389 2' >> /tmp/sentinel.conf && echo 'sentinel down-after-milliseconds mymaster 5000' >> /tmp/sentinel.conf && echo 'sentinel parallel-syncs mymaster 1' >> /tmp/sentinel.conf && echo 'sentinel failover-timeout mymaster 10000' >> /tmp/sentinel.conf && redis-sentinel /tmp/sentinel.conf"
     network_mode: host
@@ -29,7 +29,7 @@ services:
       - redis-sentinel-1-data:/data
 
   redis-sentinel-2:
-    image: redis:latest
+    image: redis:8.10.1-trixie@sha256:298e5b3bc566bade82f46ad5511777a4a07a294097ce16ada2f6a42be5239df5
     container_name: redis-sentinel-2
     command: sh -c "echo 'port 26380' > /tmp/sentinel.conf && echo 'sentinel monitor mymaster 127.0.0.1 6389 2' >> /tmp/sentinel.conf && echo 'sentinel down-after-milliseconds mymaster 5000' >> /tmp/sentinel.conf && echo 'sentinel parallel-syncs mymaster 1' >> /tmp/sentinel.conf && echo 'sentinel failover-timeout mymaster 10000' >> /tmp/sentinel.conf && redis-sentinel /tmp/sentinel.conf"
     network_mode: host
@@ -40,7 +40,7 @@ services:
       - redis-sentinel-2-data:/data
 
   redis-sentinel-3:
-    image: redis:latest
+    image: redis:8.10.1-trixie@sha256:298e5b3bc566bade82f46ad5511777a4a07a294097ce16ada2f6a42be5239df5
     container_name: redis-sentinel-3
     command: sh -c "echo 'port 26381' > /tmp/sentinel.conf && echo 'sentinel monitor mymaster 127.0.0.1 6389 2' >> /tmp/sentinel.conf && echo 'sentinel down-after-milliseconds mymaster 5000' >> /tmp/sentinel.conf && echo 'sentinel parallel-syncs mymaster 1' >> /tmp/sentinel.conf && echo 'sentinel failover-timeout mymaster 10000' >> /tmp/sentinel.conf && redis-sentinel /tmp/sentinel.conf"
     network_mode: host

--- a/scripts/docker-compose.yaml
+++ b/scripts/docker-compose.yaml
@@ -64,13 +64,13 @@ services:
     ports:
       - 6370:6370
   keyv_redis:
-    image: redis:latest
+    image: redis:8.10.1-trixie@sha256:298e5b3bc566bade82f46ad5511777a4a07a294097ce16ada2f6a42be5239df5
     environment:
       REDIS_HOST: redis
     ports:
       - 6379:6379
   keyv_redis_1:
-    image: redis:latest
+    image: redis:8.10.1-trixie@sha256:298e5b3bc566bade82f46ad5511777a4a07a294097ce16ada2f6a42be5239df5
     command: redis-server --port 0 --tls-port 6380 --tls-cert-file /tls/redis.crt --tls-key-file /tls/redis.key --tls-ca-cert-file /tls/ca.crt --tls-auth-clients no
     environment:
       REDIS_HOST: redis


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Pin Redis test services from floating `redis:latest` to Redis 8.10.1 on Debian trixie, using the multi-arch index digest that `latest`, `8`, `8.10`, and `8.10.1-trixie` already share (`Created` 2026-08-25).

This is test compose only — not a Keyv library change. Valkey stays on `valkey/valkey:latest` for its own service PR.

## Changes
- pin `keyv_redis` / TLS Redis in `scripts/docker-compose.yaml` and `scripts/docker-compose-arm64.yaml`
- pin cluster and sentinel services in `scripts/docker-compose-redis-cluster.yaml` and `scripts/docker-compose-redis-sentinel.yaml`
- all to `redis:8.10.1-trixie@sha256:298e5b3bc566bade82f46ad5511777a4a07a294097ce16ada2f6a42be5239df5`

## Verification
- [x] `skopeo inspect`: matching tags share this digest (14 days old)
- [x] compose YAML parses (13 Redis services)
- [ ] `docker compose` pull/up (no Docker daemon here; CI starts test services)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457061d6-444f-4516-9546-273a7c3a110c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457061d6-444f-4516-9546-273a7c3a110c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

