### PR TITLE
mono - chore: pin valkey Docker service image

### DIFF
--- a/scripts/docker-compose-arm64.yaml
+++ b/scripts/docker-compose-arm64.yaml
@@ -57,7 +57,7 @@ services:
       MYSQL_DATABASE: keyv_test
       MYSQL_ROOT_HOST: '%'
   keyv_valkey:
-    image: valkey/valkey:latest
+    image: valkey/valkey:9.1.1-trixie@sha256:64e361b630ecf18dff7ca4df6a88e6eafc193687eb48cff2c7e0a293ab67d29a
     command: redis-server --port 6370
     environment:
       REDIS_HOST: redis

--- a/scripts/docker-compose.yaml
+++ b/scripts/docker-compose.yaml
@@ -57,7 +57,7 @@ services:
       MYSQL_DATABASE: keyv_test
       MYSQL_ROOT_HOST: '%'
   keyv_valkey:
-    image: valkey/valkey:latest
+    image: valkey/valkey:9.1.1-trixie@sha256:64e361b630ecf18dff7ca4df6a88e6eafc193687eb48cff2c7e0a293ab67d29a
     command: redis-server --port 6370
     environment:
       REDIS_HOST: redis


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Pin the Valkey test service from floating `valkey/valkey:latest` to Valkey 9.1.1 on Debian trixie.

`:latest` currently tracks 9.1.2 (`Created` 2026-09-07, ~1 day old), which fails the 7-day age gate. 9.1.1-trixie is the newest 9.x trixie image at least 7 days old (`Created` 2026-08-31).

This is test compose only — not a Keyv library change.

## Changes
- pin `keyv_valkey` in `scripts/docker-compose.yaml` and `scripts/docker-compose-arm64.yaml` to `valkey/valkey:9.1.1-trixie@sha256:64e361b630ecf18dff7ca4df6a88e6eafc193687eb48cff2c7e0a293ab67d29a`

## Verification
- [x] `skopeo inspect`: 9.1.2 too young; 9.1.1-trixie is 8 days old
- [x] compose YAML parses
- [ ] `docker compose` pull/up (no Docker daemon here; CI starts test services)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457061d6-444f-4516-9546-273a7c3a110c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457061d6-444f-4516-9546-273a7c3a110c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

