### PR TITLE
mono - chore: pin mongo Docker service image

### DIFF
--- a/scripts/docker-compose-arm64.yaml
+++ b/scripts/docker-compose-arm64.yaml
@@ -79,7 +79,7 @@ services:
     volumes:
       - ../packages/redis/tls:/tls
   keyv_mongo:
-    image: mongo:latest
+    image: mongo:8.3.8@sha256:5211c51171f57ae60842b11664bb244628971b3d35325762a97888337b9bb0db
     restart: always
     ports:
       - 27017:27017

--- a/scripts/docker-compose.yaml
+++ b/scripts/docker-compose.yaml
@@ -79,7 +79,7 @@ services:
     volumes:
       - ../packages/redis/tls:/tls
   keyv_mongo:
-    image: mongo:latest
+    image: mongo:8.3.8@sha256:5211c51171f57ae60842b11664bb244628971b3d35325762a97888337b9bb0db
     restart: always
     ports:
       - 27017:27017


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Pin the MongoDB test service from floating `mongo:latest` to MongoDB 8.3.8, using the multi-arch index digest that `latest`, `8`, `8.3`, and `8.3.8` already share (`Created` 2026-08-18, 20 days old).

This is test compose only — not a Keyv library change. `mongo:8.3.8-noble` is a different digest, so the pin stays on un-suffixed `8.3.8` to match `:latest`.

## Changes
- pin `keyv_mongo` in `scripts/docker-compose.yaml` and `scripts/docker-compose-arm64.yaml` to `mongo:8.3.8@sha256:5211c51171f57ae60842b11664bb244628971b3d35325762a97888337b9bb0db`

## Verification
- [x] `skopeo inspect`: matching tags share this digest
- [x] compose YAML parses
- [ ] `docker compose` pull/up (no Docker daemon here; CI starts test services)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457061d6-444f-4516-9546-273a7c3a110c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457061d6-444f-4516-9546-273a7c3a110c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

