### PR TITLE
mono - chore: pin memcached Docker service image

### DIFF
--- a/scripts/docker-compose-arm64.yaml
+++ b/scripts/docker-compose-arm64.yaml
@@ -84,7 +84,7 @@ services:
     ports:
       - 27017:27017
   keyv_memcached:
-    image: memcached:latest
+    image: memcached:1.6.45-trixie@sha256:75c93cc91e76853da7c029e74d6e8dbd44774dd3713c93be8cd1971ad26120a4
     ports:
       - "11211:11211"
   keyv_etcd:

--- a/scripts/docker-compose.yaml
+++ b/scripts/docker-compose.yaml
@@ -84,7 +84,7 @@ services:
     ports:
       - 27017:27017
   keyv_memcached:
-    image: memcached:latest
+    image: memcached:1.6.45-trixie@sha256:75c93cc91e76853da7c029e74d6e8dbd44774dd3713c93be8cd1971ad26120a4
     ports:
       - "11211:11211"
   keyv_etcd:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Pin the Memcached test service from floating `memcached:latest` to Memcached 1.6.45 on Debian trixie, using the multi-arch index digest that `latest`, `1`, `1.6`, and `1.6.45-trixie` already share (`Created` 2026-08-25).

This is test compose only — not a Keyv library change.

## Changes
- pin `keyv_memcached` in `scripts/docker-compose.yaml` and `scripts/docker-compose-arm64.yaml` to `memcached:1.6.45-trixie@sha256:75c93cc91e76853da7c029e74d6e8dbd44774dd3713c93be8cd1971ad26120a4`

## Verification
- [x] `skopeo inspect`: matching tags share this digest (14 days old)
- [x] compose YAML parses
- [ ] `docker compose` pull/up (no Docker daemon here; CI starts test services)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457061d6-444f-4516-9546-273a7c3a110c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457061d6-444f-4516-9546-273a7c3a110c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

