### PR TITLE
mono - chore: pin dynamodb-local Docker service image

### DIFF
--- a/scripts/docker-compose-arm64.yaml
+++ b/scripts/docker-compose-arm64.yaml
@@ -98,7 +98,7 @@ services:
       - 2379:2379
       - 2380:2380
   keyv_dynamo:
-    image: amazon/dynamodb-local:latest
+    image: amazon/dynamodb-local:3.3.1@sha256:ff89bd48ff32cd8d9be5fee8873b65b8854dc408f1afe881be6eb00247bc0dab
     ports:
       - 8000:8000
     healthcheck:

--- a/scripts/docker-compose.yaml
+++ b/scripts/docker-compose.yaml
@@ -97,7 +97,7 @@ services:
       - 2379:2379
       - 2380:2380
   keyv_dynamo:
-    image: amazon/dynamodb-local:latest
+    image: amazon/dynamodb-local:3.3.1@sha256:ff89bd48ff32cd8d9be5fee8873b65b8854dc408f1afe881be6eb00247bc0dab
     ports:
       - 8000:8000
     healthcheck:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Pin the DynamoDB Local test service from floating `amazon/dynamodb-local:latest` to 3.3.1, using the multi-arch index digest that `latest` and `3.3.1` already share (`Created` 2026-07-31).

This is test compose only — not a Keyv library change.

## Changes
- pin `keyv_dynamo` in `scripts/docker-compose.yaml` and `scripts/docker-compose-arm64.yaml` to `amazon/dynamodb-local:3.3.1@sha256:ff89bd48ff32cd8d9be5fee8873b65b8854dc408f1afe881be6eb00247bc0dab`

## Verification
- [x] `skopeo inspect`: `latest` and `3.3.1` share this digest (39 days old)
- [x] compose YAML parses
- [ ] `docker compose` pull/up (no Docker daemon here; CI starts test services)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457061d6-444f-4516-9546-273a7c3a110c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457061d6-444f-4516-9546-273a7c3a110c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

