### PR TITLE
mono - chore: pin etcd Docker service image

### DIFF
--- a/scripts/docker-compose-arm64.yaml
+++ b/scripts/docker-compose-arm64.yaml
@@ -88,7 +88,7 @@ services:
     ports:
       - "11211:11211"
   keyv_etcd:
-    image: registry.k8s.io/etcd:3.5.15-0
+    image: registry.k8s.io/etcd:3.5.33-0@sha256:89e9d4e344864374bf141d10ac90034e50647f58498ef0b5f0d6e4fd328c58b9
     platform: linux/arm64/v8
     command:
       - etcd

--- a/scripts/docker-compose.yaml
+++ b/scripts/docker-compose.yaml
@@ -88,7 +88,7 @@ services:
     ports:
       - "11211:11211"
   keyv_etcd:
-    image: registry.k8s.io/etcd:3.5.15-0
+    image: registry.k8s.io/etcd:3.5.33-0@sha256:89e9d4e344864374bf141d10ac90034e50647f58498ef0b5f0d6e4fd328c58b9
     command:
       - etcd
       - --listen-client-urls=http://0.0.0.0:2379


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Pin the etcd test service and refresh it within the 3.5 line: `registry.k8s.io/etcd:3.5.15-0` (no digest, July 2024) → `3.5.33-0` with the multi-arch index digest. 3.5.33-0 is the newest 3.5.x tag at least 7 days old (`Created` 2026-07-23).

etcd 3.6 is a major-line bump and is not included. This is test compose only — not a Keyv library change.

## Changes
- pin `keyv_etcd` in `scripts/docker-compose.yaml` and `scripts/docker-compose-arm64.yaml` to `registry.k8s.io/etcd:3.5.33-0@sha256:89e9d4e344864374bf141d10ac90034e50647f58498ef0b5f0d6e4fd328c58b9`

## Verification
- [x] `skopeo inspect`: 3.5.33-0 is 47 days old; 3.6.14-0 left unpinned on purpose
- [x] compose YAML parses
- [ ] `docker compose` pull/up (no Docker daemon here; CI starts test services)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457061d6-444f-4516-9546-273a7c3a110c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457061d6-444f-4516-9546-273a7c3a110c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

