### PR TITLE
keyv - chore: upgrade lru.min to 1.1.5

### DIFF
--- a/packages/keyv/package.json
+++ b/packages/keyv/package.json
@@ -72,7 +72,7 @@
 		"@keyv/sqlite": "workspace:^",
 		"@keyv/test-suite": "workspace:^",
 		"@vitest/coverage-v8": "^4.1.9",
-		"lru.min": "^1.1.1",
+		"lru.min": "^1.1.5",
 		"quick-lru": "^7.0.0",
 		"rimraf": "^6.1.2",
 		"timekeeper": "^2.3.1",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Bump the test-only `lru.min` fixture in `keyv` from 1.1.4 to 1.1.5. 1.1.5 is now past the 7-day `minimumReleaseAge` gate. This is not a Keyv runtime dependency.

## Changes
- `packages/keyv` `devDependencies.lru.min`: `^1.1.1` → `^1.1.5`

## Artifact diffs
- [lru.min 1.1.4 → 1.1.5](https://drydock.org/diff/lru.min/1.1.4/1.1.5)

## Verification
- [x] `pnpm --filter keyv add -D lru.min@1.1.5`
- [x] `pnpm build:keyv`
- [x] `vitest run test/generic-store-integration.test.ts` (101 tests)
- [ ] full `pnpm test` (no Docker here; CI covers it)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457061d6-444f-4516-9546-273a7c3a110c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457061d6-444f-4516-9546-273a7c3a110c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

