### PR TITLE
dynamo - chore: upgrade AWS SDK DynamoDB dependencies

### DIFF
--- a/packages/dynamo/package.json
+++ b/packages/dynamo/package.json
@@ -50,8 +50,8 @@
   },
   "homepage": "https://github.com/jaredwray/keyv",
   "dependencies": {
-    "@aws-sdk/client-dynamodb": "^3.958.0",
-    "@aws-sdk/lib-dynamodb": "^3.958.0"
+    "@aws-sdk/client-dynamodb": "^3.1124.0",
+    "@aws-sdk/lib-dynamodb": "^3.1124.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.5.1",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Bump the DynamoDB adapter’s AWS SDK v3 packages from 3.1123.0 to 3.1124.0. Same major line — not a Keyv public-API change.

## Changes
- `@aws-sdk/client-dynamodb` and `@aws-sdk/lib-dynamodb` in `packages/dynamo`: `^3.958.0` → `^3.1124.0`

## Artifact diffs
- [@aws-sdk/client-dynamodb 3.1123.0 → 3.1124.0](https://drydock.org/diff/@aws-sdk/client-dynamodb/3.1123.0/3.1124.0)
- [@aws-sdk/lib-dynamodb 3.1123.0 → 3.1124.0](https://drydock.org/diff/@aws-sdk/lib-dynamodb/3.1123.0/3.1124.0)

## Verification
- [x] `pnpm --filter @keyv/dynamo add` both packages at 3.1124.0
- [x] `pnpm --filter @keyv/dynamo run build`
- [x] `pnpm --filter @keyv/dynamo run lint:ci`
- [ ] `pnpm --filter @keyv/dynamo test` (needs DynamoDB Local; CI covers it)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457061d6-444f-4516-9546-273a7c3a110c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457061d6-444f-4516-9546-273a7c3a110c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

