### PR TITLE
mono - chore: defense - add CODEOWNERS for high-risk paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# High-risk paths. Last matching pattern wins.
+# Root-anchored so nested copies (e.g. skills/**/scripts/) are not owned here.
+/.github/ @jaredwray
+/.vscode/ @jaredwray
+/.cursor/ @jaredwray
+/.devcontainer/ @jaredwray
+/scripts/ @jaredwray

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -12,11 +12,11 @@ Omitted until they apply on this branch:
 - Dev Container image pin — no `devcontainer.json`
 
 ## 1. Security docs
-- [ ] `SECURITY.md` present — contact info + "How this repository is secured" summary (PR #2128 pending)
-- [ ] `DEFENSE_IN_DEPTH.md` present (this file) (PR #2128 pending)
+- [x] `SECURITY.md` present — contact info + "How this repository is secured" summary — PR #2128
+- [x] `DEFENSE_IN_DEPTH.md` present (this file) — PR #2128
 
 ## 2. CODEOWNERS and cloud bootstrap
-- [ ] `.github/CODEOWNERS` covers `/.github/`, `/.vscode/`, `/.cursor/`, `/.devcontainer/`, `/scripts/` with owners the maintainer names
+- [ ] `.github/CODEOWNERS` covers `/.github/`, `/.vscode/`, `/.cursor/`, `/.devcontainer/`, `/scripts/` with owners the maintainer names (PR pending)
 
 ## 3. Dependencies (pnpm)
 - [x] `packageManager: pnpm@11.3+` pinned in `package.json` — verified 2026-09-08 (`pnpm@12.2.1`)

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -16,7 +16,7 @@ Omitted until they apply on this branch:
 - [x] `DEFENSE_IN_DEPTH.md` present (this file) — PR #2128
 
 ## 2. CODEOWNERS and cloud bootstrap
-- [ ] `.github/CODEOWNERS` covers `/.github/`, `/.vscode/`, `/.cursor/`, `/.devcontainer/`, `/scripts/` with owners the maintainer names (PR pending)
+- [ ] `.github/CODEOWNERS` covers `/.github/`, `/.vscode/`, `/.cursor/`, `/.devcontainer/`, `/scripts/` with owners the maintainer names (PR #2129 pending)
 
 ## 3. Dependencies (pnpm)
 - [x] `packageManager: pnpm@11.3+` pinned in `package.json` — verified 2026-09-08 (`pnpm@12.2.1`)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,3 +30,4 @@ hardening checklist; progress is tracked in [DEFENSE_IN_DEPTH.md](./DEFENSE_IN_D
 - Workflows do not use `pull_request_target`.
 - Published packages set `repository.url` to this repo so provenance can map back.
 - Socket reviews every pull request that changes dependencies; Aikido scans every build.
+- `.github/CODEOWNERS` names `@jaredwray` for `/.github/`, `/.vscode/`, `/.cursor/`, `/.devcontainer/`, and `/scripts/`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Add `.github/CODEOWNERS` for high-risk paths on `v5` (`defense-in-depth-nodejs` § 2).

## Status update

`DEFENSE_IN_DEPTH.md`: CODEOWNERS → (PR #2129 pending); § 1 items → PR #2128

## Changes

- Add `.github/CODEOWNERS` covering `/.github/`, `/.vscode/`, `/.cursor/`, `/.devcontainer/`, and `/scripts/` with owner `@jaredwray`.
- Reconcile § 1 as merged (`SECURITY.md` / `DEFENSE_IN_DEPTH.md` — PR #2128).
- Record the CODEOWNERS control in the `SECURITY.md` summary.

## Verification

- [x] CODEOWNERS matches the skill template with the owners you named
- [x] CI on this PR (bun, codecov, node-20/22/24, Aikido, Socket)

Reference: `defense-in-depth-nodejs` § 2

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b5aa2a5d-7117-4421-b5ac-dce805a1c49d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b5aa2a5d-7117-4421-b5ac-dce805a1c49d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

