### PR TITLE
mono - chore: defense - set pnpm trustPolicy to no-downgrade

### DIFF
--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -21,7 +21,7 @@ Omitted until they apply on this branch:
 ## 3. Dependencies (pnpm)
 - [x] `packageManager: pnpm@11.3+` pinned in `package.json` — verified 2026-09-08 (`pnpm@12.2.1`)
 - [x] 7-day cooldown: `minimumReleaseAge: 10080`, `minimumReleaseAgeStrict: true`, `minimumReleaseAgeIgnoreMissingTime: false`; no first-party `minimumReleaseAgeExclude` — PR #2130
-- [ ] `trustPolicy: no-downgrade`; no first-party `trustPolicyExclude` (PR pending)
+- [ ] `trustPolicy: no-downgrade`; no first-party `trustPolicyExclude` (PR #2131 pending)
 - [ ] Lifecycle scripts blocked: `strictDepBuilds: true`, `dangerouslyAllowAllBuilds: false`, `allowBuilds: {}` baseline
 - [ ] `blockExoticSubdeps: true`
 - [ ] Lockfile committed; CI installs with `pnpm install --frozen-lockfile`

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -20,8 +20,8 @@ Omitted until they apply on this branch:
 
 ## 3. Dependencies (pnpm)
 - [x] `packageManager: pnpm@11.3+` pinned in `package.json` — verified 2026-09-08 (`pnpm@12.2.1`)
-- [ ] 7-day cooldown: `minimumReleaseAge: 10080`, `minimumReleaseAgeStrict: true`, `minimumReleaseAgeIgnoreMissingTime: false`; no first-party `minimumReleaseAgeExclude` (PR #2130 pending)
-- [ ] `trustPolicy: no-downgrade`; no first-party `trustPolicyExclude`
+- [x] 7-day cooldown: `minimumReleaseAge: 10080`, `minimumReleaseAgeStrict: true`, `minimumReleaseAgeIgnoreMissingTime: false`; no first-party `minimumReleaseAgeExclude` — PR #2130
+- [ ] `trustPolicy: no-downgrade`; no first-party `trustPolicyExclude` (PR pending)
 - [ ] Lifecycle scripts blocked: `strictDepBuilds: true`, `dangerouslyAllowAllBuilds: false`, `allowBuilds: {}` baseline
 - [ ] `blockExoticSubdeps: true`
 - [ ] Lockfile committed; CI installs with `pnpm install --frozen-lockfile`

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,14 @@ packages:
 minimumReleaseAge: 10080
 minimumReleaseAgeStrict: true
 minimumReleaseAgeIgnoreMissingTime: false
+# Fail if a later-published version has weaker trust evidence than an earlier one.
+trustPolicy: no-downgrade
+# These versions fail trustPolicy: no-downgrade (no provenance; later versions
+# of the same package have attestations). Pin to a version that already meets
+# the gate — do not exclude first-party packages.
+overrides:
+  semver@5.7.2: 7.7.3
+  chokidar@4.0.3: 5.0.0
 # Adapters and @keyv/test-suite depend on each other. pnpm 12 fails cyclic
 # `run build` unless this is set; pnpm 11 only warned.
 ignoreWorkspaceCycles: true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Enable `trustPolicy: no-downgrade` on `v5` (`defense-in-depth-nodejs` § 3).

## Status update

`DEFENSE_IN_DEPTH.md`: trustPolicy → (PR #2131 pending); 7-day cooldown → PR #2130

## Changes

- Set `trustPolicy: no-downgrade`. No `trustPolicyExclude`.
- Override `semver@5.7.2` → `7.7.3` and `chokidar@4.0.3` → `5.0.0` so install can meet the gate (those versions have no provenance; later ones do). Same approach as `main`.
- Reconcile the cooldown item as merged in PR #2130.

`chokidar@5` is ESM-only and needs Node ≥ 20.19. `tsup` still declares `chokidar@^4.0.3`; CI already uses Node 20/22/24.

## Verification

- [x] `pnpm install` succeeds with `trustPolicy: no-downgrade` after the overrides
- [x] `tsup` CJS/ESM build for `keyv` still succeeds with `chokidar@5.0.0`
- [x] CI on this PR (bun, codecov, node-20/22/24, Aikido, Socket)

Reference: `defense-in-depth-nodejs` § 3

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b5aa2a5d-7117-4421-b5ac-dce805a1c49d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b5aa2a5d-7117-4421-b5ac-dce805a1c49d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

