### PR TITLE
mono - chore: defense - block unapproved pnpm lifecycle scripts

### DIFF
--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -30,9 +30,6 @@ jobs:
       - name: Install Dependencies  
         run: pnpm install
 
-      - name: Approve Builds
-        run: pnpm approve-builds
-
       - name: Build
         run: pnpm build
         

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -21,8 +21,8 @@ Omitted until they apply on this branch:
 ## 3. Dependencies (pnpm)
 - [x] `packageManager: pnpm@11.3+` pinned in `package.json` — verified 2026-09-08 (`pnpm@12.2.1`)
 - [x] 7-day cooldown: `minimumReleaseAge: 10080`, `minimumReleaseAgeStrict: true`, `minimumReleaseAgeIgnoreMissingTime: false`; no first-party `minimumReleaseAgeExclude` — PR #2130
-- [ ] `trustPolicy: no-downgrade`; no first-party `trustPolicyExclude` (PR #2131 pending)
-- [ ] Lifecycle scripts blocked: `strictDepBuilds: true`, `dangerouslyAllowAllBuilds: false`, `allowBuilds: {}` baseline
+- [x] `trustPolicy: no-downgrade`; no first-party `trustPolicyExclude` — PR #2131
+- [ ] Lifecycle scripts blocked: `strictDepBuilds: true`, `dangerouslyAllowAllBuilds: false`, `allowBuilds: {}` baseline (PR pending)
 - [ ] `blockExoticSubdeps: true`
 - [ ] Lockfile committed; CI installs with `pnpm install --frozen-lockfile`
 - [x] No `.github/dependabot.yml`; other dependency-update tools (if any) open PRs only — never auto-merge — verified 2026-09-08

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -22,7 +22,7 @@ Omitted until they apply on this branch:
 - [x] `packageManager: pnpm@11.3+` pinned in `package.json` — verified 2026-09-08 (`pnpm@12.2.1`)
 - [x] 7-day cooldown: `minimumReleaseAge: 10080`, `minimumReleaseAgeStrict: true`, `minimumReleaseAgeIgnoreMissingTime: false`; no first-party `minimumReleaseAgeExclude` — PR #2130
 - [x] `trustPolicy: no-downgrade`; no first-party `trustPolicyExclude` — PR #2131
-- [ ] Lifecycle scripts blocked: `strictDepBuilds: true`, `dangerouslyAllowAllBuilds: false`, `allowBuilds: {}` baseline (PR pending)
+- [ ] Lifecycle scripts blocked: `strictDepBuilds: true`, `dangerouslyAllowAllBuilds: false`, `allowBuilds: {}` baseline (PR #2132 pending)
 - [ ] `blockExoticSubdeps: true`
 - [ ] Lockfile committed; CI installs with `pnpm install --frozen-lockfile`
 - [x] No `.github/dependabot.yml`; other dependency-update tools (if any) open PRs only — never auto-merge — verified 2026-09-08

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,11 +16,11 @@ overrides:
 # Adapters and @keyv/test-suite depend on each other. pnpm 12 fails cyclic
 # `run build` unless this is set; pnpm 11 only warned.
 ignoreWorkspaceCycles: true
-# pnpm 11 moved dependency build-script approval here (was
-# pnpm.onlyBuiltDependencies in package.json) — same set, same format as main.
+# Lifecycle scripts are blocked unless listed here. Each entry is a reviewed
+# third-party exception — do not run `pnpm approve-builds` in CI.
+strictDepBuilds: true
+dangerouslyAllowAllBuilds: false
 allowBuilds:
   esbuild: true
   protobufjs: true
   sqlite3: true
-  sqlite325h: true
-  unrs-resolver: true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Block unapproved pnpm lifecycle scripts on `v5` (`defense-in-depth-nodejs` § 3).

## Status update

`DEFENSE_IN_DEPTH.md`: lifecycle scripts → (PR #2132 pending); trustPolicy → PR #2131

## Changes

- Set `strictDepBuilds: true` and `dangerouslyAllowAllBuilds: false`.
- Keep reviewed third-party `allowBuilds` exceptions that this repo actually needs: `esbuild`, `protobufjs`, `sqlite3`. Drop unused `sqlite325h` and `unrs-resolver`.
- Remove `pnpm approve-builds` from the codecov workflow so CI cannot silently approve new install scripts.

## Verification

- [x] `pnpm install` succeeds with the strict build policy
- [x] CI on this PR (bun, codecov, node-20/22/24, Aikido, Socket)

Reference: `defense-in-depth-nodejs` § 3

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b5aa2a5d-7117-4421-b5ac-dce805a1c49d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b5aa2a5d-7117-4421-b5ac-dce805a1c49d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

