### PR TITLE
mono - chore: defense - kebab-case Actions workflow and job names

### DIFF
--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: Node 24
+    name: node-24
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,7 +9,7 @@
 # the `language` matrix defined below to confirm you have the correct set of
 # supported CodeQL languages.
 #
-name: "CodeQL"
+name: codeql
 
 on:
   push:
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   analyze:
-    name: Analyze
+    name: analyze
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   setup-build-deploy:
-    name: Deploy Website
+    name: deploy-website
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,7 +53,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    name: Build
+    name: build
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -82,7 +82,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    name: Test
+    name: test
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -118,7 +118,7 @@ jobs:
     needs: [build, test]
     runs-on: ubuntu-latest # provenance/OIDC require a cloud-hosted runner
     timeout-minutes: 20
-    name: Publish
+    name: publish
     environment: release
     # OIDC trusted publishing: GitHub mints a short-lived OIDC token that pnpm
     # exchanges with npm for a one-time publish credential. No NPM_TOKEN.

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -29,8 +29,8 @@ This checklist is for the `v5` branch. The same catalog is already complete on `
 - [x] No `contents: write` except jobs whose purpose is mutating the repo (GitHub Release, Changesets version PR); generated output is a workflow artifact, never committed back from CI — verified 2026-09-09 (no remaining `contents: write`, `git commit` / `git push`, or auto-commit actions)
 - [x] Every action pinned to a full commit SHA (`npx actions-up`) — PR #2137
 - [x] Every job installs Socket Firewall (`SocketDev/action` SHA-pinned, `firewall-version` pinned); `pnpm install` / `npm install` run as `sfw pnpm install` / `sfw npm install` — PR #2138
-- [ ] `.github/workflows/check-workflows.yaml` lints workflows with zizmor on every PR (PR #2139 pending)
-- [ ] Workflow `name:` and job `name:` contain no spaces (kebab-case) so they can be set as required status checks
+- [x] `.github/workflows/check-workflows.yaml` lints workflows with zizmor on every PR — PR #2139
+- [ ] Workflow `name:` and job `name:` contain no spaces (kebab-case) so they can be set as required status checks (PR pending)
 - [x] `persist-credentials: false` on checkouts that don't push — verified 2026-09-09 (required for zizmor to pass)
 - [x] No `pull_request_target` on workflows that run untrusted PR code — verified 2026-09-08
 - [ ] Artifact-publishing workflows disable `actions/setup-node` default caching (`package-manager-cache: false`) to prevent cache poisoning

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -30,7 +30,7 @@ This checklist is for the `v5` branch. The same catalog is already complete on `
 - [x] Every action pinned to a full commit SHA (`npx actions-up`) — PR #2137
 - [x] Every job installs Socket Firewall (`SocketDev/action` SHA-pinned, `firewall-version` pinned); `pnpm install` / `npm install` run as `sfw pnpm install` / `sfw npm install` — PR #2138
 - [x] `.github/workflows/check-workflows.yaml` lints workflows with zizmor on every PR — PR #2139
-- [ ] Workflow `name:` and job `name:` contain no spaces (kebab-case) so they can be set as required status checks (PR pending)
+- [ ] Workflow `name:` and job `name:` contain no spaces (kebab-case) so they can be set as required status checks (PR #2140 pending)
 - [x] `persist-credentials: false` on checkouts that don't push — verified 2026-09-09 (required for zizmor to pass)
 - [x] No `pull_request_target` on workflows that run untrusted PR code — verified 2026-09-08
 - [ ] Artifact-publishing workflows disable `actions/setup-node` default caching (`package-manager-cache: false`) to prevent cache poisoning


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [ ] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Defense-in-depth catalog item: kebab-case workflow and job `name:` (no spaces) so they can be required status checks.

## Summary
Rename GitHub Actions workflow and job `name:` values to kebab-case. GitHub rulesets cannot require a check whose name contains a space.

**Status:** `DEFENSE_IN_DEPTH.md`: kebab-case workflow/job names → `(PR #2140 pending)`

Also marks zizmor as PR #2139 (merged).

## Renames
| File | Before | After |
| --- | --- | --- |
| `codecov.yaml` job | `Node 24` | `node-24` |
| `deploy-website.yml` job | `Deploy Website` | `deploy-website` |
| `codeql-analysis.yml` workflow | `"CodeQL"` | `codeql` |
| `codeql-analysis.yml` job | `Analyze` | `analyze` |
| `release.yaml` jobs | `Build` / `Test` / `Publish` | `build` / `test` / `publish` |

`tests.yaml` (`node-${{ matrix.node }}`), `bun`, and `check-workflows` were already kebab-case. Step names still have spaces on purpose.

## Verification
- [x] Every workflow `name:` and job `name:` in `.github/workflows/` has no spaces
- [ ] CI on this PR is green (check contexts for codecov / CodeQL will show the new names)

Reference: defense-in-depth-nodejs § 4

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b5aa2a5d-7117-4421-b5ac-dce805a1c49d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b5aa2a5d-7117-4421-b5ac-dce805a1c49d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

