### PR TITLE
mono - chore: defense - stage npm packages instead of live publish

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,19 +1,19 @@
 name: release
 
-# Publishes v5-branch workspace packages to npm whose manually-set version is
+# Stages v5-branch workspace packages to npm whose manually-set version is
 # ahead of the registry. Versions are never bumped here — a human bumps each
 # package's `version` (typically via a release PR), then runs this workflow
 # MANUALLY from the v5 branch, which figures out what actually needs
-# publishing and publishes it in dependency order under the right dist-tag.
+# staging and stages it in dependency order under the right dist-tag.
 # See scripts/release.mjs for the decision logic, including the MAJOR CEILING:
-# nothing at or above 6.0.0 (including pre-releases) can ever be published
+# nothing at or above 6.0.0 (including pre-releases) can ever be staged
 # from the v5 branch — v6 is released from `main`.
 #
 # How to run it (manual, workflow_dispatch only):
 #   Actions tab → "release" → "Run workflow" → set "Use workflow from" to the
 #   `v5` branch → leave "Dry run" checked to preview the plan, or uncheck it to
-#   publish for real → "Run workflow". The workflow definition on the branch
-#   you pick is the one that runs; a real publish only happens from `v5` (any
+#   stage for real → "Run workflow". The workflow definition on the branch
+#   you pick is the one that runs; a real stage only happens from `v5` (any
 #   other ref is forced to a dry run below).
 #
 # Authentication uses OIDC trusted publishing (tokenless) with provenance:
@@ -23,6 +23,7 @@ name: release
 #     `jaredwray/keyv` + workflow `release.yaml` (+ environment `release`).
 #     This file shares its name with main's release workflow on purpose, so
 #     one trusted-publisher configuration covers both release lines.
+#     Configure that publisher **stage-only** so CI can stage, never publish live.
 #   - This workflow is fully tokenless: no NPM_TOKEN secret anywhere. A
 #     brand-new package's first-ever publish (which OIDC cannot do) needs a
 #     one-time manual `pnpm publish` — the release script refuses such
@@ -162,10 +163,11 @@ jobs:
         run: pnpm test:release
 
       # Honors the dry_run input, and is forced to a dry run from any ref other
-      # than the v5 branch so branch versions can't be pushed to npm. A real
-      # publish therefore requires dispatching from v5 with dry_run unchecked.
+      # than the v5 branch so branch versions can't be staged to npm. A real
+      # stage therefore requires dispatching from v5 with dry_run unchecked.
       # The script's own guards still apply on top: the < 6.0.0 major ceiling,
       # skip-already-published, refuse first-time (non-OIDC) publishes, and
-      # never move a dist-tag backwards.
+      # never move a dist-tag backwards. Each package is packed to ./packed/
+      # then staged with `pnpm stage publish ./packed/<name>.tgz`.
       - name: Release
         run: node scripts/release.mjs ${{ (inputs.dry_run || github.ref != 'refs/heads/v5') && '--dry-run' || '' }}

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,9 @@ jspm_packages
 # Optional REPL history
 .node_repl_history
 
+# Release staging tarballs (scripts/release.mjs)
+packed
+
 ## OS X
 
 *.DS_Store

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -38,7 +38,7 @@ This checklist is for the `v5` branch. The same catalog is already complete on `
 
 ## 5. npm publishing — npm libraries only
 - [ ] OIDC trusted publishing configured **stage-only** on npmjs.com for the publish workflow — it can stage, never publish live (manual)
-- [ ] `.github/workflows/release.yaml` packs then stages with `pnpm stage publish ./packed/*.tgz --no-git-checks` (PR pending)
+- [ ] `.github/workflows/release.yaml` packs then stages with `pnpm stage publish ./packed/*.tgz --no-git-checks` (PR #2142 pending)
 - [ ] Maintainer promotes staged versions with 2FA (manual)
 - [ ] Drydock connected — staged releases reviewed before promotion (manual)
 - [ ] No direct publish rights: package requires 2FA and disallows tokens (manual)

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -33,12 +33,12 @@ This checklist is for the `v5` branch. The same catalog is already complete on `
 - [x] Workflow `name:` and job `name:` contain no spaces (kebab-case) so they can be set as required status checks — PR #2140
 - [x] `persist-credentials: false` on checkouts that don't push — verified 2026-09-09 (required for zizmor to pass)
 - [x] No `pull_request_target` on workflows that run untrusted PR code — verified 2026-09-08
-- [ ] Artifact-publishing workflows disable `actions/setup-node` default caching (`package-manager-cache: false`) to prevent cache poisoning (PR #2141 pending)
+- [x] Artifact-publishing workflows disable `actions/setup-node` default caching (`package-manager-cache: false`) to prevent cache poisoning — PR #2141
 - [ ] No npm tokens (or other registry credentials) in Actions secrets
 
 ## 5. npm publishing — npm libraries only
 - [ ] OIDC trusted publishing configured **stage-only** on npmjs.com for the publish workflow — it can stage, never publish live (manual)
-- [ ] `.github/workflows/release.yaml` packs then stages with `pnpm stage publish ./packed/*.tgz --no-git-checks`
+- [ ] `.github/workflows/release.yaml` packs then stages with `pnpm stage publish ./packed/*.tgz --no-git-checks` (PR pending)
 - [ ] Maintainer promotes staged versions with 2FA (manual)
 - [ ] Drydock connected — staged releases reviewed before promotion (manual)
 - [ ] No direct publish rights: package requires 2FA and disallows tokens (manual)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,6 +34,7 @@ hardening checklist; progress is tracked in [DEFENSE_IN_DEPTH.md](./DEFENSE_IN_D
 - CI `pnpm install` / `npm install` runs through Socket Firewall (`sfw`).
 - Workflows are security-linted with zizmor on every pull request.
 - Release and website-deploy jobs disable `setup-node`'s default package-manager cache.
+- The release workflow stages packages with `pnpm stage publish` (pack then stage a tarball); it does not publish live.
 - Published packages set `repository.url` to this repo so provenance can map back.
 - Socket reviews every pull request that changes dependencies; Aikido scans every build.
 - `.github/CODEOWNERS` names `@jaredwray` for `/.github/`, `/.vscode/`, `/.cursor/`, `/.devcontainer/`, and `/scripts/`.

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -6,7 +6,8 @@
  * bumped by a human / release PR). This script never changes versions. Its job
  * is to decide, for every publishable workspace package, whether the locally
  * declared version still needs to be published — and under which dist-tag —
- * and, unless running a dry run, to publish the ones that do.
+ * and, unless running a dry run, to stage the ones that do. A maintainer
+ * promotes each staged version with 2FA; this script never publishes live.
  *
  * ## The v5 branch context
  *
@@ -68,22 +69,28 @@
  *
  * Publishing happens in **dependency order** (topological sort over the
  * workspace's runtime deps — dependencies, optionalDependencies and
- * peerDependencies): a package is always published after the workspace
+ * peerDependencies): a package is always staged after the workspace
  * packages it relies on, because pnpm rewrites each `workspace:^` reference
- * to the dependency's concrete version at publish time, and a dependent must
+ * to the dependency's concrete version at pack time, and a dependent must
  * never be released ahead of a dependency it points at. If a run fails
- * partway, dependencies are already published before their dependents.
+ * partway, dependencies are already staged before their dependents.
  *
- * Publishing uses pnpm only (never npm) with provenance, so packages are
+ * Staging uses pnpm only (never npm) with provenance, so packages are
  * cryptographically linked to this repo + workflow when run from CI with an
  * OIDC `id-token: write` permission (npm trusted publishing — no NPM_TOKEN):
  *
- *     pnpm --filter <name> publish --tag <tag> --provenance --access public --no-git-checks
+ *     pnpm --filter <name> pack --out ./packed/<name>.tgz
+ *     pnpm stage publish ./packed/<name>.tgz --tag <tag> --provenance --access public --no-git-checks
+ *
+ * `pnpm stage publish` uploads to npm's staging queue, not the live
+ * registry. OIDC authorizes stage/publish only — it does not authorize
+ * `npm dist-tag add` (npm/cli#8547). Exactly one tag is applied via
+ * `stage publish --tag`.
  *
  * ## Usage
  *
- *   node scripts/release.mjs              # publish every package whose version is new
- *   node scripts/release.mjs --dry-run    # print the plan + validate packaging, publish nothing
+ *   node scripts/release.mjs              # stage every package whose version is new
+ *   node scripts/release.mjs --dry-run    # print the plan + pack tarballs, stage nothing
  *   node scripts/release.mjs --json       # emit the plan as JSON (implies no publishing noise)
  *
  * ## Environment
@@ -97,16 +104,19 @@
  * lookup failed, or a publish failed.
  *
  * The pure helpers (parseVersion / compareSemver / computeTag /
- * resolvePlanAction) are exported and unit-tested in release.test.mjs;
+ * resolvePlanAction / packedTarballFor / packArgs / publishArgs) are exported
+ * and unit-tested in release.test.mjs;
  * main() only executes when the file is run directly, so importing it for
  * tests has no side effects.
  */
 
 import { spawnSync } from "node:child_process";
-import { appendFileSync, readFileSync } from "node:fs";
+import { appendFileSync, mkdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
+
+const ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
 const REGISTRY = (process.env.NPM_CONFIG_REGISTRY || "https://registry.npmjs.org").replace(/\/$/, "");
 
@@ -154,8 +164,8 @@ function parseArgs(argv) {
 const HELP = `Release orchestrator for the Keyv v5 maintenance branch.
 
 Usage:
-  node scripts/release.mjs            Publish every package whose version is not yet on npm
-  node scripts/release.mjs --dry-run  Print the plan and validate packaging without publishing
+  node scripts/release.mjs            Stage every package whose version is not yet on npm
+  node scripts/release.mjs --dry-run  Print the plan and pack tarballs without staging
   node scripts/release.mjs --json     Emit the publish plan as JSON
 
 Versions are set manually; this script never bumps them. No version may be
@@ -546,36 +556,70 @@ function writeOutputs(published) {
 // Publishing.
 // ---------------------------------------------------------------------------
 
-/** Publish a single package with pnpm under exactly one dist-tag. Returns true on success. */
-function publishPackage(entry, { dryRun }) {
-	// --registry pins the publish to the SAME registry the plan was computed
-	// against, so an NPM_CONFIG_REGISTRY override can never produce a plan
-	// from one registry and a publish to another.
+// ---------------------------------------------------------------------------
+// Packing and staging.
+// ---------------------------------------------------------------------------
+
+/**
+ * Flatten a package name into a `./packed/*.tgz` path (`pnpm pack --out`
+ * and `pnpm stage publish` treat it as a local path). Scoped names are
+ * flattened (`@keyv/redis` → `keyv-redis`).
+ */
+export function packedTarballFor(name) {
+	return `./packed/${name.replace(/^@/, "").replaceAll("/", "-")}.tgz`;
+}
+
+/** Pack a workspace package to a known tarball path under `./packed/`. */
+export function packArgs(name) {
+	return ["--filter", name, "pack", "--out", packedTarballFor(name)];
+}
+
+/**
+ * The exact `pnpm` argument list used to stage a packed tarball. Flags:
+ * `--no-git-checks` (git-checks run even for a tarball and fail on a detached
+ * checkout and on the untracked pack output), `--access public` (required for
+ * scoped `@keyv/*` packages), `--provenance` on a real stage (REQUIRED:
+ * generates the npm provenance attestation from the CI OIDC context; it
+ * fails closed when no OIDC context is available). A dry run packs then
+ * runs `stage publish --dry-run` so packaging is validated without uploading.
+ * `--registry` pins the stage to the same registry the plan was computed
+ * against.
+ */
+export function publishArgs(tarball, tag, { dryRun = false } = {}) {
 	const args = [
-		"--filter",
-		entry.name,
+		"stage",
 		"publish",
+		tarball,
 		"--registry",
 		REGISTRY,
 		"--tag",
-		entry.tag,
+		tag,
 		"--access",
 		"public",
 		"--no-git-checks",
 	];
-
-	// Provenance attestations require the CI OIDC token (npm trusted
-	// publishing), so the flag is only meaningful for a real publish — and
-	// then it is REQUIRED, failing closed when no OIDC context is available.
-	// A dry run just validates the tarball/packaging locally.
 	if (dryRun) {
 		args.push("--dry-run");
 	} else {
 		args.push("--provenance");
 	}
 
-	console.log(`\n$ pnpm ${args.join(" ")}`);
-	const result = spawnSync("pnpm", args, { stdio: "inherit" });
+	return args;
+}
+
+/** Pack a package, then stage the tarball under exactly one dist-tag. Returns true on success. */
+function publishPackage(entry, { dryRun }) {
+	mkdirSync(path.join(ROOT_DIR, "packed"), { recursive: true });
+	const pack = packArgs(entry.name);
+	console.log(`\n$ pnpm ${pack.join(" ")}`);
+	const packed = spawnSync("pnpm", pack, { cwd: ROOT_DIR, stdio: "inherit" });
+	if (packed.status !== 0) {
+		return false;
+	}
+
+	const args = publishArgs(packedTarballFor(entry.name), entry.tag, { dryRun });
+	console.log(`$ pnpm ${args.join(" ")}`);
+	const result = spawnSync("pnpm", args, { cwd: ROOT_DIR, stdio: "inherit" });
 	return result.status === 0;
 }
 
@@ -642,7 +686,7 @@ async function main() {
 	}
 
 	console.log(
-		`\n${args.dryRun ? "[dry run] would publish" : "Publishing"} ${toPublish.length} package(s): ${toPublish
+		`\n${args.dryRun ? "[dry run] would stage" : "Staging"} ${toPublish.length} package(s): ${toPublish
 			.map((entry) => `${entry.name}@${entry.version} → ${entry.tag}`)
 			.join(", ")}`,
 	);
@@ -699,7 +743,7 @@ async function main() {
 
 	console.log("");
 	if (failed.length > 0) {
-		console.error(`Failed to publish ${failed.length} package(s):`);
+		console.error(`Failed to stage ${failed.length} package(s):`);
 		for (const entry of failed) {
 			console.error(`  - ${entry.name}@${entry.version}`);
 		}
@@ -718,8 +762,8 @@ async function main() {
 
 	console.log(
 		args.dryRun
-			? `Dry run complete — ${toPublish.length} package(s) would be published.`
-			: `Published ${published.length} package(s) successfully.`,
+			? `Dry run complete — ${toPublish.length} package(s) would be staged.`
+			: `Staged ${published.length} package(s) successfully.`,
 	);
 }
 

--- a/scripts/release.test.mjs
+++ b/scripts/release.test.mjs
@@ -4,7 +4,10 @@ import {
 	compareSemver,
 	computeTag,
 	exceedsMajorCeiling,
+	packArgs,
+	packedTarballFor,
 	parseVersion,
+	publishArgs,
 	resolvePlanAction,
 } from "./release.mjs";
 
@@ -215,5 +218,51 @@ describe("resolvePlanAction", () => {
 	it("handles a registry document without dist-tags", () => {
 		const doc = { versions: { "1.0.0": {} } };
 		expect(resolvePlanAction(pkg("@keyv/x", "1.0.1"), doc)).toMatchObject({ action: "publish", tag: "latest" });
+	});
+});
+
+describe("packedTarballFor / packArgs", () => {
+	it("flattens scoped names into a ./packed tarball path", () => {
+		expect(packedTarballFor("keyv")).toBe("./packed/keyv.tgz");
+		expect(packedTarballFor("@keyv/redis")).toBe("./packed/keyv-redis.tgz");
+	});
+
+	it("packs a workspace package to that tarball path", () => {
+		expect(packArgs("keyv")).toEqual(["--filter", "keyv", "pack", "--out", "./packed/keyv.tgz"]);
+	});
+});
+
+describe("publishArgs", () => {
+	it("builds the exact pnpm stage publish command for a tarball + tag", () => {
+		expect(publishArgs("./packed/keyv.tgz", "beta")).toEqual([
+			"stage",
+			"publish",
+			"./packed/keyv.tgz",
+			"--registry",
+			"https://registry.npmjs.org",
+			"--tag",
+			"beta",
+			"--access",
+			"public",
+			"--no-git-checks",
+			"--provenance",
+		]);
+	});
+
+	it("uses the given tarball and tag", () => {
+		expect(`pnpm ${publishArgs("./packed/keyv-redis.tgz", "v5-lts").join(" ")}`).toBe(
+			"pnpm stage publish ./packed/keyv-redis.tgz --registry https://registry.npmjs.org --tag v5-lts --access public --no-git-checks --provenance",
+		);
+	});
+
+	it("always includes --provenance on a real stage (required for npm provenance attestation)", () => {
+		expect(publishArgs("./packed/keyv.tgz", "latest")).toContain("--provenance");
+		expect(publishArgs("./packed/keyv-redis.tgz", "beta")).toContain("--provenance");
+	});
+
+	it("uses --dry-run instead of --provenance for a dry run", () => {
+		const args = publishArgs("./packed/keyv.tgz", "latest", { dryRun: true });
+		expect(args).toContain("--dry-run");
+		expect(args).not.toContain("--provenance");
 	});
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [ ] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Defense-in-depth catalog item: pack then `pnpm stage publish` instead of live `pnpm publish`.

## Summary
Switch the existing v5 release orchestrator from live `pnpm --filter … publish` to pack + `pnpm stage publish ./packed/<name>.tgz --no-git-checks`. Custom pipeline stays: major ceiling (`< 6.0.0`), per-package dist-tags (`latest` / `v5-lts` / channels), dependency order, dry-run, OIDC + provenance.

**Status:** `DEFENSE_IN_DEPTH.md`: packs then stages with `pnpm stage publish` → `(PR #2142 pending)`

Also marks setup-node cache as PR #2141 (merged).

npmjs **stage-only** trusted publisher, Drydock, and 2FA promotion remain `(manual)` — this PR only changes what CI runs. After merge, a real `release` dispatch will fail until each package's trusted publisher on npmjs.com includes `createStagedPackage` (ideally that permission only).

## Verification
- [x] `pnpm test:release` — 40 tests passed (helpers for `packedTarballFor` / `packArgs` / `publishArgs`, including required `--provenance`)
- [ ] CI on this PR is green

Reference: defense-in-depth-nodejs § 5

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b5aa2a5d-7117-4421-b5ac-dce805a1c49d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b5aa2a5d-7117-4421-b5ac-dce805a1c49d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

