### PR TITLE
mono - chore: defense - record completed npm and account manuals

### DIFF
--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -34,14 +34,14 @@ This checklist is for the `v5` branch. The same catalog is already complete on `
 - [x] `persist-credentials: false` on checkouts that don't push — verified 2026-09-09 (required for zizmor to pass)
 - [x] No `pull_request_target` on workflows that run untrusted PR code — verified 2026-09-08
 - [x] Artifact-publishing workflows disable `actions/setup-node` default caching (`package-manager-cache: false`) to prevent cache poisoning — PR #2141
-- [ ] No npm tokens (or other registry credentials) in Actions secrets
+- [x] No npm tokens (or other registry credentials) in Actions secrets — verified 2026-09-09
 
 ## 5. npm publishing — npm libraries only
-- [ ] OIDC trusted publishing configured **stage-only** on npmjs.com for the publish workflow — it can stage, never publish live (manual)
+- [x] OIDC trusted publishing configured **stage-only** on npmjs.com for the publish workflow — it can stage, never publish live (manual) — verified 2026-09-09
 - [x] `.github/workflows/release.yaml` packs then stages with `pnpm stage publish ./packed/*.tgz --no-git-checks` — PR #2142
-- [ ] Maintainer promotes staged versions with 2FA (manual)
-- [ ] Drydock connected — staged releases reviewed before promotion (manual)
-- [ ] No direct publish rights: package requires 2FA and disallows tokens (manual)
+- [x] Maintainer promotes staged versions with 2FA (manual) — verified 2026-09-09
+- [x] Drydock connected — staged releases reviewed before promotion (manual) — verified 2026-09-09
+- [x] No direct publish rights: package requires 2FA and disallows tokens (manual) — verified 2026-09-09
 - [x] `package.json` `repository.url` accurate so provenance maps to this repo — verified 2026-09-08
 
 ## 6. Security tooling
@@ -50,6 +50,6 @@ This checklist is for the `v5` branch. The same catalog is already complete on `
 - [x] Socket reviews every PR that changes dependencies — verified 2026-09-08 (PR #2127: Socket Security Pull Request Alerts and Project Report)
 
 ## 7. Repository lockdown
-- [ ] Phishing-resistant 2FA (passkeys / hardware keys) on the GitHub and npm accounts (manual)
-- [ ] Recovery codes stored offline in a password manager (manual)
+- [x] Phishing-resistant 2FA (passkeys / hardware keys) on the GitHub and npm accounts (manual) — verified 2026-09-09
+- [x] Recovery codes stored offline in a password manager (manual) — verified 2026-09-09
 - [x] `lockdown-repo.sh` applied by a repo admin (never committed to this repo); `--check` with `--required-checks` and `--allowed-actions` passes (PRs required on the default branch, merges blocked unless required status checks pass, tag ruleset, immutable releases, fork-PR approval (public repos), read-only workflow tokens, Actions allowlist, secret scanning, Dependabot disabled, private vulnerability reporting (public repos)) — verified 2026-09-09 (repo-wide; default branch `main`) — PR #2144

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,10 +36,9 @@ hardening checklist; progress is tracked in [DEFENSE_IN_DEPTH.md](./DEFENSE_IN_D
 - CI `pnpm install` / `npm install` runs through Socket Firewall (`sfw`).
 - Workflows are security-linted with zizmor on every pull request.
 - Release and website-deploy jobs disable `setup-node`'s default package-manager cache.
-- The release workflow stages packages with `pnpm stage publish` (pack then stage a tarball); it does not publish live.
+- npm releases are staged, never published directly: CI stages via stage-only OIDC trusted publishing (`pnpm stage publish`) after an Aikido `scan-release` gate, Drydock reviews the staged artifact, and a maintainer promotes it with 2FA. There are no npm publish tokens.
 - Published packages set `repository.url` to this repo so provenance can map back.
 - Socket reviews every pull request that changes dependencies; Aikido scans every build.
-- The release stage job does not run unless an Aikido `scan-release` gate passes.
 - `.github/CODEOWNERS` names `@jaredwray` for `/.github/`, `/.vscode/`, `/.cursor/`, `/.devcontainer/`, and `/scripts/`.
 - Codespaces and Cursor Cloud Agents install through Aikido Safe Chain; package-manager shims must not be bypassed.
 - The Codespaces Dev Container image is pinned by digest (`name:<tag>@sha256:<digest>`), not a floating tag.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Record the remaining defense-in-depth manuals as complete on `v5`: no npm registry tokens, stage-only OIDC, Drydock review, 2FA promotion, phishing-resistant 2FA, and offline recovery codes.

## Status update

`DEFENSE_IN_DEPTH.md`: npm and account manuals → verified 2026-09-09. `SECURITY.md` now lists stage-only OIDC, Drydock, 2FA promotion, and no npm publish tokens.

## Verification

- [x] Maintainer confirmed the manuals are already done
- [x] `SECURITY.md` lists only controls that are live
- [x] Every catalog item on `v5` is checked

defense-in-depth-nodejs § 4, § 5, § 7

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b5aa2a5d-7117-4421-b5ac-dce805a1c49d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b5aa2a5d-7117-4421-b5ac-dce805a1c49d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

